### PR TITLE
fix: update Debian packaging version sanitization to prepend '0.' 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,8 +129,13 @@ set(CPACK_PACKAGE_VERSION "${GIT_VERSION}")
 set(CPACK_PACKAGE_INSTALL_DIRECTORY ${CPACK_PACKAGE_NAME})
 
 # Debian package specific settings
-# Sanitize version for Debian (strip leading 'v' since Debian versions must start with digit)
+# Sanitize version for Debian (must start with digit per Debian policy)
+# Strip leading 'v' and prepend '0.' if version starts with non-digit
 string(REGEX REPLACE "^v" "" DEBIAN_VERSION "${GIT_VERSION}")
+if(NOT DEBIAN_VERSION MATCHES "^[0-9]")
+    # Version starts with non-digit (e.g., commit hash), prepend "0." for valid Debian version
+    set(DEBIAN_VERSION "0.${DEBIAN_VERSION}")
+endif()
 set(CPACK_DEBIAN_PACKAGE_VERSION "${DEBIAN_VERSION}")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "OpenShieldHIT Contributors")
 set(CPACK_DEBIAN_PACKAGE_SECTION "science")


### PR DESCRIPTION
This pull request updates the Debian package version handling in the `CMakeLists.txt` file to ensure compliance with Debian's versioning policy. The logic now strips a leading 'v' from the version and prepends '0.' if the version does not start with a digit, which is required for valid Debian package versions.

Packaging improvements:
* Updated Debian package version sanitization to strip a leading 'v' and prepend '0.' if the version starts with a non-digit, ensuring the version string always starts with a digit as required by Debian policy.