### PR TITLE
resources: host detection + memory budgeting (issue #152)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,15 @@ jobs:
       shell: pwsh
       run: ./build/bin/Debug/openshieldhit.exe --version
 
+    - name: Print host resources (Linux/macOS)
+      if: runner.os != 'Windows'
+      run: ./build/bin/openshieldhit --print-resources
+
+    - name: Print host resources (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: ./build/bin/Debug/openshieldhit.exe --print-resources
+
   # Windows Release build — catches MSVC warnings-as-errors that only fire in
   # Release mode (e.g. C4701 uninitialized variable).  No test run needed here;
   # correctness is verified by the Debug job above.

--- a/include/openshieldhit/scoring.h
+++ b/include/openshieldhit/scoring.h
@@ -106,9 +106,7 @@ struct osh_scoring_mem_estimate {
  * Pages whose geometry cannot be resolved or whose bin count is zero contribute
  * nothing (they are rejected or harmless at compile time).
  *
- * @param[in]  ws   Parsed scoring workspace.
- * @param[out] out  Receives the estimate; zero-initialised on entry.
- *
+ * @param[out] out  Receives the estimate (fields are reset by the function).
  * @returns OSH_OK on success, OSH_EINVAL if @p ws or @p out is NULL.
  */
 enum osh_status osh_scoring_estimate_memory(struct osh_scoring_workspace const *ws,

--- a/include/openshieldhit/scoring.h
+++ b/include/openshieldhit/scoring.h
@@ -2,6 +2,7 @@
 #define OPENSHIELDHIT_SCORING_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "openshieldhit/status.h"
 
@@ -63,6 +64,55 @@ struct osh_scoring_geometry_def const *osh_scoring_geometry_by_name(struct osh_s
  */
 struct osh_scoring_output_def const *osh_scoring_output_by_filename(struct osh_scoring_workspace const *ws,
                                                                     char const *filename);
+
+/* ---- Memory estimate ----------------------------------------------------- */
+
+/** Fixed capacity for the geometry-name hint in @ref osh_scoring_mem_estimate. */
+#define OSH_SCORING_MEM_NAME_CAP 64u
+
+/**
+ * @brief Predicted memory footprint of the scoring accumulators for a run.
+ *
+ * @details
+ * Computed from the parsed (cold) scoring configuration *before* any buffers
+ * are allocated, so callers can detect an out-of-memory situation up front
+ * rather than crashing mid-allocation.  It accounts only for the scoring
+ * accumulator arrays (the dominant, configuration-driven allocation); the much
+ * smaller geometry/material/particle-pool memory is not included.
+ *
+ * The figure mirrors exactly what @c osh_scoring_compile() will later allocate:
+ * for every scored page, `bins × sizeof(double)` for the primary accumulator,
+ * doubled for "average" quantities (LET/Qeff) that also keep a weight
+ * accumulator.  See @ref osh_scoring_estimate_memory.
+ */
+struct osh_scoring_mem_estimate {
+    uint64_t accum_bytes;                            /**< Total bytes across all scoring accumulator arrays. */
+    size_t npages;                                   /**< Number of scored pages (geometry × quantity). */
+    uint64_t largest_page_bytes;                     /**< Bytes of the single largest scored page. */
+    char largest_geometry[OSH_SCORING_MEM_NAME_CAP]; /**< Geometry name of that page (for messages). */
+};
+
+/**
+ * @brief Estimate the scoring accumulator memory for a parsed configuration.
+ *
+ * @details
+ * Pure, allocation-free sizing pass over the parsed workspace.  Intended to be
+ * called after the workspace is fully populated (including any app-side voxel
+ * grid setup) but before @c osh_simulation_create(), so the caller can apply a
+ * memory budget and refuse a run that would otherwise exhaust RAM.  The result
+ * matches the buffers @c osh_scoring_compile() allocates, because it reuses the
+ * same per-geometry bin count and the same "uses a weight accumulator" rule.
+ *
+ * Pages whose geometry cannot be resolved or whose bin count is zero contribute
+ * nothing (they are rejected or harmless at compile time).
+ *
+ * @param[in]  ws   Parsed scoring workspace.
+ * @param[out] out  Receives the estimate; zero-initialised on entry.
+ *
+ * @returns OSH_OK on success, OSH_EINVAL if @p ws or @p out is NULL.
+ */
+enum osh_status osh_scoring_estimate_memory(struct osh_scoring_workspace const *ws,
+                                            struct osh_scoring_mem_estimate *out);
 
 /* ---- Top-level workspace ------------------------------------------------- */
 

--- a/include/openshieldhit/scoring.h
+++ b/include/openshieldhit/scoring.h
@@ -67,8 +67,8 @@ struct osh_scoring_output_def const *osh_scoring_output_by_filename(struct osh_s
 
 /* ---- Memory estimate ----------------------------------------------------- */
 
-/** Fixed capacity for the geometry-name hint in @ref osh_scoring_mem_estimate. */
-#define OSH_SCORING_MEM_NAME_CAP 64u
+/** Maximum length (including NUL) for a geometry name stored in @ref osh_scoring_mem_estimate. */
+#define OSH_SCORING_GEO_NAME_MAXLEN 64u
 
 /**
  * @brief Predicted memory footprint of the scoring accumulators for a run.
@@ -80,16 +80,23 @@ struct osh_scoring_output_def const *osh_scoring_output_by_filename(struct osh_s
  * accumulator arrays (the dominant, configuration-driven allocation); the much
  * smaller geometry/material/particle-pool memory is not included.
  *
- * The figure mirrors exactly what @c osh_scoring_compile() will later allocate:
- * for every scored page, `bins × sizeof(double)` for the primary accumulator,
- * doubled for "average" quantities (LET/Qeff) that also keep a weight
- * accumulator.  See @ref osh_scoring_estimate_memory.
+ * The figure mirrors exactly what @c osh_scoring_compile() will later allocate.
+ * For every scored page:
+ *   - `spatial_bins × diff1_bins × diff2_bins × sizeof(double)` bytes for the
+ *     primary accumulator (diff1/diff2 = 1 when differential scoring is off);
+ *   - an equal-sized second weight accumulator for "average" quantities such as
+ *     LET or Qeff that require a separate fluence weight array.
+ *
+ * See @ref osh_scoring_estimate_memory.
  */
 struct osh_scoring_mem_estimate {
-    uint64_t accum_bytes;                            /**< Total bytes across all scoring accumulator arrays. */
-    size_t npages;                                   /**< Number of scored pages (geometry × quantity). */
-    uint64_t largest_page_bytes;                     /**< Bytes of the single largest scored page. */
-    char largest_geometry[OSH_SCORING_MEM_NAME_CAP]; /**< Geometry name of that page (for messages). */
+    uint64_t accum_bytes;                               /**< Total bytes across all scoring accumulator arrays. */
+    size_t npages;                                      /**< Total (Output, Quantity) pairs across all Output blocks.
+                                                         *   Each Output block may declare any number of Quantity
+                                                         *   lines; this is their sum, not a geometry × quantity
+                                                         *   product. */
+    uint64_t largest_page_bytes;                        /**< Bytes of the single largest scored page. */
+    char largest_geometry[OSH_SCORING_GEO_NAME_MAXLEN]; /**< Geometry name of that page (for messages). */
 };
 
 /**

--- a/src/apps/osh/CMakeLists.txt
+++ b/src/apps/osh/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(osh_app_osh
     osh_geometry_parse.c
     osh_app_osh.c
     osh_run.c
+    osh_membudget.c
 )
 
 target_include_directories(osh_app_osh

--- a/src/apps/osh/main.c
+++ b/src/apps/osh/main.c
@@ -5,6 +5,7 @@
 #include "cli/osh_cli.h"
 #include "common/osh_exit.h"
 #include "common/osh_file.h"
+#include "common/osh_sysinfo.h"
 #include "openshieldhit/diag.h"
 #include "openshieldhit/status.h"
 #include "openshieldhit/version.h"
@@ -40,6 +41,27 @@ int main(int argc, char *argv[]) {
 
     if (opt.action == OSH_CLI_ACTION_VERSION) {
         printf("OpenShieldHIT version %s\n", osh_version_string());
+        return EX_OK;
+    }
+
+    if (opt.action == OSH_CLI_ACTION_PRINT_RESOURCES) {
+        struct osh_sysinfo info;
+        char total[32];
+        char avail[32];
+
+        osh_sysinfo_query(&info);
+        osh_sysinfo_format_bytes(info.ram_total_bytes, total, sizeof(total));
+        osh_sysinfo_format_bytes(info.ram_available_bytes, avail, sizeof(avail));
+
+        printf("Host resources:\n");
+        if (info.logical_cores > 0u) {
+            printf("  Logical CPU cores : %u\n", info.logical_cores);
+        } else {
+            printf("  Logical CPU cores : unknown\n");
+        }
+        printf("  Total RAM         : %s\n", info.ram_total_bytes > 0u ? total : "unknown");
+        printf("  Available RAM     : %s\n", info.ram_available_bytes > 0u ? avail : "unknown");
+        printf("  GPU detection     : not yet implemented\n");
         return EX_OK;
     }
 

--- a/src/apps/osh/main.c
+++ b/src/apps/osh/main.c
@@ -61,7 +61,6 @@ int main(int argc, char *argv[]) {
         }
         printf("  Total RAM         : %s\n", info.ram_total_bytes > 0u ? total : "unknown");
         printf("  Available RAM     : %s\n", info.ram_available_bytes > 0u ? avail : "unknown");
-        printf("  GPU detection     : not yet implemented\n");
         return EX_OK;
     }
 

--- a/src/apps/osh/main.c
+++ b/src/apps/osh/main.c
@@ -92,6 +92,7 @@ int main(int argc, char *argv[]) {
     run_opt.validate_only = opt.dry_run ? 1 : 0;
     run_opt.pool_capacity = opt.pool_capacity;
     run_opt.has_pool_capacity = opt.has_pool_capacity;
+    run_opt.mem_budget = opt.mem_budget;
     run_opt.profile_path = opt.profile_path;
     run_opt.diag = &diag;
 

--- a/src/apps/osh/osh_membudget.c
+++ b/src/apps/osh/osh_membudget.c
@@ -91,22 +91,32 @@ int osh_membudget_parse(char const *text, uint64_t base, uint64_t *out_bytes) {
 
     if (*end == '%') {
         char const *after = end + 1;
+        double bytes_d;
         while (*after == ' ' || *after == '\t') {
             ++after;
         }
-        if (*after != '\0') {
-            return 0; /* trailing junk after % */
+        if (*after != '\0' || base == 0u) {
+            return 0; /* trailing junk after % or unknown base */
         }
-        *out_bytes = (uint64_t) ((value / 100.0) * (double) base);
+        bytes_d = (value / 100.0) * (double) base;
+        if (!(bytes_d >= 0.0) || bytes_d > (double) UINT64_MAX) {
+            return 0;
+        }
+        *out_bytes = (uint64_t) bytes_d;
         return 1;
     }
 
     {
         uint64_t const mult = unit_multiplier(end);
+        double bytes_d;
         if (mult == 0u) {
             return 0; /* unrecognised unit */
         }
-        *out_bytes = (uint64_t) (value * (double) mult);
+        bytes_d = value * (double) mult;
+        if (!(bytes_d >= 0.0) || bytes_d > (double) UINT64_MAX) {
+            return 0;
+        }
+        *out_bytes = (uint64_t) bytes_d;
         return 1;
     }
 }

--- a/src/apps/osh/osh_membudget.c
+++ b/src/apps/osh/osh_membudget.c
@@ -4,33 +4,66 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* Smallest absolute reserve we always leave below the detected limit. */
-#define OSH_MEMBUDGET_RESERVE_MIN ((uint64_t) 256u << 20) /* 256 MiB */
-/* Fraction of the limit used as the budget before applying the reserve floor. */
+/*
+ * Policy constants — all #defined so they appear in user-facing error messages
+ * and can be patched at compile time for specialised deployments.
+ */
+
+/* Smallest absolute reserve we always keep below the detected memory limit.
+ * Written as a product of visible factors so the value is self-documenting. */
+#define OSH_MEMBUDGET_RESERVE_MIN ((uint64_t) 256 * 1024 * 1024) /* 256 MiB */
+
+/* Fraction of the memory limit to offer as the preliminary budget (before
+ * applying the reserve floor).  0.80 means "use at most 80 % of available". */
 #define OSH_MEMBUDGET_FRACTION 0.80
-/* Fraction of total RAM that also bounds the reserve from below. */
+
+/* Lower bound on the reserve expressed as a fraction of *total* RAM.
+ * On machines with little RAM (e.g. 1 GiB), 5 % keeps the reserve larger
+ * than 50 MiB even when OSH_MEMBUDGET_RESERVE_MIN would be the binding limit. */
 #define OSH_MEMBUDGET_RESERVE_FRACTION 0.05
 
-/* Return the byte multiplier for a (case-insensitive) unit suffix, or 0 if the
- * suffix is not a recognised unit.  "", "B" → 1; "K"/"KB"/"KiB" → 1024; etc.
- * Units are binary (1024-based): "KB" and "KiB" are treated identically. */
+/*
+ * unit_multiplier — map a binary-size suffix to its byte multiplier.
+ *
+ * Accepts a suffix string that immediately follows the numeric part of a size
+ * token.  Leading whitespace is consumed.  The token is matched case-insensitively
+ * and may be followed only by whitespace; any extra non-whitespace characters
+ * cause a 0 return so the caller can report an unrecognised unit.
+ *
+ * Recognised suffixes and their multipliers (all 1024-based / binary):
+ *
+ *   ""  / "B"             →          1  (plain bytes)
+ *   "K" / "KB" / "KiB"   →      1 024  (kibibytes)
+ *   "M" / "MB" / "MiB"   →  1 048 576  (mebibytes)
+ *   "G" / "GB" / "GiB"   →  1 073 741 824            (gibibytes)
+ *   "T" / "TB" / "TiB"   →  1 099 511 627 776        (tebibytes)
+ *   "P" / "PB" / "PiB"   →  1 125 899 906 842 624    (pebibytes)
+ *
+ * "KB" and "KiB" are treated as synonyms — both mean 1024 bytes.
+ * Returns 0 for any unrecognised or malformed suffix.
+ */
 static uint64_t unit_multiplier(char const *suffix) {
-    char u[4];
+    char u[4]; /* longest valid token is "KiB\0" = 4 chars */
     size_t n = 0u;
 
+    /* Skip optional whitespace between the number and the unit token. */
     while (*suffix == ' ' || *suffix == '\t') {
         ++suffix;
     }
-    /* Copy the unit token, stopping at whitespace or end. */
+
+    /* Copy the unit token into a local buffer, upper-casing as we go.
+     * Stop at whitespace or end-of-string; reject tokens longer than 3 chars. */
     while (suffix[n] != '\0' && suffix[n] != ' ' && suffix[n] != '\t') {
         if (n >= sizeof(u) - 1u) {
-            return 0u; /* longer than any valid unit */
+            return 0u; /* longer than any valid unit ("PiB" is the longest = 3 chars) */
         }
         u[n] = (char) toupper((unsigned char) suffix[n]);
         ++n;
     }
     u[n] = '\0';
-    /* Anything after the token must be trailing whitespace only. */
+
+    /* Anything after the token must be trailing whitespace only.
+     * e.g. "1GB " is OK but "1GB extra" is not. */
     {
         char const *tail = suffix + n;
         while (*tail == ' ' || *tail == '\t') {
@@ -41,25 +74,26 @@ static uint64_t unit_multiplier(char const *suffix) {
         }
     }
 
+    /* Match the normalised token. Empty string or bare "B" means plain bytes. */
     if (u[0] == '\0' || strcmp(u, "B") == 0) {
         return 1u;
     }
     if (strcmp(u, "K") == 0 || strcmp(u, "KB") == 0 || strcmp(u, "KIB") == 0) {
-        return (uint64_t) 1u << 10;
+        return (uint64_t) 1u << 10; /* 1 024 */
     }
     if (strcmp(u, "M") == 0 || strcmp(u, "MB") == 0 || strcmp(u, "MIB") == 0) {
-        return (uint64_t) 1u << 20;
+        return (uint64_t) 1u << 20; /* 1 048 576 */
     }
     if (strcmp(u, "G") == 0 || strcmp(u, "GB") == 0 || strcmp(u, "GIB") == 0) {
-        return (uint64_t) 1u << 30;
+        return (uint64_t) 1u << 30; /* 1 073 741 824 */
     }
     if (strcmp(u, "T") == 0 || strcmp(u, "TB") == 0 || strcmp(u, "TIB") == 0) {
-        return (uint64_t) 1u << 40;
+        return (uint64_t) 1u << 40; /* 1 099 511 627 776 */
     }
     if (strcmp(u, "P") == 0 || strcmp(u, "PB") == 0 || strcmp(u, "PIB") == 0) {
-        return (uint64_t) 1u << 50;
+        return (uint64_t) 1u << 50; /* 1 125 899 906 842 624 */
     }
-    return 0u;
+    return 0u; /* unrecognised */
 }
 
 int osh_membudget_parse(char const *text, uint64_t base, uint64_t *out_bytes) {
@@ -71,34 +105,46 @@ int osh_membudget_parse(char const *text, uint64_t base, uint64_t *out_bytes) {
         return 0;
     }
 
+    /* Skip leading whitespace; reject immediately if the string is empty or
+     * starts with a sign character (budgets are non-negative magnitudes). */
     p = text;
     while (*p == ' ' || *p == '\t') {
         ++p;
     }
     if (*p == '\0' || *p == '-' || *p == '+') {
-        return 0; /* empty or signed: reject (budgets are non-negative magnitudes) */
+        return 0;
     }
 
+    /* Parse the leading numeric part.  strtod handles integer and fractional
+     * forms ("512", "1.5", "62.5") and stops at the first non-numeric char. */
     value = strtod(p, &end);
     if (end == p || value < 0.0) {
         return 0; /* no number parsed, or negative */
     }
 
-    /* Skip spaces between the number and its unit/percent marker. */
+    /* Skip optional whitespace between the number and its unit/percent marker
+     * so "4 GiB" and "4GiB" are both accepted. */
     while (*end == ' ' || *end == '\t') {
         ++end;
     }
 
+    /* --- Percentage form: "80%" means 80 % of base ---
+     * base == 0 is rejected because the result would always be 0, which would
+     * silently disable the budget instead of refusing an unusable input. */
     if (*end == '%') {
         char const *after = end + 1;
         double bytes_d;
+
+        /* Consume any trailing whitespace after '%'; any other character is junk. */
         while (*after == ' ' || *after == '\t') {
             ++after;
         }
         if (*after != '\0' || base == 0u) {
             return 0; /* trailing junk after % or unknown base */
         }
+
         bytes_d = (value / 100.0) * (double) base;
+        /* Guard against NaN, negative results, and values too large for uint64_t. */
         if (!(bytes_d >= 0.0) || bytes_d > (double) UINT64_MAX) {
             return 0;
         }
@@ -106,13 +152,18 @@ int osh_membudget_parse(char const *text, uint64_t base, uint64_t *out_bytes) {
         return 1;
     }
 
+    /* --- Unit suffix form: "512MB", "4GiB", "2k", "1048576B", "" (plain bytes) ---
+     * unit_multiplier() handles the suffix and rejects trailing junk. */
     {
         uint64_t const mult = unit_multiplier(end);
         double bytes_d;
+
         if (mult == 0u) {
-            return 0; /* unrecognised unit */
+            return 0; /* unrecognised unit or trailing garbage */
         }
+
         bytes_d = value * (double) mult;
+        /* Guard against NaN, negative results, and values too large for uint64_t. */
         if (!(bytes_d >= 0.0) || bytes_d > (double) UINT64_MAX) {
             return 0;
         }
@@ -122,29 +173,54 @@ int osh_membudget_parse(char const *text, uint64_t base, uint64_t *out_bytes) {
 }
 
 uint64_t osh_membudget_default(struct osh_sysinfo const *info) {
-    uint64_t limit;
-    uint64_t reserve;
-    uint64_t headroom_cap;
-    uint64_t frac_cap;
+    uint64_t limit;        /* The memory figure we base the budget on. */
+    uint64_t reserve;      /* Bytes kept back as a safety margin. */
+    uint64_t frac_cap;     /* Budget from the OSH_MEMBUDGET_FRACTION percentage. */
+    uint64_t headroom_cap; /* Budget from the reserve-floor approach. */
 
     if (!info) {
         return 0u;
     }
 
-    /* Prefer available RAM; fall back to total. 0 ⇒ unknown ⇒ no budget. */
-    limit = (info->ram_available_bytes > 0u) ? info->ram_available_bytes : info->ram_total_bytes;
+    /* Choose the memory baseline: prefer currently *available* RAM because it
+     * already accounts for other running processes.  Fall back to total RAM on
+     * platforms that cannot report available RAM (e.g. some WSL1 versions or
+     * kernels without /proc/meminfo MemAvailable).  0 means unknown → no budget. */
+    if (info->ram_available_bytes > 0u) {
+        limit = info->ram_available_bytes;
+    } else {
+        limit = info->ram_total_bytes;
+    }
     if (limit == 0u) {
         return 0u;
     }
 
+    /* Compute the reserve floor: the larger of the hard minimum (256 MiB) and
+     * 5 % of *total* RAM.  Using total (not available) keeps the reserve stable
+     * and independent of transient allocations by other processes.
+     * On a 32 GiB machine: 5 % = 1.6 GiB > 256 MiB → reserve = 1.6 GiB.
+     * On a  2 GiB machine: 5 % = 100 MiB < 256 MiB → reserve = 256 MiB. */
     reserve = OSH_MEMBUDGET_RESERVE_MIN;
     if (info->ram_total_bytes > 0u) {
-        uint64_t const frac_reserve = (uint64_t) (OSH_MEMBUDGET_RESERVE_FRACTION * (double) info->ram_total_bytes);
-        if (frac_reserve > reserve) {
-            reserve = frac_reserve;
+        uint64_t const pct_reserve = (uint64_t) (OSH_MEMBUDGET_RESERVE_FRACTION * (double) info->ram_total_bytes);
+        if (pct_reserve > reserve) {
+            reserve = pct_reserve;
         }
     }
 
+    /* Two independent caps; we return whichever is *smaller* so both constraints
+     * are always satisfied simultaneously:
+     *
+     *   frac_cap     = 80 % of limit
+     *                  → never use more than 80 % of (available/total) RAM.
+     *
+     *   headroom_cap = limit - reserve
+     *                  → always leave at least `reserve` bytes untouched for the
+     *                    OS, other processes, and OpenShieldHIT's own (small)
+     *                    non-scoring allocations.
+     *
+     * If limit ≤ reserve the machine is already tight; return 0 to skip
+     * budget enforcement rather than returning a nonsensical negative-ish value. */
     frac_cap = (uint64_t) (OSH_MEMBUDGET_FRACTION * (double) limit);
     headroom_cap = (limit > reserve) ? (limit - reserve) : 0u;
 

--- a/src/apps/osh/osh_membudget.c
+++ b/src/apps/osh/osh_membudget.c
@@ -1,0 +1,142 @@
+#include "apps/osh/osh_membudget.h"
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Smallest absolute reserve we always leave below the detected limit. */
+#define OSH_MEMBUDGET_RESERVE_MIN ((uint64_t) 256u << 20) /* 256 MiB */
+/* Fraction of the limit used as the budget before applying the reserve floor. */
+#define OSH_MEMBUDGET_FRACTION 0.80
+/* Fraction of total RAM that also bounds the reserve from below. */
+#define OSH_MEMBUDGET_RESERVE_FRACTION 0.05
+
+/* Return the byte multiplier for a (case-insensitive) unit suffix, or 0 if the
+ * suffix is not a recognised unit.  "", "B" → 1; "K"/"KB"/"KiB" → 1024; etc.
+ * Units are binary (1024-based): "KB" and "KiB" are treated identically. */
+static uint64_t unit_multiplier(char const *suffix) {
+    char u[4];
+    size_t n = 0u;
+
+    while (*suffix == ' ' || *suffix == '\t') {
+        ++suffix;
+    }
+    /* Copy the unit token, stopping at whitespace or end. */
+    while (suffix[n] != '\0' && suffix[n] != ' ' && suffix[n] != '\t') {
+        if (n >= sizeof(u) - 1u) {
+            return 0u; /* longer than any valid unit */
+        }
+        u[n] = (char) toupper((unsigned char) suffix[n]);
+        ++n;
+    }
+    u[n] = '\0';
+    /* Anything after the token must be trailing whitespace only. */
+    {
+        char const *tail = suffix + n;
+        while (*tail == ' ' || *tail == '\t') {
+            ++tail;
+        }
+        if (*tail != '\0') {
+            return 0u;
+        }
+    }
+
+    if (u[0] == '\0' || strcmp(u, "B") == 0) {
+        return 1u;
+    }
+    if (strcmp(u, "K") == 0 || strcmp(u, "KB") == 0 || strcmp(u, "KIB") == 0) {
+        return (uint64_t) 1u << 10;
+    }
+    if (strcmp(u, "M") == 0 || strcmp(u, "MB") == 0 || strcmp(u, "MIB") == 0) {
+        return (uint64_t) 1u << 20;
+    }
+    if (strcmp(u, "G") == 0 || strcmp(u, "GB") == 0 || strcmp(u, "GIB") == 0) {
+        return (uint64_t) 1u << 30;
+    }
+    if (strcmp(u, "T") == 0 || strcmp(u, "TB") == 0 || strcmp(u, "TIB") == 0) {
+        return (uint64_t) 1u << 40;
+    }
+    if (strcmp(u, "P") == 0 || strcmp(u, "PB") == 0 || strcmp(u, "PIB") == 0) {
+        return (uint64_t) 1u << 50;
+    }
+    return 0u;
+}
+
+int osh_membudget_parse(char const *text, uint64_t base, uint64_t *out_bytes) {
+    char const *p;
+    char *end = NULL;
+    double value;
+
+    if (!text || !out_bytes) {
+        return 0;
+    }
+
+    p = text;
+    while (*p == ' ' || *p == '\t') {
+        ++p;
+    }
+    if (*p == '\0' || *p == '-' || *p == '+') {
+        return 0; /* empty or signed: reject (budgets are non-negative magnitudes) */
+    }
+
+    value = strtod(p, &end);
+    if (end == p || value < 0.0) {
+        return 0; /* no number parsed, or negative */
+    }
+
+    /* Skip spaces between the number and its unit/percent marker. */
+    while (*end == ' ' || *end == '\t') {
+        ++end;
+    }
+
+    if (*end == '%') {
+        char const *after = end + 1;
+        while (*after == ' ' || *after == '\t') {
+            ++after;
+        }
+        if (*after != '\0') {
+            return 0; /* trailing junk after % */
+        }
+        *out_bytes = (uint64_t) ((value / 100.0) * (double) base);
+        return 1;
+    }
+
+    {
+        uint64_t const mult = unit_multiplier(end);
+        if (mult == 0u) {
+            return 0; /* unrecognised unit */
+        }
+        *out_bytes = (uint64_t) (value * (double) mult);
+        return 1;
+    }
+}
+
+uint64_t osh_membudget_default(struct osh_sysinfo const *info) {
+    uint64_t limit;
+    uint64_t reserve;
+    uint64_t headroom_cap;
+    uint64_t frac_cap;
+
+    if (!info) {
+        return 0u;
+    }
+
+    /* Prefer available RAM; fall back to total. 0 ⇒ unknown ⇒ no budget. */
+    limit = (info->ram_available_bytes > 0u) ? info->ram_available_bytes : info->ram_total_bytes;
+    if (limit == 0u) {
+        return 0u;
+    }
+
+    reserve = OSH_MEMBUDGET_RESERVE_MIN;
+    if (info->ram_total_bytes > 0u) {
+        uint64_t const frac_reserve = (uint64_t) (OSH_MEMBUDGET_RESERVE_FRACTION * (double) info->ram_total_bytes);
+        if (frac_reserve > reserve) {
+            reserve = frac_reserve;
+        }
+    }
+
+    frac_cap = (uint64_t) (OSH_MEMBUDGET_FRACTION * (double) limit);
+    headroom_cap = (limit > reserve) ? (limit - reserve) : 0u;
+
+    return (frac_cap < headroom_cap) ? frac_cap : headroom_cap;
+}

--- a/src/apps/osh/osh_membudget.h
+++ b/src/apps/osh/osh_membudget.h
@@ -1,0 +1,69 @@
+#ifndef OSH_MEMBUDGET_H
+#define OSH_MEMBUDGET_H
+
+/**
+ * @file osh_membudget.h
+ * @brief Memory-budget parsing and the default budgeting policy.
+ *
+ * @details
+ * App-layer helpers that turn detected host resources (@ref osh_sysinfo) and an
+ * optional user override string into a concrete byte budget.  Kept separate
+ * from osh_run.c so the parsing and policy can be unit-tested in isolation.
+ *
+ * These are pure functions: they never touch the OS or allocate.  Resource
+ * detection lives in osh_sysinfo; consuming the budget (estimating scoring
+ * memory and refusing over-budget runs) lives in osh_run.c.
+ */
+
+#include <stdint.h>
+
+#include "common/osh_sysinfo.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Parse a memory-budget string into an absolute byte count.
+ *
+ * @details
+ * Accepts:
+ *   - a plain byte count: `"1048576"`;
+ *   - a size with a binary unit suffix (case-insensitive, 1024-based;
+ *     `KB`/`KiB` are treated identically): `"512MB"`, `"4GiB"`, `"2g"`;
+ *   - a percentage of @p base: `"80%"`.
+ *
+ * The value may be fractional for unit/percent forms (`"1.5GB"`, `"62.5%"`).
+ * Leading/trailing spaces are tolerated.  Negative, empty, non-numeric, or
+ * out-of-range inputs are rejected.
+ *
+ * @param[in]  text  The budget string (must not be NULL).
+ * @param[in]  base  Reference size for the `%` form (typically available RAM).
+ * @param[out] out_bytes  Receives the parsed byte count on success.
+ *
+ * @returns 1 on success, 0 if @p text is malformed or out of range.
+ */
+int osh_membudget_parse(char const *text, uint64_t base, uint64_t *out_bytes);
+
+/**
+ * @brief Compute the default memory budget from detected resources.
+ *
+ * @details
+ * Policy: 80% of currently *available* RAM (falling back to total RAM if
+ * available is unknown), but never closer than a reserve floor of
+ * `max(256 MiB, 5% of total)` to the limit, so the OS and OpenShieldHIT's
+ * other (small) allocations keep breathing room.  Basing on *available* rather
+ * than total already accounts for memory other processes hold.
+ *
+ * @param[in] info  Detected host resources.
+ *
+ * @returns The budget in bytes, or 0 when no memory figure is known (in which
+ *          case the caller should skip budget enforcement).
+ */
+uint64_t osh_membudget_default(struct osh_sysinfo const *info);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OSH_MEMBUDGET_H */

--- a/src/apps/osh/osh_run.c
+++ b/src/apps/osh/osh_run.c
@@ -430,19 +430,25 @@ run_check_memory(struct osh_scoring_workspace const *scoring, char const *mem_bu
     osh_sysinfo_format_bytes(est.accum_bytes, b_scoring, sizeof(b_scoring));
 
     if (out) {
-        fprintf(out,
-                "Resources: %u core(s), RAM %s total / %s available\n",
-                info.logical_cores,
-                info.ram_total_bytes > 0u ? b_total : "unknown",
-                info.ram_available_bytes > 0u ? b_avail : "unknown");
+        if (info.logical_cores > 0u) {
+            fprintf(out,
+                    "Resources: %u core(s), RAM %s total / %s available\n",
+                    info.logical_cores,
+                    info.ram_total_bytes > 0u ? b_total : "unknown",
+                    info.ram_available_bytes > 0u ? b_avail : "unknown");
+        } else {
+            fprintf(out,
+                    "Resources: cores unknown, RAM %s total / %s available\n",
+                    info.ram_total_bytes > 0u ? b_total : "unknown",
+                    info.ram_available_bytes > 0u ? b_avail : "unknown");
+        }
         fprintf(out, "Scoring memory: %s across %zu page(s)\n", b_scoring, est.npages);
         if (budget > 0u) {
             osh_sysinfo_format_bytes(budget, b_budget, sizeof(b_budget));
             fprintf(out,
                     "Memory budget: %s%s\n",
                     b_budget,
-                    mem_budget_override ? " (--mem-budget)" : " (default: 80% of available)");
-        }
+                    mem_budget_override ? " (--mem-budget)" : " (default policy)" );
     }
 
     if (budget > 0u && est.accum_bytes > budget) {

--- a/src/apps/osh/osh_run.c
+++ b/src/apps/osh/osh_run.c
@@ -445,10 +445,9 @@ run_check_memory(struct osh_scoring_workspace const *scoring, char const *mem_bu
         fprintf(out, "Scoring memory: %s across %zu page(s)\n", b_scoring, est.npages);
         if (budget > 0u) {
             osh_sysinfo_format_bytes(budget, b_budget, sizeof(b_budget));
-            fprintf(out,
-                    "Memory budget: %s%s\n",
-                    b_budget,
-                    mem_budget_override ? " (--mem-budget)" : " (default policy)" );
+            fprintf(
+                out, "Memory budget: %s%s\n", b_budget, mem_budget_override ? " (--mem-budget)" : " (default policy)");
+        }
     }
 
     if (budget > 0u && est.accum_bytes > budget) {

--- a/src/apps/osh/osh_run.c
+++ b/src/apps/osh/osh_run.c
@@ -12,9 +12,11 @@
 #include <string.h>
 
 #include "apps/osh/osh_app_osh.h"
+#include "apps/osh/osh_membudget.h"
 #include "common/osh_diag.h"
 #include "common/osh_file.h"
 #include "common/osh_patient_position.h"
+#include "common/osh_sysinfo.h"
 #include "common/osh_time.h"
 #include "common/osh_vect.h"
 #include "openshieldhit/const.h"
@@ -43,6 +45,8 @@ static enum osh_status run_setup_voxel_scoring(struct osh_geometry_workspace con
                                                char const *detect_path,
                                                struct osh_diag_sink const *diag);
 static int run_file_exists(char const *path);
+static enum osh_status
+run_check_memory(struct osh_scoring_workspace const *scoring, char const *mem_budget_override, FILE *out, FILE *err);
 static enum osh_status run_write_profile_json(char const *path,
                                               struct osh_simulation_profile const *prof,
                                               size_t nstat,
@@ -263,6 +267,14 @@ enum osh_status osh_run(struct osh_run_options const *opt, FILE *out, FILE *err)
         goto cleanup;
     }
 
+    /* Detect host resources, report the scoring memory footprint, and refuse
+     * the run up front if it would exceed the memory budget — before
+     * osh_simulation_create() allocates any scoring buffers. */
+    rc = run_check_memory(scoring, opt->mem_budget, out, err);
+    if (rc != OSH_OK) {
+        goto cleanup;
+    }
+
     t_mark = osh_monotonic_seconds();
     rc = osh_simulation_create(beam, geom, mat, scoring, opt->diag, &sim);
     compile_s = osh_monotonic_seconds() - t_mark;
@@ -356,6 +368,106 @@ cleanup:
 }
 
 /* ---- Internal helpers ---------------------------------------------------- */
+
+/**
+ * @brief Report host resources and the scoring memory footprint, and gate the
+ *        run against a memory budget.
+ *
+ * @details
+ * Detects CPU/RAM via osh_sysinfo, resolves a budget (the @p mem_budget_override
+ * string when given, otherwise the default 80%-of-available policy), estimates
+ * the scoring accumulator memory from the parsed configuration, and prints a
+ * short report to @p out.  If a budget is known and the estimate exceeds it,
+ * prints an actionable message to @p err and returns OSH_ENOMEM so the caller
+ * aborts *before* any scoring buffers are allocated — turning a would-be
+ * out-of-memory crash into a clear, recoverable refusal.
+ *
+ * When no memory figure can be detected and no override is given, the budget is
+ * 0 and the run proceeds unguarded (best effort, never a false refusal).
+ *
+ * @param[in] scoring             Parsed scoring workspace (fully populated).
+ * @param[in] mem_budget_override Budget string (e.g. "8GB", "80%") or NULL.
+ * @param[in] out                 Human-readable report stream, or NULL.
+ * @param[in] err                 Error stream for the refusal message, or NULL.
+ *
+ * @returns OSH_OK to proceed, OSH_ENOMEM if over budget, OSH_EINVAL on a
+ *          malformed override string.
+ */
+static enum osh_status
+run_check_memory(struct osh_scoring_workspace const *scoring, char const *mem_budget_override, FILE *out, FILE *err) {
+    struct osh_sysinfo info;
+    struct osh_scoring_mem_estimate est;
+    uint64_t base;
+    uint64_t budget = 0u;
+    char b_total[32];
+    char b_avail[32];
+    char b_scoring[32];
+    char b_budget[32];
+    char b_largest[32];
+
+    osh_sysinfo_query(&info);
+    base = (info.ram_available_bytes > 0u) ? info.ram_available_bytes : info.ram_total_bytes;
+
+    if (mem_budget_override && mem_budget_override[0]) {
+        if (!osh_membudget_parse(mem_budget_override, base, &budget)) {
+            if (err) {
+                fprintf(err,
+                        "Error: invalid --mem-budget value '%s' (use e.g. 8GB, 512MiB, or 80%%)\n",
+                        mem_budget_override);
+            }
+            return OSH_EINVAL;
+        }
+    } else {
+        budget = osh_membudget_default(&info); /* 0 ⇒ unknown ⇒ no enforcement */
+    }
+
+    if (osh_scoring_estimate_memory(scoring, &est) != OSH_OK) {
+        return OSH_OK; /* estimate unavailable: do not block the run */
+    }
+
+    osh_sysinfo_format_bytes(info.ram_total_bytes, b_total, sizeof(b_total));
+    osh_sysinfo_format_bytes(info.ram_available_bytes, b_avail, sizeof(b_avail));
+    osh_sysinfo_format_bytes(est.accum_bytes, b_scoring, sizeof(b_scoring));
+
+    if (out) {
+        fprintf(out,
+                "Resources: %u core(s), RAM %s total / %s available\n",
+                info.logical_cores,
+                info.ram_total_bytes > 0u ? b_total : "unknown",
+                info.ram_available_bytes > 0u ? b_avail : "unknown");
+        fprintf(out, "Scoring memory: %s across %zu page(s)\n", b_scoring, est.npages);
+        if (budget > 0u) {
+            osh_sysinfo_format_bytes(budget, b_budget, sizeof(b_budget));
+            fprintf(out,
+                    "Memory budget: %s%s\n",
+                    b_budget,
+                    mem_budget_override ? " (--mem-budget)" : " (default: 80% of available)");
+        }
+    }
+
+    if (budget > 0u && est.accum_bytes > budget) {
+        if (err) {
+            osh_sysinfo_format_bytes(budget, b_budget, sizeof(b_budget));
+            osh_sysinfo_format_bytes(est.largest_page_bytes, b_largest, sizeof(b_largest));
+            fprintf(err,
+                    "Error: scoring would allocate %s, exceeding the memory budget of %s.\n"
+                    "  Largest scorer: geometry '%s' (%s).\n"
+                    "  Detected RAM: %s total, %s available.\n"
+                    "  To proceed, reduce the scoring mesh/bin counts, or raise the limit with\n"
+                    "  --mem-budget (e.g. --mem-budget %s). Aborting before allocating memory.\n",
+                    b_scoring,
+                    b_budget,
+                    est.largest_geometry,
+                    b_largest,
+                    info.ram_total_bytes > 0u ? b_total : "unknown",
+                    info.ram_available_bytes > 0u ? b_avail : "unknown",
+                    b_scoring);
+        }
+        return OSH_ENOMEM;
+    }
+
+    return OSH_OK;
+}
 
 /**
  * @brief Resolve one optional input override against the working directory.

--- a/src/apps/osh/osh_run.c
+++ b/src/apps/osh/osh_run.c
@@ -406,7 +406,14 @@ run_check_memory(struct osh_scoring_workspace const *scoring, char const *mem_bu
     char b_largest[32];
 
     osh_sysinfo_query(&info);
-    base = (info.ram_available_bytes > 0u) ? info.ram_available_bytes : info.ram_total_bytes;
+
+    /* Use available RAM as the reference for "%" budget strings so that
+     * "80%" means 80 % of what is actually free, not of what is installed. */
+    if (info.ram_available_bytes > 0u) {
+        base = info.ram_available_bytes;
+    } else {
+        base = info.ram_total_bytes; /* fall back when available is unknown */
+    }
 
     if (mem_budget_override && mem_budget_override[0]) {
         if (!osh_membudget_parse(mem_budget_override, base, &budget)) {

--- a/src/apps/osh/osh_run.h
+++ b/src/apps/osh/osh_run.h
@@ -32,6 +32,7 @@ struct osh_run_options {
     int validate_only;                /**< 1 = validate inputs then exit without running transport. */
     unsigned long long pool_capacity; /**< Transport pool capacity override; used only when has_pool_capacity != 0. */
     int has_pool_capacity;            /**< 1 if pool_capacity should override the compiled default. */
+    char const *mem_budget;           /**< Memory-budget override string (e.g. "8GB", "80%"); NULL = default policy. */
     char const *profile_path;         /**< Profile JSON output path; NULL disables profiling. */
     struct osh_diag_sink const *diag; /**< Borrowed diagnostics sink for simulation/transport messages. */
 };

--- a/src/cli/osh_cli.c
+++ b/src/cli/osh_cli.c
@@ -42,6 +42,7 @@ int osh_cli_parse(int argc, char *argv[], struct osh_cli_options *opt, char *err
     opt->has_seed_offset = 0;
     opt->pool_capacity = 0;
     opt->has_pool_capacity = 0;
+    opt->mem_budget = NULL;
     opt->profile_path = NULL;
 
     if (argc <= 1) {
@@ -106,6 +107,10 @@ void osh_cli_print_help(FILE *out, char const *prog) {
     fprintf(out,
             "      --pool-capacity <n>  Live-history pool size (perf knob; 0 = default; physics unchanged,\n"
             "                           scored output matches up to FP rounding)\n");
+    fprintf(out,
+            "      --mem-budget <size>  Max memory OSH may use for scoring (e.g. 8GB, 512MiB, 80%%);\n"
+            "                           a run whose scoring exceeds this is refused. Default: 80%% of\n"
+            "                           available RAM\n");
     fprintf(out, "      --profile <file>  Write a one-line JSON timing/counter profile to <file>\n");
     fprintf(out, "\n");
     fprintf(out, "Notes:\n");
@@ -254,6 +259,13 @@ static int parse_long_option(int argc, char *argv[], int *idx, struct osh_cli_op
             return set_err(err, err_cap, "invalid integer value for option '%s'", "--pool-capacity");
         }
         opt->has_pool_capacity = 1;
+        return 0;
+    }
+    if ((name_len == 10) && (strncmp(name, "mem-budget", name_len) == 0)) {
+        if (!value && !consume_option_arg(argc, argv, idx, arg, &value)) {
+            return set_err(err, err_cap, "unknown or invalid option '%s'", arg);
+        }
+        opt->mem_budget = value;
         return 0;
     }
     if ((name_len == 7) && (strncmp(name, "workdir", name_len) == 0)) {

--- a/src/cli/osh_cli.c
+++ b/src/cli/osh_cli.c
@@ -92,6 +92,7 @@ void osh_cli_print_help(FILE *out, char const *prog) {
     fprintf(out, "Options:\n");
     fprintf(out, "  -h, --help            Show this help message\n");
     fprintf(out, "  -V, --version         Print version information\n");
+    fprintf(out, "      --print-resources Detect and print host CPU/RAM, then exit\n");
     fprintf(out, "  -v, --verbose         Increase verbosity\n");
     fprintf(out, "  -n, --nstat <n>       Number of requested primary histories\n");
     fprintf(out, "  -N, --seedoffset <n>  Random seed offset override (max 9999)\n");
@@ -207,6 +208,10 @@ static int parse_long_option(int argc, char *argv[], int *idx, struct osh_cli_op
     }
     if ((name_len == 7) && (strncmp(name, "version", name_len) == 0) && !value) {
         opt->action = OSH_CLI_ACTION_VERSION;
+        return 0;
+    }
+    if ((name_len == 15) && (strncmp(name, "print-resources", name_len) == 0) && !value) {
+        opt->action = OSH_CLI_ACTION_PRINT_RESOURCES;
         return 0;
     }
     if ((name_len == 7) && (strncmp(name, "verbose", name_len) == 0) && !value) {

--- a/src/cli/osh_cli.h
+++ b/src/cli/osh_cli.h
@@ -39,6 +39,7 @@ struct osh_cli_options {
     int has_seed_offset;              /**< Non-zero if --seedoffset/-N was explicitly given. */
     unsigned long long pool_capacity; /**< Transport pool capacity override (0 = compiled default). */
     int has_pool_capacity;            /**< Non-zero if --pool-capacity was explicitly given. */
+    char const *mem_budget;           /**< Memory-budget override string (e.g. "8GB", "80%"); NULL = default policy. */
     char const *profile_path;         /**< Profile JSON output path; NULL disables profiling. */
 };
 

--- a/src/cli/osh_cli.h
+++ b/src/cli/osh_cli.h
@@ -9,7 +9,12 @@
  * Used by src/apps/osh/main.c and the test_osh_cli test suite. */
 
 /** Actions the CLI parser may request the caller to perform. */
-enum osh_cli_action { OSH_CLI_ACTION_RUN = 0, OSH_CLI_ACTION_HELP = 1, OSH_CLI_ACTION_VERSION = 2 };
+enum osh_cli_action {
+    OSH_CLI_ACTION_RUN = 0,
+    OSH_CLI_ACTION_HELP = 1,
+    OSH_CLI_ACTION_VERSION = 2,
+    OSH_CLI_ACTION_PRINT_RESOURCES = 3 /**< Print detected host resources and exit. */
+};
 
 /**
  * @brief Parsed and validated command-line options.

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(osh_common
     osh_step.c
     osh_particle_pool.c
     osh_time.c
+    osh_sysinfo.c
 )
 
 # Make sure consumers of the library see the headers

--- a/src/common/osh_sysinfo.c
+++ b/src/common/osh_sysinfo.c
@@ -83,6 +83,8 @@ static void sysinfo_query_platform(struct osh_sysinfo *out) {
             uint64_t const reclaimable = (uint64_t) vm.free_count + (uint64_t) vm.inactive_count;
             out->ram_available_bytes = reclaimable * (uint64_t) page_size;
         }
+
+        (void) mach_port_deallocate(mach_task_self(), host);
     }
 }
 

--- a/src/common/osh_sysinfo.c
+++ b/src/common/osh_sysinfo.c
@@ -1,0 +1,226 @@
+#include "common/osh_sysinfo.h"
+
+#include <stdio.h>
+
+/*
+ * Platform resource detection.  Each branch is self-contained; the goal is a
+ * best-effort snapshot, never a hard failure.  Unknown values stay 0.
+ *
+ * Memory semantics we aim for:
+ *   ram_total_bytes     = usable RAM ceiling: physical RAM, but capped by a
+ *                         cgroup/container limit (Linux) or the heap maximum
+ *                         (WASM) when those are smaller — because that is the
+ *                         real ceiling a run will hit.
+ *   ram_available_bytes = what could be allocated right now (free plus easily
+ *                         reclaimable memory), as reported by the OS.
+ */
+
+#if defined(__EMSCRIPTEN__)
+/* ---- WebAssembly (Emscripten) ------------------------------------------- */
+#include <emscripten/emscripten.h>
+#include <emscripten/threading.h>
+
+static void sysinfo_query_platform(struct osh_sysinfo *out) {
+    /* The wasm linear memory maximum is the hard ceiling (wasm32 also caps the
+     * address space at ~4 GiB regardless of host RAM). */
+    size_t const heap_max = emscripten_get_heap_max();
+    size_t const heap_used = emscripten_get_heap_size();
+
+    int const cores = emscripten_num_logical_cores();
+    out->logical_cores = (cores > 0) ? (unsigned) cores : 0u;
+    out->ram_total_bytes = (uint64_t) heap_max;
+    out->ram_available_bytes = (heap_max > heap_used) ? (uint64_t) (heap_max - heap_used) : 0u;
+}
+
+#elif defined(_WIN32)
+/* ---- Windows ------------------------------------------------------------- */
+#include <windows.h>
+
+static void sysinfo_query_platform(struct osh_sysinfo *out) {
+    MEMORYSTATUSEX mem;
+    DWORD cores;
+
+    cores = GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
+    out->logical_cores = (cores > 0) ? (unsigned) cores : 0u;
+
+    mem.dwLength = sizeof(mem);
+    if (GlobalMemoryStatusEx(&mem)) {
+        out->ram_total_bytes = (uint64_t) mem.ullTotalPhys;
+        out->ram_available_bytes = (uint64_t) mem.ullAvailPhys;
+    }
+}
+
+#elif defined(__APPLE__)
+/* ---- macOS --------------------------------------------------------------- */
+#include <mach/mach.h>
+#include <mach/mach_host.h>
+#include <sys/sysctl.h>
+#include <unistd.h>
+
+static void sysinfo_query_platform(struct osh_sysinfo *out) {
+    int ncpu = 0;
+    size_t len = sizeof(ncpu);
+    uint64_t memsize = 0;
+
+    if (sysctlbyname("hw.logicalcpu", &ncpu, &len, NULL, 0) == 0 && ncpu > 0) {
+        out->logical_cores = (unsigned) ncpu;
+    }
+
+    len = sizeof(memsize);
+    if (sysctlbyname("hw.memsize", &memsize, &len, NULL, 0) == 0) {
+        out->ram_total_bytes = memsize;
+    }
+
+    /* Available ≈ (free + inactive) pages: inactive pages are reclaimable. */
+    {
+        mach_port_t host = mach_host_self();
+        vm_size_t page_size = 0;
+        vm_statistics64_data_t vm;
+        mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+
+        if (host_page_size(host, &page_size) == KERN_SUCCESS
+            && host_statistics64(host, HOST_VM_INFO64, (host_info64_t) &vm, &count) == KERN_SUCCESS) {
+            uint64_t const reclaimable = (uint64_t) vm.free_count + (uint64_t) vm.inactive_count;
+            out->ram_available_bytes = reclaimable * (uint64_t) page_size;
+        }
+    }
+}
+
+#elif defined(__linux__)
+/* ---- Linux --------------------------------------------------------------- */
+#include <unistd.h>
+
+/* Read a single unsigned integer from a one-line sysfs/proc file.
+ * Returns 1 and sets *out on success; 0 if the file is absent or holds a
+ * non-numeric sentinel such as cgroup-v2's "max". */
+static int read_u64_file(char const *path, uint64_t *out) {
+    FILE *f = fopen(path, "r");
+    unsigned long long v;
+    int got;
+
+    if (!f) {
+        return 0;
+    }
+    got = fscanf(f, "%llu", &v);
+    fclose(f);
+    if (got != 1) {
+        return 0; /* e.g. "max" → unlimited */
+    }
+    *out = (uint64_t) v;
+    return 1;
+}
+
+/* Parse MemAvailable (kB) from /proc/meminfo; returns bytes or 0 if absent. */
+static uint64_t linux_mem_available(void) {
+    FILE *f = fopen("/proc/meminfo", "r");
+    char line[256];
+    uint64_t result = 0u;
+
+    if (!f) {
+        return 0u;
+    }
+    while (fgets(line, sizeof(line), f)) {
+        unsigned long long kb;
+        if (sscanf(line, "MemAvailable: %llu kB", &kb) == 1) {
+            result = (uint64_t) kb * 1024u;
+            break;
+        }
+    }
+    fclose(f);
+    return result;
+}
+
+/* A cgroup limit this large is the kernel's "unlimited" sentinel, not a real
+ * cap; ignore anything at/above a generous threshold. */
+#define OSH_CGROUP_UNLIMITED_MIN ((uint64_t) 1 << 62)
+
+static uint64_t linux_cgroup_limit(void) {
+    uint64_t v = 0u;
+
+    /* cgroup v2 first, then v1. */
+    if (read_u64_file("/sys/fs/cgroup/memory.max", &v) && v < OSH_CGROUP_UNLIMITED_MIN) {
+        return v;
+    }
+    if (read_u64_file("/sys/fs/cgroup/memory/memory.limit_in_bytes", &v) && v < OSH_CGROUP_UNLIMITED_MIN) {
+        return v;
+    }
+    return 0u; /* unlimited / not present */
+}
+
+static void sysinfo_query_platform(struct osh_sysinfo *out) {
+    long const ncpu = sysconf(_SC_NPROCESSORS_ONLN);
+    long const pages = sysconf(_SC_PHYS_PAGES);
+    long const page_size = sysconf(_SC_PAGESIZE);
+    uint64_t physical = 0u;
+    uint64_t cgroup;
+    uint64_t avail;
+
+    if (ncpu > 0) {
+        out->logical_cores = (unsigned) ncpu;
+    }
+    if (pages > 0 && page_size > 0) {
+        physical = (uint64_t) pages * (uint64_t) page_size;
+    }
+
+    /* Honor a container/cgroup limit when it is smaller than physical RAM —
+     * the JVM's well-known container-OOM bug was exactly ignoring this. */
+    cgroup = linux_cgroup_limit();
+    if (physical == 0u) {
+        out->ram_total_bytes = cgroup;
+    } else if (cgroup > 0u && cgroup < physical) {
+        out->ram_total_bytes = cgroup;
+    } else {
+        out->ram_total_bytes = physical;
+    }
+
+    avail = linux_mem_available();
+    /* Never report "available" above the (possibly cgroup-capped) total. */
+    if (avail > 0u && out->ram_total_bytes > 0u && avail > out->ram_total_bytes) {
+        avail = out->ram_total_bytes;
+    }
+    out->ram_available_bytes = avail;
+}
+
+#else
+/* ---- Unknown platform: best-effort zero fill ----------------------------- */
+static void sysinfo_query_platform(struct osh_sysinfo *out) {
+    (void) out; /* all fields already zeroed by the caller */
+}
+#endif
+
+enum osh_status osh_sysinfo_query(struct osh_sysinfo *out) {
+    if (!out) {
+        return OSH_EINVAL;
+    }
+
+    out->logical_cores = 0u;
+    out->ram_total_bytes = 0u;
+    out->ram_available_bytes = 0u;
+    out->gpu_count = 0u;
+
+    sysinfo_query_platform(out);
+    return OSH_OK;
+}
+
+void osh_sysinfo_format_bytes(uint64_t bytes, char *buf, size_t buflen) {
+    static char const *const units[] = {"B", "KiB", "MiB", "GiB", "TiB", "PiB"};
+    size_t const n_units = sizeof(units) / sizeof(units[0]);
+    double value = (double) bytes;
+    size_t unit = 0u;
+
+    if (!buf || buflen == 0u) {
+        return;
+    }
+
+    while (value >= 1024.0 && unit + 1u < n_units) {
+        value /= 1024.0;
+        ++unit;
+    }
+
+    if (unit == 0u) {
+        /* Exact byte count — no decimals. */
+        (void) snprintf(buf, buflen, "%llu %s", (unsigned long long) bytes, units[unit]);
+    } else {
+        (void) snprintf(buf, buflen, "%.1f %s", value, units[unit]);
+    }
+}

--- a/src/common/osh_sysinfo.h
+++ b/src/common/osh_sysinfo.h
@@ -1,0 +1,95 @@
+#ifndef OSH_SYSINFO_H
+#define OSH_SYSINFO_H
+
+/**
+ * @file osh_sysinfo.h
+ * @brief Best-effort host resource detection (CPU cores, RAM; later: GPU).
+ *
+ * @details
+ * This is a thin platform-abstraction utility, the resource-detection
+ * counterpart of osh_time.c.  It is the ONLY place in the project that queries
+ * the operating system for hardware/resource information, so all OS-specific
+ * code (`#ifdef _WIN32 / __APPLE__ / __linux__ / __EMSCRIPTEN__`) is confined
+ * here and the rest of the tree stays portable.
+ *
+ * Design intent (parallelization preparation, see issue #152):
+ *   - The CORE library never calls this.  Resource detection is a policy
+ *     concern owned by the application (or a library embedder), which may also
+ *     inject its own numbers instead of probing the OS.  The core simulation
+ *     only ever consumes a plain memory-budget number.
+ *   - The query is best-effort: it fills whatever the platform can report and
+ *     leaves unknown fields as 0.  It never fails hard.
+ *
+ * This module currently powers the `--print-resources` CLI action.  A later
+ * change (component B of #152) will use the same struct to size a memory
+ * budget and gate runs that would otherwise risk out-of-memory.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "openshieldhit/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Snapshot of host resources relevant to sizing a run.
+ *
+ * @details
+ * Any field that the platform cannot report is left as 0 ("unknown"), so
+ * callers must treat 0 as "no information" rather than "zero cores / zero
+ * bytes".  Memory figures are physical RAM, except that on constrained
+ * environments they reflect the binding limit: a Linux cgroup/container limit
+ * (taken as the min with physical RAM) or, under WebAssembly, the configured
+ * heap maximum.
+ */
+struct osh_sysinfo {
+    unsigned logical_cores;       /**< Online logical CPUs; 0 = unknown. */
+    uint64_t ram_total_bytes;     /**< Total usable RAM (physical or cgroup/WASM cap); 0 = unknown. */
+    uint64_t ram_available_bytes; /**< Currently available RAM (free + reclaimable); 0 = unknown. */
+
+    /* Reserved for future GPU detection (component of the GPU work in #148);
+     * always 0 today so callers can already branch on it. */
+    unsigned gpu_count; /**< Number of detected compute GPUs; 0 = none/unknown. */
+};
+
+/**
+ * @brief Query host resources into @p out (best-effort).
+ *
+ * @details
+ * Fills @p out with whatever the current platform can report, leaving unknown
+ * fields 0.  Implemented per platform (Linux, macOS, Windows, Emscripten) with
+ * a zero-filled fallback for any other target.
+ *
+ * @param[out] out  Receives the snapshot; must not be NULL.
+ *
+ * @returns OSH_OK on success (including the partial/zero-filled case),
+ *          OSH_EINVAL if @p out is NULL.
+ */
+enum osh_status osh_sysinfo_query(struct osh_sysinfo *out);
+
+/**
+ * @brief Format a byte count as a short human-readable string (binary units).
+ *
+ * @details
+ * Produces values such as "0 B", "512 KiB", "61.2 GiB" using 1024-based units
+ * (B, KiB, MiB, GiB, TiB, PiB).  Values >= 1 KiB are printed with one decimal;
+ * bytes are printed as an integer.  Always NUL-terminates if @p buflen > 0.
+ *
+ * This lives here (rather than in the reporting code) because the same
+ * formatting is reused by the resource report and, later, by the memory-budget
+ * report (component B of #152).
+ *
+ * @param[in]  bytes   Value to format.
+ * @param[out] buf     Output buffer.
+ * @param[in]  buflen  Size of @p buf in bytes.
+ */
+void osh_sysinfo_format_bytes(uint64_t bytes, char *buf, size_t buflen);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OSH_SYSINFO_H */

--- a/src/scoring/runtime/osh_scoring_compile.c
+++ b/src/scoring/runtime/osh_scoring_compile.c
@@ -235,7 +235,8 @@ enum osh_status osh_scoring_estimate_memory(struct osh_scoring_workspace const *
                 page_bytes = (len <= UINT64_MAX / bytes_per_bin) ? (len * bytes_per_bin) : UINT64_MAX;
             }
 
-            out->accum_bytes = (out->accum_bytes <= UINT64_MAX - page_bytes) ? (out->accum_bytes + page_bytes) : UINT64_MAX;
+            out->accum_bytes =
+                (out->accum_bytes <= UINT64_MAX - page_bytes) ? (out->accum_bytes + page_bytes) : UINT64_MAX;
             out->npages += 1u;
 
             if (page_bytes > out->largest_page_bytes) {

--- a/src/scoring/runtime/osh_scoring_compile.c
+++ b/src/scoring/runtime/osh_scoring_compile.c
@@ -1,12 +1,14 @@
 #include "scoring/runtime/osh_scoring_compile.h"
 
 #include <math.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "common/osh_diag.h"
 #include "common/raytrace/osh_raytrace.h"
 #include "openshieldhit/const.h"
+#include "openshieldhit/scoring.h"
 
 /* Scratch record built during the first compile pass; sorted by geometry+kind
  * so pages that share a geometry and scorer type end up in the same hot group. */
@@ -181,6 +183,52 @@ static char score_kind_uses_data2(enum osh_scoring_score_kind score_kind) {
     default:
         return 0;
     }
+}
+
+enum osh_status osh_scoring_estimate_memory(struct osh_scoring_workspace const *ws,
+                                            struct osh_scoring_mem_estimate *out) {
+    size_t i;
+    size_t j;
+
+    if (!ws || !out) {
+        return OSH_EINVAL;
+    }
+
+    out->accum_bytes = 0u;
+    out->npages = 0u;
+    out->largest_page_bytes = 0u;
+    out->largest_geometry[0] = '\0';
+
+    /* Mirror exactly what osh_scoring_compile() allocates: one page per
+     * (output, quantity); each page owns `bins` doubles for its primary
+     * accumulator, plus a second `bins`-double weight accumulator for the
+     * "average" quantities (LET/Qeff).  bins is the geometry's bin product,
+     * computed by the same geometry_nbins() the compiler uses, so the estimate
+     * cannot drift from the real allocation. */
+    for (i = 0u; i < ws->noutputs; ++i) {
+        struct osh_scoring_output_def const *output = &ws->outputs[i];
+        struct osh_scoring_geometry_def const *geo = osh_scoring_geometry_by_name(ws, output->geometry_name);
+        size_t const bins = geo ? geometry_nbins(geo) : 0u;
+
+        for (j = 0u; j < output->npages; ++j) {
+            enum osh_scoring_score_kind const kind = quantity_to_score_kind(output->pages[j].quantity);
+            unsigned const arrays = score_kind_uses_data2(kind) ? 2u : 1u;
+            uint64_t const page_bytes = (uint64_t) bins * (uint64_t) sizeof(double) * (uint64_t) arrays;
+
+            out->accum_bytes += page_bytes;
+            out->npages += 1u;
+
+            if (page_bytes > out->largest_page_bytes) {
+                char const *name = (geo && geo->name)      ? geo->name
+                                   : output->geometry_name ? output->geometry_name
+                                                           : "(unnamed)";
+                out->largest_page_bytes = page_bytes;
+                (void) snprintf(out->largest_geometry, sizeof(out->largest_geometry), "%s", name);
+            }
+        }
+    }
+
+    return OSH_OK;
 }
 
 /* divide=1 means postproc divides data by data2 (LET average) → AVER mode.

--- a/src/scoring/runtime/osh_scoring_compile.c
+++ b/src/scoring/runtime/osh_scoring_compile.c
@@ -211,11 +211,31 @@ enum osh_status osh_scoring_estimate_memory(struct osh_scoring_workspace const *
         size_t const bins = geo ? geometry_nbins(geo) : 0u;
 
         for (j = 0u; j < output->npages; ++j) {
-            enum osh_scoring_score_kind const kind = quantity_to_score_kind(output->pages[j].quantity);
+            struct osh_scoring_page_def const *page = &output->pages[j];
+            enum osh_scoring_score_kind const kind = quantity_to_score_kind(page->quantity);
             unsigned const arrays = score_kind_uses_data2(kind) ? 2u : 1u;
-            uint64_t const page_bytes = (uint64_t) bins * (uint64_t) sizeof(double) * (uint64_t) arrays;
+            uint64_t len = (uint64_t) bins;
+            uint64_t page_bytes;
 
-            out->accum_bytes += page_bytes;
+            if (len > 0u && page->diff_nbins > 0u) {
+                uint64_t const d1 = (uint64_t) page->diff_nbins;
+                uint64_t const d2 = (uint64_t) ((page->diff2_nbins > 0u) ? page->diff2_nbins : 1u);
+                if (d1 > 0u) {
+                    len = (len <= UINT64_MAX / d1) ? (len * d1) : UINT64_MAX;
+                }
+                if (d2 > 0u) {
+                    len = (len <= UINT64_MAX / d2) ? (len * d2) : UINT64_MAX;
+                }
+            }
+
+            if (len == 0u) {
+                page_bytes = 0u;
+            } else {
+                uint64_t const bytes_per_bin = (uint64_t) sizeof(double) * (uint64_t) arrays;
+                page_bytes = (len <= UINT64_MAX / bytes_per_bin) ? (len * bytes_per_bin) : UINT64_MAX;
+            }
+
+            out->accum_bytes = (out->accum_bytes <= UINT64_MAX - page_bytes) ? (out->accum_bytes + page_bytes) : UINT64_MAX;
             out->npages += 1u;
 
             if (page_bytes > out->largest_page_bytes) {

--- a/tests/bench/CMakeLists.txt
+++ b/tests/bench/CMakeLists.txt
@@ -8,6 +8,19 @@
 
 find_program(BENCH_PYTHON NAMES python3 python)
 
+# ---- Out-of-memory gate: an oversized scoring config must be refused up front,
+#      with a meaningful message, on every OS (no Python needed). ----
+add_test(
+    NAME "bench::oom_gate"
+    COMMAND ${CMAKE_COMMAND}
+        -DOSH_EXECUTABLE=$<TARGET_FILE:openshieldhit>
+        -DCASE_DIR=${PROJECT_SOURCE_DIR}/tests/cases/00_minimal
+        -DDETECT_FILE=${CMAKE_CURRENT_SOURCE_DIR}/huge_detect.dat
+        -DWORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/oom_gate
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/run_oom_gate.cmake
+)
+set_tests_properties("bench::oom_gate" PROPERTIES LABELS "bench")
+
 # ---- Bench case inputs: one validation test per case directory ----
 file(GLOB BENCH_CASE_DIRS CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/benchmarks/performance/cases/*/")
 foreach(case_dir ${BENCH_CASE_DIRS})

--- a/tests/bench/huge_detect.dat
+++ b/tests/bench/huge_detect.dat
@@ -1,0 +1,18 @@
+# Deliberately enormous scoring mesh for the OOM-gate test (tests/bench/run_oom_gate.cmake).
+#
+# 2000 x 2000 x 2000 = 8e9 bins => ~59.6 GiB of dose accumulator alone.
+# No machine in CI can hold this; the run must be REFUSED at setup with a clear
+# memory message, never attempting the allocation. Paired with --mem-budget the
+# refusal is deterministic regardless of the runner's RAM.
+
+Geometry Mesh
+    Name HugeMesh
+    X -1.0   1.0   2000
+    Y -1.0   1.0   2000
+    Z  0.0  20.0   2000
+
+Output
+    Filename huge.dat
+    Fileformat TEXT
+    Geo HugeMesh
+    Quantity Dose

--- a/tests/bench/run_oom_gate.cmake
+++ b/tests/bench/run_oom_gate.cmake
@@ -1,0 +1,42 @@
+# run_oom_gate.cmake — CTest driver for the out-of-memory gate (issue #152).
+#
+# Runs a deliberately enormous scoring configuration (huge_detect.dat, ~59.6 GiB
+# of accumulators) against a small explicit --mem-budget.  The point is to prove
+# that OpenShieldHIT refuses such a run *before* allocating anything and prints a
+# meaningful message, rather than crashing or being OOM-killed.  Using an
+# explicit budget makes the refusal deterministic on any runner, so this is safe
+# to run on all CI OSes.
+
+cmake_minimum_required(VERSION 3.14)
+
+foreach(required_var OSH_EXECUTABLE CASE_DIR DETECT_FILE WORK_DIR)
+    if(NOT DEFINED ${required_var})
+        message(FATAL_ERROR "run_oom_gate.cmake: required parameter -D${required_var}=... not set")
+    endif()
+endforeach()
+
+file(MAKE_DIRECTORY "${WORK_DIR}")
+
+execute_process(
+    COMMAND "${OSH_EXECUTABLE}" --workdir "${CASE_DIR}" -d "${DETECT_FILE}"
+        -n 10 -o "${WORK_DIR}" --mem-budget 256MB
+    RESULT_VARIABLE rc
+    OUTPUT_VARIABLE out
+    ERROR_VARIABLE err
+)
+
+set(combined "${out}${err}")
+
+# 1. The run must NOT succeed (it would otherwise try to allocate ~60 GiB).
+if(rc EQUAL 0)
+    message(FATAL_ERROR "OOM gate failed: run succeeded but should have been refused.\n${combined}")
+endif()
+
+# 2. The refusal must carry a meaningful memory message, not a random crash.
+string(FIND "${combined}" "memory budget" budget_pos)
+string(FIND "${combined}" "Aborting before allocating memory" abort_pos)
+if(budget_pos EQUAL -1 OR abort_pos EQUAL -1)
+    message(FATAL_ERROR "OOM gate refused (rc=${rc}) but without the expected message:\n${combined}")
+endif()
+
+message(STATUS "OOM gate refused the oversized run as expected (rc=${rc}).")

--- a/tests/fixtures/scoring_estimate/detect.dat
+++ b/tests/fixtures/scoring_estimate/detect.dat
@@ -1,0 +1,20 @@
+# Fixture for the osh_scoring_estimate_memory() unit test.
+#
+# Geometry "G" is a 1 x 1 x 100 mesh => 100 bins.
+# Two scored quantities on one output:
+#   Dose  -> 1 accumulator  => 100 * 8 * 1 =  800 bytes
+#   DLET  -> 2 accumulators => 100 * 8 * 2 = 1600 bytes   (LET keeps a weight sum)
+# Expected: accum_bytes = 2400, npages = 2, largest_page_bytes = 1600, geometry "G".
+
+Geometry Mesh
+    Name G
+    X -1.0   1.0     1
+    Y -1.0   1.0     1
+    Z  0.0  10.0   100
+
+Output
+    Filename est.dat
+    Fileformat TEXT
+    Geo G
+    Quantity Dose
+    Quantity DLET

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -70,4 +70,9 @@ endforeach()
 # ---- CLI smoke test via the built executable ----
 add_test(NAME "unit::cli::version" COMMAND $<TARGET_FILE:openshieldhit> --version)
 add_test(NAME "unit::cli::help"    COMMAND $<TARGET_FILE:openshieldhit> --help)
+add_test(NAME "unit::cli::print_resources" COMMAND $<TARGET_FILE:openshieldhit> --print-resources)
 set_tests_properties("unit::cli::version" "unit::cli::help" PROPERTIES LABELS "unit")
+# Exercises osh_sysinfo end-to-end on every CI OS; require the detected RAM line.
+set_tests_properties("unit::cli::print_resources" PROPERTIES
+    LABELS "unit"
+    PASS_REGULAR_EXPRESSION "Total RAM")

--- a/tests/unit/test_osh_membudget.c
+++ b/tests/unit/test_osh_membudget.c
@@ -16,7 +16,6 @@
 #include <stdlib.h>
 
 #include "apps/osh/osh_membudget.h"
-
 #include "test_assert.h"
 
 /* Byte-count helpers — spelled out as products so the intent is obvious. */

--- a/tests/unit/test_osh_membudget.c
+++ b/tests/unit/test_osh_membudget.c
@@ -1,0 +1,93 @@
+/*
+ * Unit tests for the memory-budget parser and default policy (osh_membudget).
+ * Pure arithmetic, so these run identically on every OS.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "apps/osh/osh_membudget.h"
+
+#define ASSERT_TRUE(cond)                                                                                              \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            fprintf(stderr, "ASSERT FAILED: %s (%s:%d)\n", #cond, __FILE__, __LINE__);                                 \
+            exit(1);                                                                                                   \
+        }                                                                                                              \
+    } while (0)
+
+#define KIB ((uint64_t) 1u << 10)
+#define MIB ((uint64_t) 1u << 20)
+#define GIB ((uint64_t) 1u << 30)
+
+static void test_parse_plain_bytes(void) {
+    uint64_t v = 0u;
+    ASSERT_TRUE(osh_membudget_parse("1048576", 0u, &v) && v == 1048576u);
+    ASSERT_TRUE(osh_membudget_parse("0", 0u, &v) && v == 0u);
+}
+
+static void test_parse_units(void) {
+    uint64_t v = 0u;
+    ASSERT_TRUE(osh_membudget_parse("1KB", 0u, &v) && v == KIB);
+    ASSERT_TRUE(osh_membudget_parse("1KiB", 0u, &v) && v == KIB);
+    ASSERT_TRUE(osh_membudget_parse("1k", 0u, &v) && v == KIB);
+    ASSERT_TRUE(osh_membudget_parse("2M", 0u, &v) && v == 2u * MIB);
+    ASSERT_TRUE(osh_membudget_parse("8GB", 0u, &v) && v == 8u * GIB);
+    ASSERT_TRUE(osh_membudget_parse("1.5GiB", 0u, &v) && v == (uint64_t) (1.5 * (double) GIB));
+    ASSERT_TRUE(osh_membudget_parse("  4 GiB ", 0u, &v) && v == 4u * GIB);
+}
+
+static void test_parse_percent(void) {
+    uint64_t v = 0u;
+    ASSERT_TRUE(osh_membudget_parse("50%", 1000u, &v) && v == 500u);
+    ASSERT_TRUE(osh_membudget_parse("80%", 10u * GIB, &v) && v == (uint64_t) (0.80 * (double) (10u * GIB)));
+    ASSERT_TRUE(osh_membudget_parse("100%", 4096u, &v) && v == 4096u);
+}
+
+static void test_parse_rejects_garbage(void) {
+    uint64_t v = 0u;
+    ASSERT_TRUE(!osh_membudget_parse("", 0u, &v));
+    ASSERT_TRUE(!osh_membudget_parse("abc", 0u, &v));
+    ASSERT_TRUE(!osh_membudget_parse("-5", 0u, &v));
+    ASSERT_TRUE(!osh_membudget_parse("10XB", 0u, &v));
+    ASSERT_TRUE(!osh_membudget_parse("1GB junk", 0u, &v));
+    ASSERT_TRUE(!osh_membudget_parse(NULL, 0u, &v));
+}
+
+static void test_default_policy(void) {
+    struct osh_sysinfo info;
+    uint64_t budget;
+
+    /* Known total + available: budget ≈ 80% of available, below available. */
+    info.logical_cores = 8u;
+    info.ram_total_bytes = 16u * GIB;
+    info.ram_available_bytes = 10u * GIB;
+    info.gpu_count = 0u;
+    budget = osh_membudget_default(&info);
+    ASSERT_TRUE(budget > 0u);
+    ASSERT_TRUE(budget < info.ram_available_bytes); /* leaves headroom */
+    ASSERT_TRUE(budget >= info.ram_available_bytes / 2u);
+
+    /* Available unknown: falls back to total. */
+    info.ram_available_bytes = 0u;
+    budget = osh_membudget_default(&info);
+    ASSERT_TRUE(budget > 0u && budget < info.ram_total_bytes);
+
+    /* Nothing known: 0 (caller skips enforcement). */
+    info.ram_total_bytes = 0u;
+    budget = osh_membudget_default(&info);
+    ASSERT_TRUE(budget == 0u);
+
+    /* NULL is handled. */
+    ASSERT_TRUE(osh_membudget_default(NULL) == 0u);
+}
+
+int main(void) {
+    test_parse_plain_bytes();
+    test_parse_units();
+    test_parse_percent();
+    test_parse_rejects_garbage();
+    test_default_policy();
+    return 0;
+}

--- a/tests/unit/test_osh_membudget.c
+++ b/tests/unit/test_osh_membudget.c
@@ -17,13 +17,7 @@
 
 #include "apps/osh/osh_membudget.h"
 
-#define ASSERT_TRUE(cond)                                                                                              \
-    do {                                                                                                               \
-        if (!(cond)) {                                                                                                 \
-            fprintf(stderr, "ASSERT FAILED: %s (%s:%d)\n", #cond, __FILE__, __LINE__);                                 \
-            exit(1);                                                                                                   \
-        }                                                                                                              \
-    } while (0)
+#include "test_assert.h"
 
 /* Byte-count helpers — spelled out as products so the intent is obvious. */
 #define KIB ((uint64_t) 1024)

--- a/tests/unit/test_osh_membudget.c
+++ b/tests/unit/test_osh_membudget.c
@@ -1,6 +1,14 @@
 /*
  * Unit tests for the memory-budget parser and default policy (osh_membudget).
  * Pure arithmetic, so these run identically on every OS.
+ *
+ * Coverage:
+ *   test_parse_plain_bytes      — bare integer strings (no unit suffix)
+ *   test_parse_all_units        — all recognised unit suffixes (K/KB/KiB … P/PB/PiB)
+ *   test_parse_spacing          — leading/trailing/internal whitespace
+ *   test_parse_percent          — "N%" form, including base-zero rejection
+ *   test_parse_rejects_garbage  — malformed inputs that must return 0
+ *   test_default_policy         — osh_membudget_default() policy invariants
  */
 
 #include <stdint.h>
@@ -17,77 +25,187 @@
         }                                                                                                              \
     } while (0)
 
-#define KIB ((uint64_t) 1u << 10)
-#define MIB ((uint64_t) 1u << 20)
-#define GIB ((uint64_t) 1u << 30)
+/* Byte-count helpers — spelled out as products so the intent is obvious. */
+#define KIB ((uint64_t) 1024)
+#define MIB ((uint64_t) 1024 * 1024)
+#define GIB ((uint64_t) 1024 * 1024 * 1024)
+#define TIB ((uint64_t) 1024 * 1024 * 1024 * 1024)
+#define PIB ((uint64_t) 1024 * 1024 * 1024 * 1024 * 1024)
+
+/* ---- Plain byte strings --------------------------------------------------- */
 
 static void test_parse_plain_bytes(void) {
     uint64_t v = 0u;
-    ASSERT_TRUE(osh_membudget_parse("1048576", 0u, &v) && v == 1048576u);
+    /* Exact integer byte counts, no unit suffix. */
     ASSERT_TRUE(osh_membudget_parse("0", 0u, &v) && v == 0u);
+    ASSERT_TRUE(osh_membudget_parse("1", 0u, &v) && v == 1u);
+    ASSERT_TRUE(osh_membudget_parse("1048576", 0u, &v) && v == 1048576u);
+    ASSERT_TRUE(osh_membudget_parse("4294967295", 0u, &v) && v == 4294967295u); /* 2^32-1 */
 }
 
-static void test_parse_units(void) {
+/* ---- Unit suffix variants ------------------------------------------------- */
+
+/*
+ * unit_multiplier() is a private static function; test it indirectly through
+ * osh_membudget_parse().  Every suffix variant (short, long, SI-looking, IEC)
+ * must produce the same binary (1024-based) result.
+ */
+static void test_parse_all_units(void) {
     uint64_t v = 0u;
-    ASSERT_TRUE(osh_membudget_parse("1KB", 0u, &v) && v == KIB);
-    ASSERT_TRUE(osh_membudget_parse("1KiB", 0u, &v) && v == KIB);
+
+    /* Plain bytes — "B" suffix or no suffix at all. */
+    ASSERT_TRUE(osh_membudget_parse("1B", 0u, &v) && v == 1u);
+    ASSERT_TRUE(osh_membudget_parse("512B", 0u, &v) && v == 512u);
+
+    /* Kibibytes: K, KB, KiB (all lowercase/mixed-case too). */
+    ASSERT_TRUE(osh_membudget_parse("1K", 0u, &v) && v == KIB);
     ASSERT_TRUE(osh_membudget_parse("1k", 0u, &v) && v == KIB);
+    ASSERT_TRUE(osh_membudget_parse("1KB", 0u, &v) && v == KIB);
+    ASSERT_TRUE(osh_membudget_parse("1kb", 0u, &v) && v == KIB);
+    ASSERT_TRUE(osh_membudget_parse("1KiB", 0u, &v) && v == KIB);
+    ASSERT_TRUE(osh_membudget_parse("1kib", 0u, &v) && v == KIB);
+
+    /* Mebibytes: M, MB, MiB. */
+    ASSERT_TRUE(osh_membudget_parse("1M", 0u, &v) && v == MIB);
     ASSERT_TRUE(osh_membudget_parse("2M", 0u, &v) && v == 2u * MIB);
+    ASSERT_TRUE(osh_membudget_parse("1MB", 0u, &v) && v == MIB);
+    ASSERT_TRUE(osh_membudget_parse("1MiB", 0u, &v) && v == MIB);
+    ASSERT_TRUE(osh_membudget_parse("256MB", 0u, &v) && v == 256u * MIB);
+
+    /* Gibibytes: G, GB, GiB. */
+    ASSERT_TRUE(osh_membudget_parse("1G", 0u, &v) && v == GIB);
     ASSERT_TRUE(osh_membudget_parse("8GB", 0u, &v) && v == 8u * GIB);
+    ASSERT_TRUE(osh_membudget_parse("1GiB", 0u, &v) && v == GIB);
     ASSERT_TRUE(osh_membudget_parse("1.5GiB", 0u, &v) && v == (uint64_t) (1.5 * (double) GIB));
-    ASSERT_TRUE(osh_membudget_parse("  4 GiB ", 0u, &v) && v == 4u * GIB);
+
+    /* Tebibytes: T, TB, TiB. */
+    ASSERT_TRUE(osh_membudget_parse("1T", 0u, &v) && v == TIB);
+    ASSERT_TRUE(osh_membudget_parse("1TB", 0u, &v) && v == TIB);
+    ASSERT_TRUE(osh_membudget_parse("1TiB", 0u, &v) && v == TIB);
+    ASSERT_TRUE(osh_membudget_parse("2TB", 0u, &v) && v == 2u * TIB);
+
+    /* Pebibytes: P, PB, PiB. */
+    ASSERT_TRUE(osh_membudget_parse("1P", 0u, &v) && v == PIB);
+    ASSERT_TRUE(osh_membudget_parse("1PB", 0u, &v) && v == PIB);
+    ASSERT_TRUE(osh_membudget_parse("1PiB", 0u, &v) && v == PIB);
 }
+
+/* ---- Whitespace tolerance ------------------------------------------------- */
+
+static void test_parse_spacing(void) {
+    uint64_t v = 0u;
+    /* Leading/trailing spaces around the whole string. */
+    ASSERT_TRUE(osh_membudget_parse("  512MB", 0u, &v) && v == 512u * MIB);
+    ASSERT_TRUE(osh_membudget_parse("512MB  ", 0u, &v) && v == 512u * MIB);
+    ASSERT_TRUE(osh_membudget_parse("  512MB  ", 0u, &v) && v == 512u * MIB);
+    /* Space between number and unit: "4 GiB" → same as "4GiB". */
+    ASSERT_TRUE(osh_membudget_parse("4 GiB", 0u, &v) && v == 4u * GIB);
+    ASSERT_TRUE(osh_membudget_parse("  4 GiB ", 0u, &v) && v == 4u * GIB);
+    /* Plain byte string with spaces. */
+    ASSERT_TRUE(osh_membudget_parse("  1048576  ", 0u, &v) && v == 1048576u);
+}
+
+/* ---- Percentage form ------------------------------------------------------ */
 
 static void test_parse_percent(void) {
     uint64_t v = 0u;
+
+    /* Standard uses. */
     ASSERT_TRUE(osh_membudget_parse("50%", 1000u, &v) && v == 500u);
-    ASSERT_TRUE(osh_membudget_parse("80%", 10u * GIB, &v) && v == (uint64_t) (0.80 * (double) (10u * GIB)));
     ASSERT_TRUE(osh_membudget_parse("100%", 4096u, &v) && v == 4096u);
+    ASSERT_TRUE(osh_membudget_parse("80%", 10u * GIB, &v) && v == (uint64_t) (0.80 * (double) (10u * GIB)));
+
+    /* Fractional percentage. */
+    ASSERT_TRUE(osh_membudget_parse("62.5%", 1024u, &v) && v == 640u);
+
+    /* Whitespace around the whole string. */
+    ASSERT_TRUE(osh_membudget_parse("  50%  ", 1000u, &v) && v == 500u);
+
+    /* base == 0: percentage has no meaningful reference → must fail.
+     * Without this guard "80%" with unknown RAM would silently produce 0,
+     * which would disable the budget rather than reporting bad input. */
+    ASSERT_TRUE(!osh_membudget_parse("80%", 0u, &v));
+    ASSERT_TRUE(!osh_membudget_parse("0%", 0u, &v));
 }
+
+/* ---- Rejection of malformed inputs --------------------------------------- */
 
 static void test_parse_rejects_garbage(void) {
     uint64_t v = 0u;
-    ASSERT_TRUE(!osh_membudget_parse("", 0u, &v));
-    ASSERT_TRUE(!osh_membudget_parse("abc", 0u, &v));
-    ASSERT_TRUE(!osh_membudget_parse("-5", 0u, &v));
-    ASSERT_TRUE(!osh_membudget_parse("10XB", 0u, &v));
-    ASSERT_TRUE(!osh_membudget_parse("1GB junk", 0u, &v));
+
+    /* NULL or empty. */
     ASSERT_TRUE(!osh_membudget_parse(NULL, 0u, &v));
+    ASSERT_TRUE(!osh_membudget_parse("", 0u, &v));
+    ASSERT_TRUE(!osh_membudget_parse("   ", 0u, &v));
+
+    /* Signed values (budgets are non-negative). */
+    ASSERT_TRUE(!osh_membudget_parse("-5", 0u, &v));
+    ASSERT_TRUE(!osh_membudget_parse("+5", 0u, &v));
+    ASSERT_TRUE(!osh_membudget_parse("-1GB", 0u, &v));
+
+    /* Non-numeric start. */
+    ASSERT_TRUE(!osh_membudget_parse("abc", 0u, &v));
+    ASSERT_TRUE(!osh_membudget_parse("GB", 0u, &v));
+
+    /* Unrecognised unit suffix. */
+    ASSERT_TRUE(!osh_membudget_parse("10XB", 0u, &v));
+    ASSERT_TRUE(!osh_membudget_parse("10YiB", 0u, &v));
+    ASSERT_TRUE(!osh_membudget_parse("10bytes", 0u, &v));
+
+    /* Trailing junk after a valid unit. */
+    ASSERT_TRUE(!osh_membudget_parse("1GB junk", 0u, &v));
+    ASSERT_TRUE(!osh_membudget_parse("1GBextra", 0u, &v));
+
+    /* Trailing junk after a percentage. */
+    ASSERT_TRUE(!osh_membudget_parse("80% extra", 1000u, &v));
+    ASSERT_TRUE(!osh_membudget_parse("80%MB", 1000u, &v));
 }
+
+/* ---- Default policy invariants ------------------------------------------- */
 
 static void test_default_policy(void) {
     struct osh_sysinfo info;
     uint64_t budget;
 
-    /* Known total + available: budget ≈ 80% of available, below available. */
+    /* NULL guard. */
+    ASSERT_TRUE(osh_membudget_default(NULL) == 0u);
+
+    /* Both total and available known: budget should be between 50 % and 100 %
+     * of available (exact value depends on the reserve calculation). */
     info.logical_cores = 8u;
     info.ram_total_bytes = 16u * GIB;
     info.ram_available_bytes = 10u * GIB;
     info.gpu_count = 0u;
     budget = osh_membudget_default(&info);
     ASSERT_TRUE(budget > 0u);
-    ASSERT_TRUE(budget < info.ram_available_bytes); /* leaves headroom */
-    ASSERT_TRUE(budget >= info.ram_available_bytes / 2u);
+    ASSERT_TRUE(budget < info.ram_available_bytes);       /* always leaves headroom */
+    ASSERT_TRUE(budget >= info.ram_available_bytes / 2u); /* at least 50 % */
 
-    /* Available unknown: falls back to total. */
+    /* Available unknown (0): falls back to total RAM. */
     info.ram_available_bytes = 0u;
     budget = osh_membudget_default(&info);
     ASSERT_TRUE(budget > 0u && budget < info.ram_total_bytes);
 
-    /* Nothing known: 0 (caller skips enforcement). */
+    /* Both unknown: return 0 so the caller skips enforcement. */
     info.ram_total_bytes = 0u;
     budget = osh_membudget_default(&info);
     ASSERT_TRUE(budget == 0u);
 
-    /* NULL is handled. */
-    ASSERT_TRUE(osh_membudget_default(NULL) == 0u);
+    /* Very small RAM (256 MiB total): reserve floor consumes all of it.
+     * Budget must be 0 rather than a nonsensical huge value. */
+    info.ram_total_bytes = 256u * MIB;
+    info.ram_available_bytes = 200u * MIB;
+    budget = osh_membudget_default(&info);
+    ASSERT_TRUE(budget == 0u || budget < info.ram_available_bytes);
 }
 
 int main(void) {
     test_parse_plain_bytes();
-    test_parse_units();
+    test_parse_all_units();
+    test_parse_spacing();
     test_parse_percent();
     test_parse_rejects_garbage();
     test_default_policy();
+    printf("All osh_membudget tests passed.\n");
     return 0;
 }

--- a/tests/unit/test_osh_scoring_estimate.c
+++ b/tests/unit/test_osh_scoring_estimate.c
@@ -17,13 +17,7 @@
 #define OSH_TEST_FIXTURES_DIR "."
 #endif
 
-#define ASSERT_TRUE(cond)                                                                                              \
-    do {                                                                                                               \
-        if (!(cond)) {                                                                                                 \
-            fprintf(stderr, "ASSERT FAILED: %s (%s:%d)\n", #cond, __FILE__, __LINE__);                                 \
-            exit(1);                                                                                                   \
-        }                                                                                                              \
-    } while (0)
+#include "test_assert.h"
 
 static void test_estimate_known_fixture(void) {
     char path[1024];

--- a/tests/unit/test_osh_scoring_estimate.c
+++ b/tests/unit/test_osh_scoring_estimate.c
@@ -1,0 +1,58 @@
+/*
+ * Unit tests for osh_scoring_estimate_memory(): the allocation-free scoring
+ * memory estimate that the OOM gate relies on.  Loads a committed detect.dat
+ * fixture whose accumulator byte total is known exactly and checks the estimate
+ * against it (including the 2x "data2" doubling for LET-average quantities).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "apps/osh/osh_app_osh.h"
+#include "openshieldhit/scoring.h"
+#include "openshieldhit/status.h"
+
+#ifndef OSH_TEST_FIXTURES_DIR
+#define OSH_TEST_FIXTURES_DIR "."
+#endif
+
+#define ASSERT_TRUE(cond)                                                                                              \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            fprintf(stderr, "ASSERT FAILED: %s (%s:%d)\n", #cond, __FILE__, __LINE__);                                 \
+            exit(1);                                                                                                   \
+        }                                                                                                              \
+    } while (0)
+
+static void test_estimate_known_fixture(void) {
+    char path[1024];
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_mem_estimate est;
+
+    (void) snprintf(path, sizeof(path), "%s/scoring_estimate/detect.dat", OSH_TEST_FIXTURES_DIR);
+
+    ASSERT_TRUE(osh_scoring_setup_from_path(path, NULL, &ws) == OSH_OK);
+    ASSERT_TRUE(ws != NULL);
+
+    ASSERT_TRUE(osh_scoring_estimate_memory(ws, &est) == OSH_OK);
+
+    /* 100 bins: Dose = 100*8*1 = 800, DLET = 100*8*2 = 1600 -> 2400 total. */
+    ASSERT_TRUE(est.npages == 2u);
+    ASSERT_TRUE(est.accum_bytes == 2400u);
+    ASSERT_TRUE(est.largest_page_bytes == 1600u);
+    ASSERT_TRUE(strcmp(est.largest_geometry, "G") == 0);
+
+    osh_scoring_workspace_free(ws);
+}
+
+static void test_estimate_null_args(void) {
+    struct osh_scoring_mem_estimate est;
+    ASSERT_TRUE(osh_scoring_estimate_memory(NULL, &est) == OSH_EINVAL);
+}
+
+int main(void) {
+    test_estimate_known_fixture();
+    test_estimate_null_args();
+    return 0;
+}

--- a/tests/unit/test_osh_sysinfo.c
+++ b/tests/unit/test_osh_sysinfo.c
@@ -46,9 +46,10 @@ static void test_query_invariants(void) {
     /* GPU detection is not implemented yet: must be reset to 0. */
     ASSERT_TRUE(info.gpu_count == 0u);
 
-    /* On every CI target (Linux/macOS/Windows) these are reported. */
+#if defined(__linux__) || defined(_WIN32) || defined(__APPLE__) || defined(__EMSCRIPTEN__)
     ASSERT_TRUE(info.logical_cores >= 1u);
     ASSERT_TRUE(info.ram_total_bytes > 0u);
+#endif
 
     /* Available is best-effort; when known it cannot exceed total. */
     if (info.ram_available_bytes > 0u) {

--- a/tests/unit/test_osh_sysinfo.c
+++ b/tests/unit/test_osh_sysinfo.c
@@ -13,13 +13,7 @@
 #include "common/osh_sysinfo.h"
 #include "openshieldhit/status.h"
 
-#define ASSERT_TRUE(cond)                                                                                              \
-    do {                                                                                                               \
-        if (!(cond)) {                                                                                                 \
-            fprintf(stderr, "ASSERT FAILED: %s (%s:%d)\n", #cond, __FILE__, __LINE__);                                 \
-            exit(1);                                                                                                   \
-        }                                                                                                              \
-    } while (0)
+#include "test_assert.h"
 
 #define ASSERT_STREQ(a, b)                                                                                             \
     do {                                                                                                               \

--- a/tests/unit/test_osh_sysinfo.c
+++ b/tests/unit/test_osh_sysinfo.c
@@ -1,0 +1,104 @@
+/*
+ * Unit tests for osh_sysinfo: best-effort host resource detection and the
+ * byte-formatting helper.  Detection values are platform-dependent, so the
+ * assertions check invariants (cores >= 1, total > 0 on supported desktop
+ * OSes, available <= total) rather than exact numbers.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common/osh_sysinfo.h"
+#include "openshieldhit/status.h"
+
+#define ASSERT_TRUE(cond)                                                                                              \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            fprintf(stderr, "ASSERT FAILED: %s (%s:%d)\n", #cond, __FILE__, __LINE__);                                 \
+            exit(1);                                                                                                   \
+        }                                                                                                              \
+    } while (0)
+
+#define ASSERT_STREQ(a, b)                                                                                             \
+    do {                                                                                                               \
+        char const *_a = (a);                                                                                          \
+        char const *_b = (b);                                                                                          \
+        if (strcmp(_a, _b) != 0) {                                                                                     \
+            fprintf(stderr, "ASSERT FAILED: \"%s\" != \"%s\" (%s:%d)\n", _a, _b, __FILE__, __LINE__);                  \
+            exit(1);                                                                                                   \
+        }                                                                                                              \
+    } while (0)
+
+static void test_query_null_is_einval(void) {
+    ASSERT_TRUE(osh_sysinfo_query(NULL) == OSH_EINVAL);
+}
+
+static void test_query_invariants(void) {
+    struct osh_sysinfo info;
+
+    /* Sentinel so we can detect that the query zero-initialises before filling. */
+    info.gpu_count = 12345u;
+
+    ASSERT_TRUE(osh_sysinfo_query(&info) == OSH_OK);
+
+    /* GPU detection is not implemented yet: must be reset to 0. */
+    ASSERT_TRUE(info.gpu_count == 0u);
+
+    /* On every CI target (Linux/macOS/Windows) these are reported. */
+    ASSERT_TRUE(info.logical_cores >= 1u);
+    ASSERT_TRUE(info.ram_total_bytes > 0u);
+
+    /* Available is best-effort; when known it cannot exceed total. */
+    if (info.ram_available_bytes > 0u) {
+        ASSERT_TRUE(info.ram_available_bytes <= info.ram_total_bytes);
+    }
+}
+
+static void test_format_bytes(void) {
+    char buf[32];
+
+    osh_sysinfo_format_bytes(0u, buf, sizeof(buf));
+    ASSERT_STREQ(buf, "0 B");
+
+    osh_sysinfo_format_bytes(512u, buf, sizeof(buf));
+    ASSERT_STREQ(buf, "512 B");
+
+    osh_sysinfo_format_bytes(1023u, buf, sizeof(buf));
+    ASSERT_STREQ(buf, "1023 B");
+
+    osh_sysinfo_format_bytes(1024u, buf, sizeof(buf));
+    ASSERT_STREQ(buf, "1.0 KiB");
+
+    osh_sysinfo_format_bytes(1536u, buf, sizeof(buf));
+    ASSERT_STREQ(buf, "1.5 KiB");
+
+    osh_sysinfo_format_bytes((uint64_t) 1u << 20, buf, sizeof(buf));
+    ASSERT_STREQ(buf, "1.0 MiB");
+
+    osh_sysinfo_format_bytes((uint64_t) 3u << 30, buf, sizeof(buf));
+    ASSERT_STREQ(buf, "3.0 GiB");
+
+    osh_sysinfo_format_bytes((uint64_t) 1u << 40, buf, sizeof(buf));
+    ASSERT_STREQ(buf, "1.0 TiB");
+}
+
+static void test_format_bytes_no_overflow_on_tiny_buffer(void) {
+    char buf[4];
+
+    /* Must NUL-terminate and not write past the buffer; content is truncated. */
+    osh_sysinfo_format_bytes((uint64_t) 3u << 30, buf, sizeof(buf));
+    ASSERT_TRUE(buf[sizeof(buf) - 1] == '\0');
+
+    /* buflen == 0 must be a no-op (no write, no crash). */
+    osh_sysinfo_format_bytes(123u, buf, 0u);
+}
+
+int main(void) {
+    test_query_null_is_einval();
+    test_query_invariants();
+    test_format_bytes();
+    test_format_bytes_no_overflow_on_tiny_buffer();
+    return 0;
+}

--- a/tests/unit/test_osh_sysinfo.c
+++ b/tests/unit/test_osh_sysinfo.c
@@ -12,7 +12,6 @@
 
 #include "common/osh_sysinfo.h"
 #include "openshieldhit/status.h"
-
 #include "test_assert.h"
 
 #define ASSERT_STREQ(a, b)                                                                                             \


### PR DESCRIPTION
This pull request introduces a memory budgeting feature to the `osh` application, allowing users to estimate and control the memory usage of scoring accumulators before running a simulation. It adds resource introspection, budget parsing, and enforcement of memory limits, as well as new CI steps to report host resources. The changes are grouped below by theme.

**Memory Budgeting and Enforcement:**

* Added a new `osh_membudget` module (`osh_membudget.c`, `osh_membudget.h`) that parses user-supplied memory budgets (plain bytes, unit-suffixed, or percentage forms) and computes a default budget based on host resources, with policies to ensure system stability. [[1]](diffhunk://#diff-3591be7a5070a5c1894dffabbecebdb05b24784ea680a840e96426fb59fb85acR1-R228) [[2]](diffhunk://#diff-97e04cb3ba7f07990509cb5b1a334cf2579d95a0a58aa385cedcce716bd2a3acR1-R69)
* Integrated memory budget checks into the scoring workflow: before allocating scoring accumulators, the code now estimates memory needs and refuses to proceed if the run would exceed the user-specified or default budget. [[1]](diffhunk://#diff-559d5132c2ba04439af7100acff3d22eca02e07f1c92ccf0b3557bdf878bdd91R48-R49) [[2]](diffhunk://#diff-559d5132c2ba04439af7100acff3d22eca02e07f1c92ccf0b3557bdf878bdd91R270-R277) [[3]](diffhunk://#diff-f4ef3e337a8b21ebfd493b60e131d559b38c7b2b783dfcc8a77167b91a939b1fR95)
* Updated the build system to include the new `osh_membudget.c` source file in the application build.

**Host Resource Introspection:**

* Added a new CLI action (`--print-resources`) to print detected host CPU and RAM resources, using the new `osh_sysinfo` functionality. This is now also exercised in CI workflows for all platforms. [[1]](diffhunk://#diff-f4ef3e337a8b21ebfd493b60e131d559b38c7b2b783dfcc8a77167b91a939b1fR8) [[2]](diffhunk://#diff-f4ef3e337a8b21ebfd493b60e131d559b38c7b2b783dfcc8a77167b91a939b1fR47-R66) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R63-R71)

**API and Header Updates:**

* Extended the scoring API with a memory estimate structure and function (`osh_scoring_mem_estimate`, `osh_scoring_estimate_memory`) to predict the memory footprint of scoring accumulators before allocation. [[1]](diffhunk://#diff-e8aa84da844a4e5d7724b3473e988dfc03360b64eab42068f7ac1d82636b0fd6R5) [[2]](diffhunk://#diff-e8aa84da844a4e5d7724b3473e988dfc03360b64eab42068f7ac1d82636b0fd6R68-R121)