### PR TITLE
beam: cursor-free primary generation via explicit global base (#165)

### DIFF
--- a/docs/dev/random_numbers.md
+++ b/docs/dev/random_numbers.md
@@ -149,6 +149,36 @@ design is **not reproducible** the moment you change batch size or add a thread,
 and it cannot be split across lanes/threads/ranks without serialising draws or
 abandoning reproducibility.
 
+### The ELI5 version
+
+Workers do not reserve chunks of one long random-number sequence.  They reserve
+history IDs.
+
+For example, a run with `nstat = 1000` can be split into four worker ranges:
+
+```text
+worker 0: histories [0, 250)
+worker 1: histories [250, 500)
+worker 2: histories [500, 750)
+worker 3: histories [750, 1000)
+```
+
+History 17 might need ten random draws, while history 18 might need ten thousand
+because it scatters more, creates secondaries, or stays in the geometry longer.
+That variation is fine because history 18 does not continue where history 17
+stopped.  Instead, each primary history starts its own RNG stream from its
+global history index:
+
+```text
+history_index = RNDOFFSET + worker_range_start + worker_local_index
+```
+
+So worker 1's first primary is seeded from history index `RNDOFFSET + 250`,
+regardless of how many random numbers worker 0 consumed.  The important
+parallelism rule is therefore simple: worker ranges must be disjoint and
+together cover `[0, nstat)`.  Then each history ID is generated once, and each
+history gets the same random stream no matter which worker runs it.
+
 ### The model
 
 Every history owns an **independent stream keyed by its global index**, carried

--- a/src/beam/CMakeLists.txt
+++ b/src/beam/CMakeLists.txt
@@ -14,6 +14,10 @@ target_include_directories(osh_beam
 )
 
 target_link_libraries(osh_beam
+    PUBLIC
+        # osh_beam_model.c samples via osh_rng_*, and struct osh_rng appears in
+        # the public osh_beam_model.h API, so osh_random is a usage requirement.
+        osh_random
     PRIVATE
         osh_common
         osh_particle

--- a/src/beam/runtime/osh_beam_runtime.c
+++ b/src/beam/runtime/osh_beam_runtime.c
@@ -14,11 +14,13 @@ static enum osh_status setup_phsp(struct osh_beam_runtime *rt);
 static enum osh_status fill_from_spots(struct osh_beam_runtime *rt,
                                        struct osh_rng_seeding const *seeding,
                                        struct osh_particle_pool *pool,
-                                       size_t n);
+                                       size_t n,
+                                       uint64_t global_prim_base);
 static enum osh_status fill_from_phsp(struct osh_beam_runtime *rt,
                                       struct osh_rng_seeding const *seeding,
                                       struct osh_particle_pool *pool,
-                                      size_t n);
+                                      size_t n,
+                                      uint64_t global_prim_base);
 
 /* ---- Lifecycle ----------------------------------------------------------- */
 
@@ -79,10 +81,11 @@ void osh_beam_runtime_free(struct osh_beam_runtime **rt) {
 
 /* ---- Primary generation -------------------------------------------------- */
 
-enum osh_status osh_beam_runtime_fill_pool(struct osh_beam_runtime *rt,
-                                           struct osh_rng_seeding const *seeding,
-                                           struct osh_particle_pool *pool,
-                                           size_t n) {
+enum osh_status osh_beam_runtime_fill_pool_at(struct osh_beam_runtime *rt,
+                                              struct osh_rng_seeding const *seeding,
+                                              struct osh_particle_pool *pool,
+                                              size_t n,
+                                              uint64_t global_prim_base) {
     if (!rt || !seeding || !pool) {
         return OSH_EINVAL;
     }
@@ -96,12 +99,34 @@ enum osh_status osh_beam_runtime_fill_pool(struct osh_beam_runtime *rt,
     switch (rt->workspace->beam_mode) {
     case OSH_BEAM_MODE_SPOTS:
     case OSH_BEAM_MODE_SOBP:
-        return fill_from_spots(rt, seeding, pool, n);
+        return fill_from_spots(rt, seeding, pool, n, global_prim_base);
     case OSH_BEAM_MODE_PHSP:
-        return fill_from_phsp(rt, seeding, pool, n);
+        return fill_from_phsp(rt, seeding, pool, n, global_prim_base);
     default:
         return OSH_ENOTSUP;
     }
+}
+
+enum osh_status osh_beam_runtime_fill_pool(struct osh_beam_runtime *rt,
+                                           struct osh_rng_seeding const *seeding,
+                                           struct osh_particle_pool *pool,
+                                           size_t n) {
+    enum osh_status rc;
+
+    if (!rt) {
+        return OSH_EINVAL;
+    }
+
+    /* Serial convenience wrapper: the global history base is the running cursor
+     * of primaries this runtime has already emitted.  All the work — and all
+     * validation — lives in _at(); only this wrapper reads or advances the
+     * shared cursor, so the cursor-free _at() path stays safe to call from many
+     * workers over disjoint, explicitly-based ranges. */
+    rc = osh_beam_runtime_fill_pool_at(rt, seeding, pool, n, (uint64_t) rt->primaries_generated);
+    if (rc == OSH_OK) {
+        rt->primaries_generated += n;
+    }
+    return rc;
 }
 
 /* ---- Spots/SOBP implementation ------------------------------------------- */
@@ -129,7 +154,8 @@ static enum osh_status setup_spots(struct osh_beam_runtime *rt) {
 static enum osh_status fill_from_spots(struct osh_beam_runtime *rt,
                                        struct osh_rng_seeding const *seeding,
                                        struct osh_particle_pool *pool,
-                                       size_t n) {
+                                       size_t n,
+                                       uint64_t global_prim_base) {
     size_t i;
     size_t slot;
     struct ray_v ray;
@@ -145,6 +171,12 @@ static enum osh_status fill_from_spots(struct osh_beam_runtime *rt,
      * regardless of fill chunking, pool capacity, or physics options, and
      * keeps it independent of the transport stream.
      *
+     * The global history index of primary i is global_prim_base + i, supplied
+     * by the caller rather than read from an internal cursor.  That is what lets
+     * two workers fill disjoint slices [a, b) and [b, c) of the same run — in
+     * any order, on any thread — and still reproduce the single-pass per-history
+     * streams exactly: the seed depends only on the index, never on call order.
+     *
      * osh_beam_new_primary() returns one ray_v (AoS) at a time. We copy the
      * seven phase-space scalars into the pool's SoA arrays and assign
      * per-history metadata, reusing one resolved species descriptor per run.
@@ -154,7 +186,7 @@ static enum osh_status fill_from_spots(struct osh_beam_runtime *rt,
      * auto-vectorization of the energy/position sampling arithmetic.
      */
     for (i = 0u; i < n; ++i) {
-        uint64_t const prim_idx = rt->primaries_generated + i;
+        uint64_t const prim_idx = global_prim_base + i;
         uint64_t const hist_index = seeding->hist_base + prim_idx;
         struct osh_rng beam_rng;
 
@@ -185,7 +217,8 @@ static enum osh_status fill_from_spots(struct osh_beam_runtime *rt,
     }
 
     pool->n += n;
-    rt->primaries_generated += n;
+    /* No rt->primaries_generated mutation here: the global base is caller-driven
+     * (see osh_beam_runtime_fill_pool_at).  The serial wrapper owns the cursor. */
     return OSH_OK;
 }
 
@@ -214,7 +247,8 @@ static enum osh_status setup_phsp(struct osh_beam_runtime *rt) {
 static enum osh_status fill_from_phsp(struct osh_beam_runtime *rt,
                                       struct osh_rng_seeding const *seeding,
                                       struct osh_particle_pool *pool,
-                                      size_t n) {
+                                      size_t n,
+                                      uint64_t global_prim_base) {
     /*
      * PHSP (MCPL) fill — not yet implemented.
      *
@@ -222,7 +256,7 @@ static enum osh_status fill_from_phsp(struct osh_beam_runtime *rt,
      *   1. Read min(n, total - file_pos) entries from the MCPL file.
      *   2. Convert each MCPL particle record to pool SoA layout.
      *   3. Advance rt->source.phsp.file_pos; rewind when exhausted.
-     *   4. Assign prim_idx from rt->primaries_generated and gen = 0.
+     *   4. Assign prim_idx from global_prim_base + i and gen = 0.
      *   5. Seed pool->rng[slot] via osh_rng_seed_history(..., hist_index,
      *      OSH_RNG_PURPOSE_PHYSICS) exactly as the spots path does, so PHSP
      *      transport is reproducible and capacity-independent too.
@@ -238,5 +272,6 @@ static enum osh_status fill_from_phsp(struct osh_beam_runtime *rt,
     (void) seeding;
     (void) pool;
     (void) n;
+    (void) global_prim_base;
     return OSH_ENOTSUP;
 }

--- a/src/beam/runtime/osh_beam_runtime.c
+++ b/src/beam/runtime/osh_beam_runtime.c
@@ -1,5 +1,6 @@
 #include "beam/runtime/osh_beam_runtime.h"
 
+#include <stdint.h>
 #include <stdlib.h>
 
 #include "beam/osh_beam_model.h"
@@ -95,6 +96,14 @@ enum osh_status osh_beam_runtime_fill_pool_at(struct osh_beam_runtime *rt,
     if (pool->n + n > pool->capacity) {
         return OSH_EINVAL;
     }
+    /* The global history index of the last primary in this fill is
+     * global_prim_base + (n - 1).  Reject a base that would wrap uint64_t rather
+     * than silently reuse indices/RNG streams.  (Unreachable in practice — it
+     * needs ~2^64 histories — but the seam is the contract for parallel fills,
+     * so fail loudly instead of corrupting tallies.) */
+    if (global_prim_base > UINT64_MAX - (uint64_t) n) {
+        return OSH_EINVAL;
+    }
 
     switch (rt->workspace->beam_mode) {
     case OSH_BEAM_MODE_SPOTS:
@@ -121,10 +130,12 @@ enum osh_status osh_beam_runtime_fill_pool(struct osh_beam_runtime *rt,
      * of primaries this runtime has already emitted.  All the work — and all
      * validation — lives in _at(); only this wrapper reads or advances the
      * shared cursor, so the cursor-free _at() path stays safe to call from many
-     * workers over disjoint, explicitly-based ranges. */
-    rc = osh_beam_runtime_fill_pool_at(rt, seeding, pool, n, (uint64_t) rt->primaries_generated);
+     * workers over disjoint, explicitly-based ranges.  The cursor is advanced
+     * only on success, and _at() rejects a base that would wrap, so the cursor
+     * can never silently overflow into reused indices. */
+    rc = osh_beam_runtime_fill_pool_at(rt, seeding, pool, n, rt->primaries_generated);
     if (rc == OSH_OK) {
-        rt->primaries_generated += n;
+        rt->primaries_generated += (uint64_t) n;
     }
     return rc;
 }

--- a/src/beam/runtime/osh_beam_runtime.c
+++ b/src/beam/runtime/osh_beam_runtime.c
@@ -93,16 +93,28 @@ enum osh_status osh_beam_runtime_fill_pool_at(struct osh_beam_runtime *rt,
     if (n == 0u) {
         return OSH_OK;
     }
-    if (pool->n + n > pool->capacity) {
+    if (pool->n > pool->capacity || n > pool->capacity - pool->n) {
         return OSH_EINVAL;
     }
-    /* The global history index of the last primary in this fill is
-     * global_prim_base + (n - 1).  Reject a base that would wrap uint64_t rather
-     * than silently reuse indices/RNG streams.  (Unreachable in practice — it
-     * needs ~2^64 histories — but the seam is the contract for parallel fills,
-     * so fail loudly instead of corrupting tallies.) */
-    if (global_prim_base > UINT64_MAX - (uint64_t) n) {
-        return OSH_EINVAL;
+    /* The last primary in this fill has prim_idx = global_prim_base + (n - 1)
+     * and hist_index = seeding->hist_base + prim_idx.  Reject any range that
+     * would wrap either value rather than silently reusing indices/RNG streams.
+     * (Unreachable in practice -- it needs ~2^64 histories -- but this is the
+     * contract for parallel fills, so fail loudly instead of corrupting tallies.) */
+    {
+        uint64_t const last_offset = (uint64_t) n - 1u;
+        uint64_t first_hist_index;
+
+        if (global_prim_base > UINT64_MAX - last_offset) {
+            return OSH_EINVAL;
+        }
+        if (seeding->hist_base > UINT64_MAX - global_prim_base) {
+            return OSH_EINVAL;
+        }
+        first_hist_index = seeding->hist_base + global_prim_base;
+        if (first_hist_index > UINT64_MAX - last_offset) {
+            return OSH_EINVAL;
+        }
     }
 
     switch (rt->workspace->beam_mode) {

--- a/src/beam/runtime/osh_beam_runtime.h
+++ b/src/beam/runtime/osh_beam_runtime.h
@@ -37,15 +37,17 @@ extern "C" {
  *   time.  This mode is not yet implemented — fill_pool returns
  *   OSH_ENOTSUP until MCPL support is added.
  *
- * primaries_generated tracks the total number of primary histories emitted
- * across all fill_pool calls on this runtime.  It is used to assign globally
- * unique prim_idx values when the transport loop chunks a large beam into
- * multiple pool fills.
+ * primaries_generated is serial-path bookkeeping: it counts the primaries
+ * emitted through the convenience wrapper osh_beam_runtime_fill_pool() so that
+ * successive chunked fills get contiguous, globally-unique prim_idx values.
+ * The cursor-free osh_beam_runtime_fill_pool_at() neither reads nor writes it —
+ * a parallel driver supplies each worker's global base explicitly instead, so
+ * the shared cursor is never a point of contention.
  */
 struct osh_beam_runtime {
     struct beam_workspace const *workspace; /* cold storage — not owned */
     struct particle primary;                /* resolved species for beam primaries */
-    size_t primaries_generated;             /* total primaries emitted so far */
+    size_t primaries_generated;             /* serial-path cursor; see header doc */
 
     union {
         /**
@@ -122,30 +124,58 @@ void osh_beam_runtime_free(struct osh_beam_runtime **rt);
 /* ---- Primary generation -------------------------------------------------- */
 
 /**
- * @brief Fill @p n new primary histories into the pool.
+ * @brief Fill @p n new primary histories into the pool at an explicit global base.
  *
  * @details
- * Appends @p n entries to @p pool starting at pool->n, then increments
- * pool->n by @p n.  The caller must ensure pool->n + n <= pool->capacity
- * before calling; OSH_EINVAL is returned otherwise.
+ * The cursor-free core of primary generation.  Appends @p n entries to @p pool
+ * starting at pool->n, then increments pool->n by @p n.  The caller must ensure
+ * pool->n + n <= pool->capacity before calling; OSH_EINVAL is returned otherwise.
  *
- * For SPOTS/SOBP mode: samples spot, energy, and phase space for each
- * primary using the beam model in beam/osh_beam_model.c.  Each entry is
- * written directly into the pool SoA arrays, bypassing the intermediate
- * AoS ray_v representation.  gen is set to 0 (beam primary) and prim_idx
- * is assigned from rt->primaries_generated so that indices are unique and
- * contiguous across multiple fill calls on the same runtime.
+ * The global history index of the i-th primary in this fill is
+ * @p global_prim_base + i — supplied by the caller, not read from any internal
+ * cursor.  This is the property that makes primary generation safe to partition
+ * across workers: each worker fills its own slice of the run by passing its own
+ * base (e.g. wctx->hist_lo + primaries_done), and because each primary is seeded
+ * purely from its global index — gen is set to 0 (beam primary), prim_idx to the
+ * global index, a transient BEAM stream samples the source phase space and the
+ * slot's persistent PHYSICS stream (pool->rng[slot]) is initialised — the same
+ * history draws the same numbers no matter which worker, thread, or rank emits
+ * it, or in what order.  Concatenating the primaries of any contiguous partition
+ * of [0, N) reproduces the single-pass [0, N) sequence exactly.
  *
- * Each primary is seeded independently from its global history index
- * (@p seeding->hist_base + prim_idx): a transient BEAM stream samples the
- * source phase space, and the slot's persistent PHYSICS stream
- * (pool->rng[slot]) is initialised for the transport loop.  Seeding by index
- * rather than from a shared stream makes the generated primaries — and the
- * whole run — reproducible and independent of pool capacity, thread, or rank.
+ * @ref osh_beam_runtime::primaries_generated is neither read nor written here;
+ * the caller owns the global index space.
  *
  * For PHSP mode: not yet implemented; returns OSH_ENOTSUP.
  *
- * @param[in,out] rt       Beam runtime (primaries_generated is updated).
+ * @param[in,out] rt               Beam runtime (read-only here; cursor untouched).
+ * @param[in]     seeding          Run-wide RNG seeding context (engine, seed, base).
+ * @param[in,out] pool             Pool to fill; must have capacity >= pool->n + n.
+ * @param[in]     n                Number of primaries to generate.
+ * @param[in]     global_prim_base Global history index of the first primary.
+ *
+ * @returns OSH_OK on success, OSH_E* on failure.
+ */
+enum osh_status osh_beam_runtime_fill_pool_at(struct osh_beam_runtime *rt,
+                                              struct osh_rng_seeding const *seeding,
+                                              struct osh_particle_pool *pool,
+                                              size_t n,
+                                              uint64_t global_prim_base);
+
+/**
+ * @brief Fill @p n new primary histories into the pool (serial convenience).
+ *
+ * @details
+ * Thin wrapper over @ref osh_beam_runtime_fill_pool_at that uses the runtime's
+ * own @ref osh_beam_runtime::primaries_generated cursor as the global base and
+ * advances it by @p n on success.  This is the right call for a single-stream
+ * serial driver that fills one runtime in order; for partitioned/parallel work
+ * call @ref osh_beam_runtime_fill_pool_at with an explicit base instead, so the
+ * shared cursor is never read or mutated concurrently.
+ *
+ * Behaviour is otherwise identical to @ref osh_beam_runtime_fill_pool_at.
+ *
+ * @param[in,out] rt       Beam runtime (primaries_generated is advanced).
  * @param[in]     seeding  Run-wide RNG seeding context (engine, seed, base).
  * @param[in,out] pool     Pool to fill; must have capacity >= pool->n + n.
  * @param[in]     n        Number of primaries to generate.

--- a/src/beam/runtime/osh_beam_runtime.h
+++ b/src/beam/runtime/osh_beam_runtime.h
@@ -47,7 +47,7 @@ extern "C" {
 struct osh_beam_runtime {
     struct beam_workspace const *workspace; /* cold storage — not owned */
     struct particle primary;                /* resolved species for beam primaries */
-    size_t primaries_generated;             /* serial-path cursor; see header doc */
+    uint64_t primaries_generated;           /* serial-path cursor; see header doc */
 
     union {
         /**

--- a/src/random/README.md
+++ b/src/random/README.md
@@ -26,6 +26,26 @@ parallel-ready. Every routine is a pure function of an explicit
   results do not depend on batch size, thread, or rank — the basis for
   reproducible SIMD/multithread/MPI/GPU transport.
 
+## The quick mental model
+
+Parallel workers are assigned **history-index ranges**, not slices of one shared
+random-number sequence.  For example, a run with `nstat = 1000` might give
+worker 0 histories `[0, 250)`, worker 1 histories `[250, 500)`, and so on.  A
+history may consume a few random draws or many random draws during transport,
+but that does not affect any other worker because each primary history is seeded
+from its own global index:
+
+```text
+history_index = rndoffset + hist_lo + worker_local_index
+```
+
+That is why the beam fill path takes the first global history index for the
+current fill explicitly.  The beam runtime should not ask "how many primaries
+have I generated so far?" from a shared counter when workers are filling
+disjoint ranges.  The worker already knows the stable history IDs it owns, and
+those IDs are enough to recreate the same primary and transport RNG streams
+regardless of pool capacity, thread scheduling, or MPI rank.
+
 ## Full documentation
 
 The detailed treatment — engine motivation and references, the distribution

--- a/src/transport/README.md
+++ b/src/transport/README.md
@@ -83,8 +83,11 @@ Why this shape:
 
 Determinism notes for a future threaded implementation:
 
-- RNG streams should be partitioned in a way that stays reproducible across
-  worker scheduling changes.
+- RNG streams are keyed by global history index, not by position in one shared
+  draw sequence.  Workers therefore own disjoint history ranges such as
+  `[0, 250)` and `[250, 500)`, and each primary is seeded from
+  `rndoffset + hist_lo + worker_local_index`.  This lets one history consume any
+  number of random draws without shifting another worker's streams.
 - Chunk ownership should be explicit and stable enough that runs can be debugged.
 - Secondary merges should happen at clear boundaries rather than by fully
   shared push-on-every-step queues.

--- a/src/transport/osh_transport_ion.c
+++ b/src/transport/osh_transport_ion.c
@@ -55,12 +55,14 @@ static enum osh_status validate_transport_modes(struct osh_transport_context con
  * so it can be driven over an explicit history range instead of always the whole
  * run.  The worker context isolates the *transport-local* mutable state — the
  * particle pool and per-step batch scratch — for one slice [hist_lo, hist_hi).
- * That is a necessary building block for parallel execution but not sufficient on
- * its own: @p beam_rt (its primaries_generated cursor), @p score_rt's shared
- * accumulators and @p transport_ctx->profile are still shared, so running slices
- * concurrently would additionally need per-worker or otherwise coordinated beam,
- * scoring and profile state.  Today a single worker covers [0, nstat), so none of
- * that sharing is yet exercised.
+ * Primary generation is already partition-safe: this loop fills the pool through
+ * osh_beam_runtime_fill_pool_at() with an explicit global base derived from the
+ * worker's own range, never the shared beam cursor.  Two pieces of shared state
+ * still stand between this and concurrent execution: @p score_rt's accumulators
+ * (deposits land in the shared master) and @p transport_ctx->profile (its
+ * counters are summed in place).  Both want per-worker copies merged at the end;
+ * see the @c accumulators field on @ref osh_worker_context.  Today a single worker
+ * covers [0, nstat), so none of that sharing is yet exercised.
  *
  *   1. When the pool is empty and primaries remain, fill it from beam_runtime
  *      (up to the worker's pool capacity).
@@ -72,16 +74,14 @@ static enum osh_status validate_transport_modes(struct osh_transport_context con
  *   5. Repeat until every history in the range is done and the pool is empty.
  *
  * Each primary is seeded from its global history index (rndoffset + hist_lo +
- * the worker-local primary index).  For the single worker over [0, nstat) used
- * today (hist_lo == 0) this reproduces the canonical per-history streams.
- * Splitting the run into arbitrary sub-ranges and replaying them in any order
- * reproduces those same streams only once each worker draws primaries from its
- * own beam cursor (or an explicit global base is threaded through
- * osh_beam_runtime_fill_pool()); with the single shared cursor today a non-zero
- * hist_lo would be double-counted, so that per-worker beam-cursor change is
- * deferred follow-up.  Deposits currently land in the shared master accumulators
- * in @p score_rt; per-worker private accumulators (@c wctx->accumulators) will
- * route here once parallel scoring lands.
+ * the worker-local primary index), assembled by passing hist_lo + primaries_done
+ * as the explicit global base to osh_beam_runtime_fill_pool_at().  Splitting the
+ * run into arbitrary disjoint sub-ranges and replaying them in any order
+ * therefore reproduces the canonical per-history streams exactly — the seed is a
+ * pure function of the index, with no shared, mutable beam cursor in the path.
+ * Deposits currently land in the shared master accumulators in @p score_rt;
+ * per-worker private accumulators (@c wctx->accumulators) will route here once
+ * parallel scoring lands.
  */
 static enum osh_status run_history_range(struct osh_worker_context *wctx,
                                          struct osh_transport_context *transport_ctx,
@@ -113,17 +113,23 @@ static enum osh_status run_history_range(struct osh_worker_context *wctx,
     enum osh_status rc = OSH_OK;
 
     /* Per-history seeding context.  Every primary derives independent BEAM and
-     * PHYSICS streams from its global history index (rndoffset + hist_lo +
-     * prim_idx), so a history sees the same random draws on any pool capacity,
-     * thread, or rank.  (Scored output is therefore invariant up to
-     * floating-point summation order in the shared scoring accumulators, not
-     * byte-for-byte.)  Offsetting the base by hist_lo gives this worker a
-     * disjoint, non-overlapping stream range.  Keeping BEAM and PHYSICS on
+     * PHYSICS streams from its global history index, so a history sees the same
+     * random draws on any pool capacity, thread, or rank.  (Scored output is
+     * therefore invariant up to floating-point summation order in the shared
+     * scoring accumulators, not byte-for-byte.)  Keeping BEAM and PHYSICS on
      * separate purposes makes NUCRE/MSCAT/STRAGG comparisons launch the same
-     * primary histories. */
+     * primary histories.
+     *
+     * The global history index is rndoffset + (hist_lo + worker-local index).
+     * We keep hist_base at rndoffset alone and carry the worker's hist_lo in the
+     * explicit global base passed to osh_beam_runtime_fill_pool_at() below, so
+     * the full global index is assembled in exactly one place.  Splitting the
+     * run into disjoint sub-ranges and running them in any order then reproduces
+     * the canonical per-history streams, because each primary's seed depends
+     * only on its index — never on a shared, mutable beam cursor. */
     seeding.type = OSH_RNG_TYPE_PCG32;
     seeding.seed = (uint64_t) params->rndseed;
-    seeding.hist_base = (uint64_t) params->rndoffset + (uint64_t) wctx->hist_lo;
+    seeding.hist_base = (uint64_t) params->rndoffset;
 
     /* Total step budget: nstat × max_steps, capped at SIZE_MAX to avoid overflow. */
     if (nstat > (size_t) -1 / OSH_TRANSPORT_MAX_STEPS_PER_PRIMARY) {
@@ -155,7 +161,12 @@ static enum osh_status run_history_range(struct osh_worker_context *wctx,
             if (prof) {
                 t_phase = osh_monotonic_seconds();
             }
-            rc = osh_beam_runtime_fill_pool(beam_rt, &seeding, pool, n_fill);
+            /* Cursor-free fill: the global index of the first primary in this
+             * chunk is this worker's range base plus the primaries it has
+             * already emitted.  No shared beam cursor is read or mutated, so
+             * disjoint workers can fill concurrently and remain reproducible. */
+            rc = osh_beam_runtime_fill_pool_at(
+                beam_rt, &seeding, pool, n_fill, (uint64_t) wctx->hist_lo + (uint64_t) primaries_done);
             if (prof) {
                 prof->fill_s += osh_monotonic_seconds() - t_phase;
             }

--- a/src/transport/osh_worker_context.h
+++ b/src/transport/osh_worker_context.h
@@ -21,11 +21,13 @@ struct osh_scoring_accumulator;
  * batch scratch — for one slice of the run, so this state stops being a barrier
  * to partitioning work across workers (threads, MPI ranks, or sequential
  * profiling replicas) over disjoint history ranges.  It is one building block,
- * not the whole story: the beam runtime (its primaries_generated cursor), the
- * scoring accumulators in score_rt and transport_ctx->profile are owned
- * elsewhere and remain shared, so concurrent execution will additionally need
- * per-worker or coordinated beam/scoring/profile state (the @ref accumulators
- * field below is where per-worker scoring memory will attach).
+ * not the whole story: the scoring accumulators in score_rt and
+ * transport_ctx->profile are owned elsewhere and remain shared, so concurrent
+ * execution will additionally need per-worker or coordinated scoring/profile
+ * state (the @ref accumulators field below is where per-worker scoring memory
+ * will attach).  Beam primary generation is no longer in that list — a worker
+ * fills its pool through osh_beam_runtime_fill_pool_at() with an explicit global
+ * base from its own range, so the beam runtime is shared read-only.
  *
  * The assigned work is the half-open history range [@ref hist_lo, @ref hist_hi).
  * Per-history RNG seeding is derived from the global history index

--- a/tests/unit/test_osh_beam_runtime_fill.c
+++ b/tests/unit/test_osh_beam_runtime_fill.c
@@ -242,16 +242,29 @@ static void test_overflow_guard(void) {
     seeding_init(&seeding);
     ASSERT_TRUE(osh_particle_pool_init(&pool, POOL_CAP) == OSH_OK);
 
-    /* [base, base + NPRIM) would wrap uint64_t: rejected, pool left untouched —
+    /* [base, base + NPRIM) would wrap prim_idx: rejected, pool left untouched —
      * fail loudly rather than reuse history indices / RNG streams. */
     ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &pool, NPRIM, UINT64_MAX - 3u) == OSH_EINVAL);
     ASSERT_TRUE(pool.n == 0u);
 
-    /* A large but non-wrapping base is accepted and assigns those global indices. */
-    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &pool, NPRIM, UINT64_MAX - 1000u) == OSH_OK);
+    /* Even when prim_idx itself would not wrap, RNDOFFSET + prim_idx must not
+     * wrap the final RNG history key. */
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &pool, NPRIM, UINT64_MAX - 1000u) == OSH_EINVAL);
+    ASSERT_TRUE(pool.n == 0u);
+
+    /* A large but non-wrapping final history-index range is accepted. With
+     * hist_base = 1000 and NPRIM = 10, this lands exactly on UINT64_MAX. */
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &pool, NPRIM, UINT64_MAX - 1009u) == OSH_OK);
     ASSERT_TRUE(pool.n == NPRIM);
-    ASSERT_TRUE(pool.prim_idx[0] == UINT64_MAX - 1000u);
-    ASSERT_TRUE(pool.prim_idx[NPRIM - 1u] == (UINT64_MAX - 1000u) + (NPRIM - 1u));
+    ASSERT_TRUE(pool.prim_idx[0] == UINT64_MAX - 1009u);
+    ASSERT_TRUE(pool.prim_idx[NPRIM - 1u] == UINT64_MAX - 1000u);
+
+    /* Off-by-one boundary: a single primary at UINT64_MAX is valid when
+     * RNDOFFSET is zero, because the last index is base + (n - 1). */
+    seeding.hist_base = 0u;
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &pool, 1u, UINT64_MAX) == OSH_OK);
+    ASSERT_TRUE(pool.n == NPRIM + 1u);
+    ASSERT_TRUE(pool.prim_idx[NPRIM] == UINT64_MAX);
 
     osh_particle_pool_free(&pool);
     osh_beam_runtime_free(&rt);

--- a/tests/unit/test_osh_beam_runtime_fill.c
+++ b/tests/unit/test_osh_beam_runtime_fill.c
@@ -19,6 +19,7 @@
  */
 
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #include "apps/osh/osh_app_osh.h"
@@ -229,11 +230,40 @@ static void test_at_does_not_touch_rt(void) {
     ASSERT_TRUE(osh_beam_workspace_free(wb) == OSH_OK);
 }
 
+/* ---- a base whose range would wrap uint64_t is rejected ------------------ */
+
+static void test_overflow_guard(void) {
+    struct osh_beam_workspace *wb = NULL;
+    struct osh_beam_runtime *rt = NULL;
+    struct osh_particle_pool pool;
+    struct osh_rng_seeding seeding;
+
+    make_runtime(&wb, &rt);
+    seeding_init(&seeding);
+    ASSERT_TRUE(osh_particle_pool_init(&pool, POOL_CAP) == OSH_OK);
+
+    /* [base, base + NPRIM) would wrap uint64_t: rejected, pool left untouched —
+     * fail loudly rather than reuse history indices / RNG streams. */
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &pool, NPRIM, UINT64_MAX - 3u) == OSH_EINVAL);
+    ASSERT_TRUE(pool.n == 0u);
+
+    /* A large but non-wrapping base is accepted and assigns those global indices. */
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &pool, NPRIM, UINT64_MAX - 1000u) == OSH_OK);
+    ASSERT_TRUE(pool.n == NPRIM);
+    ASSERT_TRUE(pool.prim_idx[0] == UINT64_MAX - 1000u);
+    ASSERT_TRUE(pool.prim_idx[NPRIM - 1u] == (UINT64_MAX - 1000u) + (NPRIM - 1u));
+
+    osh_particle_pool_free(&pool);
+    osh_beam_runtime_free(&rt);
+    ASSERT_TRUE(osh_beam_workspace_free(wb) == OSH_OK);
+}
+
 int main(void) {
     test_split_matches_single();
     test_order_independent();
     test_wrapper_advances_cursor();
     test_at_does_not_touch_rt();
+    test_overflow_guard();
     printf("All osh_beam_runtime_fill tests passed.\n");
     return 0;
 }

--- a/tests/unit/test_osh_beam_runtime_fill.c
+++ b/tests/unit/test_osh_beam_runtime_fill.c
@@ -1,0 +1,239 @@
+/*
+ * Unit tests for osh_beam_runtime_fill_pool_at() — the cursor-free primary
+ * generation that makes a run's history range partitionable across workers.
+ *
+ * The contract under test: a primary's phase space and both of its RNG streams
+ * (the transient BEAM stream and the persistent PHYSICS stream carried on the
+ * pool slot) are a pure function of its GLOBAL history index, supplied by the
+ * caller as global_prim_base + i.  Therefore filling [0, n) in one call must be
+ * byte-for-byte identical to filling [0, k) and then [k, n) in two calls — and
+ * identical regardless of the order the two slices are produced.  That identity
+ * is exactly what lets future workers own disjoint slices of the run.
+ *
+ * Coverage:
+ *   test_split_matches_single   — [0,k)+[k,n) reproduces [0,n) exactly
+ *   test_order_independent      — producing the high slice first changes nothing
+ *   test_wrapper_advances_cursor— the serial wrapper bases off / advances the
+ *                                 cursor; _at() leaves it untouched
+ *   test_at_does_not_touch_rt   — _at() never mutates primaries_generated
+ */
+
+#include <stddef.h>
+#include <stdio.h>
+
+#include "apps/osh/osh_app_osh.h"
+#include "beam/runtime/osh_beam_runtime.h"
+#include "common/osh_particle_pool.h"
+#include "openshieldhit/status.h"
+#include "random/osh_rng.h"
+#include "test_assert.h"
+
+#define POOL_CAP 16u
+#define NPRIM 10u
+#define SPLIT 4u /* fill [0,SPLIT) then [SPLIT,NPRIM) */
+
+static int _tmp_counter = 0;
+
+static void write_temp_beam(char *path, size_t path_cap) {
+    FILE *fp;
+    char const *content = "PRIMARY proton\n"
+                          "TMAX0 150.0 1.0\n"
+                          "BEAMPOS 0.5 -0.5 -20.0\n"
+                          "BEAMSIGMA 0.3 0.4\n"
+                          "BEAMDIV 2.0 3.0 0.0\n";
+
+    snprintf(path, path_cap, "osh_test_beamfill_%d.tmp", _tmp_counter++);
+    fp = fopen(path, "w");
+    ASSERT_TRUE(fp != NULL);
+    ASSERT_TRUE(fputs(content, fp) >= 0);
+    ASSERT_TRUE(fclose(fp) == 0);
+}
+
+/* Build a compiled beam runtime from a freshly-written beam file. The workspace
+ * is returned too so the caller can free it after the runtime. */
+static void make_runtime(struct osh_beam_workspace **wb_out, struct osh_beam_runtime **rt_out) {
+    char beam_path[512];
+    int rc;
+
+    write_temp_beam(beam_path, sizeof(beam_path));
+    rc = (int) osh_beam_setup_from_path(beam_path, NULL, wb_out);
+    ASSERT_TRUE(rc == OSH_OK);
+    ASSERT_TRUE(*wb_out != NULL);
+    ASSERT_TRUE(osh_beam_compile(*wb_out, rt_out) == OSH_OK);
+    ASSERT_TRUE(remove(beam_path) == 0);
+}
+
+static void seeding_init(struct osh_rng_seeding *s) {
+    s->type = OSH_RNG_TYPE_PCG32;
+    s->seed = 20260626u;  /* arbitrary fixed run seed */
+    s->hist_base = 1000u; /* arbitrary non-zero RNDOFFSET to catch base bugs */
+}
+
+/* Two carried PHYSICS streams are equal iff their engine state matches.  We
+ * compare the live engine fields rather than memcmp the whole struct: seeding
+ * leaves the gauss cache and the unused union tail uninitialised, so a raw byte
+ * compare would test garbage.  The run seeds PCG32, so state+inc is the stream. */
+static int rng_state_equal(struct osh_rng const *a, struct osh_rng const *b) {
+    return a->type == b->type && a->u.pcg32.state == b->u.pcg32.state && a->u.pcg32.inc == b->u.pcg32.inc;
+}
+
+/* Compare every per-primary field the transport loop relies on, slot by slot. */
+static void assert_slots_identical(struct osh_particle_pool const *a, struct osh_particle_pool const *b, size_t n) {
+    size_t i;
+    ASSERT_TRUE(a->n == b->n);
+    ASSERT_TRUE(a->n >= n);
+    for (i = 0; i < n; ++i) {
+        ASSERT_TRUE(a->prim_idx[i] == b->prim_idx[i]);
+        ASSERT_TRUE(a->gen[i] == b->gen[i]);
+        ASSERT_TRUE(a->x[i] == b->x[i]);
+        ASSERT_TRUE(a->y[i] == b->y[i]);
+        ASSERT_TRUE(a->z[i] == b->z[i]);
+        ASSERT_TRUE(a->ux[i] == b->ux[i]);
+        ASSERT_TRUE(a->uy[i] == b->uy[i]);
+        ASSERT_TRUE(a->uz[i] == b->uz[i]);
+        ASSERT_TRUE(a->e[i] == b->e[i]);
+        ASSERT_TRUE(a->wt[i] == b->wt[i]);
+        /* Same global history index => same persistent PHYSICS stream. */
+        ASSERT_TRUE(rng_state_equal(&a->rng[i], &b->rng[i]));
+    }
+}
+
+/* ---- [0,k)+[k,n) reproduces [0,n) exactly -------------------------------- */
+
+static void test_split_matches_single(void) {
+    struct osh_beam_workspace *wb = NULL;
+    struct osh_beam_runtime *rt = NULL;
+    struct osh_particle_pool whole;
+    struct osh_particle_pool split;
+    struct osh_rng_seeding seeding;
+
+    make_runtime(&wb, &rt);
+    seeding_init(&seeding);
+    ASSERT_TRUE(osh_particle_pool_init(&whole, POOL_CAP) == OSH_OK);
+    ASSERT_TRUE(osh_particle_pool_init(&split, POOL_CAP) == OSH_OK);
+
+    /* One shot over the whole range. */
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &whole, NPRIM, 0u) == OSH_OK);
+
+    /* Two contiguous slices, low then high; bases carry the global index. */
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &split, SPLIT, 0u) == OSH_OK);
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &split, NPRIM - SPLIT, SPLIT) == OSH_OK);
+
+    ASSERT_TRUE(whole.n == NPRIM);
+    ASSERT_TRUE(split.n == NPRIM);
+    assert_slots_identical(&whole, &split, NPRIM);
+
+    osh_particle_pool_free(&whole);
+    osh_particle_pool_free(&split);
+    osh_beam_runtime_free(&rt);
+    ASSERT_TRUE(osh_beam_workspace_free(wb) == OSH_OK);
+}
+
+/* ---- producing the high slice first changes nothing ---------------------- */
+
+static void test_order_independent(void) {
+    struct osh_beam_workspace *wb = NULL;
+    struct osh_beam_runtime *rt = NULL;
+    struct osh_particle_pool lo_hi; /* fill [0,SPLIT) then [SPLIT,NPRIM) */
+    struct osh_particle_pool hi_only;
+    struct osh_rng_seeding seeding;
+    size_t i;
+
+    make_runtime(&wb, &rt);
+    seeding_init(&seeding);
+    ASSERT_TRUE(osh_particle_pool_init(&lo_hi, POOL_CAP) == OSH_OK);
+    ASSERT_TRUE(osh_particle_pool_init(&hi_only, POOL_CAP) == OSH_OK);
+
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &lo_hi, SPLIT, 0u) == OSH_OK);
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &lo_hi, NPRIM - SPLIT, SPLIT) == OSH_OK);
+
+    /* Produce only the high slice, into a fresh pool starting at slot 0. The
+     * high-slice histories must match regardless of whether the low slice was
+     * ever generated or in what order — index is the only thing that matters. */
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &hi_only, NPRIM - SPLIT, SPLIT) == OSH_OK);
+
+    ASSERT_TRUE(hi_only.n == NPRIM - SPLIT);
+    for (i = 0; i < NPRIM - SPLIT; ++i) {
+        ASSERT_TRUE(lo_hi.prim_idx[SPLIT + i] == hi_only.prim_idx[i]);
+        ASSERT_TRUE(lo_hi.x[SPLIT + i] == hi_only.x[i]);
+        ASSERT_TRUE(lo_hi.e[SPLIT + i] == hi_only.e[i]);
+        ASSERT_TRUE(rng_state_equal(&lo_hi.rng[SPLIT + i], &hi_only.rng[i]));
+    }
+
+    osh_particle_pool_free(&lo_hi);
+    osh_particle_pool_free(&hi_only);
+    osh_beam_runtime_free(&rt);
+    ASSERT_TRUE(osh_beam_workspace_free(wb) == OSH_OK);
+}
+
+/* ---- serial wrapper bases off and advances the cursor; _at() does not ----- */
+
+static void test_wrapper_advances_cursor(void) {
+    struct osh_beam_workspace *wb = NULL;
+    struct osh_beam_runtime *rt = NULL;
+    struct osh_particle_pool via_wrapper;
+    struct osh_particle_pool via_at;
+    struct osh_rng_seeding seeding;
+
+    make_runtime(&wb, &rt);
+    seeding_init(&seeding);
+    ASSERT_TRUE(osh_particle_pool_init(&via_wrapper, POOL_CAP) == OSH_OK);
+    ASSERT_TRUE(osh_particle_pool_init(&via_at, POOL_CAP) == OSH_OK);
+
+    /* Two successive wrapper calls chain through the internal cursor: the second
+     * fill continues where the first left off. */
+    ASSERT_TRUE(rt->primaries_generated == 0u);
+    ASSERT_TRUE(osh_beam_runtime_fill_pool(rt, &seeding, &via_wrapper, SPLIT) == OSH_OK);
+    ASSERT_TRUE(rt->primaries_generated == SPLIT);
+    ASSERT_TRUE(osh_beam_runtime_fill_pool(rt, &seeding, &via_wrapper, NPRIM - SPLIT) == OSH_OK);
+    ASSERT_TRUE(rt->primaries_generated == NPRIM);
+
+    /* The same sequence built with explicit bases must be byte-identical, and
+     * must NOT have moved the cursor. */
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &via_at, SPLIT, 0u) == OSH_OK);
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &via_at, NPRIM - SPLIT, SPLIT) == OSH_OK);
+    ASSERT_TRUE(rt->primaries_generated == NPRIM); /* unchanged by _at() */
+
+    assert_slots_identical(&via_wrapper, &via_at, NPRIM);
+
+    osh_particle_pool_free(&via_wrapper);
+    osh_particle_pool_free(&via_at);
+    osh_beam_runtime_free(&rt);
+    ASSERT_TRUE(osh_beam_workspace_free(wb) == OSH_OK);
+}
+
+/* ---- _at() never mutates the cursor, even across many calls -------------- */
+
+static void test_at_does_not_touch_rt(void) {
+    struct osh_beam_workspace *wb = NULL;
+    struct osh_beam_runtime *rt = NULL;
+    struct osh_particle_pool pool;
+    struct osh_rng_seeding seeding;
+
+    make_runtime(&wb, &rt);
+    seeding_init(&seeding);
+    ASSERT_TRUE(osh_particle_pool_init(&pool, POOL_CAP) == OSH_OK);
+
+    ASSERT_TRUE(rt->primaries_generated == 0u);
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &pool, NPRIM, 500u) == OSH_OK);
+    ASSERT_TRUE(rt->primaries_generated == 0u); /* explicit base, cursor untouched */
+
+    /* n == 0 is a well-defined no-op; NULL operands are rejected. */
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, &pool, 0u, 0u) == OSH_OK);
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(NULL, &seeding, &pool, 1u, 0u) == OSH_EINVAL);
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, NULL, &pool, 1u, 0u) == OSH_EINVAL);
+    ASSERT_TRUE(osh_beam_runtime_fill_pool_at(rt, &seeding, NULL, 1u, 0u) == OSH_EINVAL);
+
+    osh_particle_pool_free(&pool);
+    osh_beam_runtime_free(&rt);
+    ASSERT_TRUE(osh_beam_workspace_free(wb) == OSH_OK);
+}
+
+int main(void) {
+    test_split_matches_single();
+    test_order_independent();
+    test_wrapper_advances_cursor();
+    test_at_does_not_touch_rt();
+    printf("All osh_beam_runtime_fill tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Makes beam primary generation a **pure function of the global history index supplied by the caller**, instead of reading and mutating the shared `osh_beam_runtime::primaries_generated` cursor. This is the first of the two correctness blockers (#165, #166) that stand between the parallelism groundwork merged in #162 and an actual threaded driver.

Behaviour-preserving for the serial path. Closes #165.

---

## Why this is needed — the pedagogy

### The one-paragraph version

A Monte Carlo run is *embarrassingly parallel*: each primary history is an independent random walk, and #150 already made every history's random draws a **pure function of its global index** — history *N* sees the same numbers no matter which thread, rank, or pool runs it. So to parallelise, you just hand worker A histories `[0, k)` and worker B histories `[k, n)` and let them run. **Except for one leak:** the place that *creates* primaries didn't take the history index as input — it read it from a counter it bumped on every call. Two workers sharing that counter would step on each other. This PR plugs that leak by passing the index in explicitly.

### What was actually wrong

When the wavefront loop needs more primaries, it calls into the beam runtime to fill the pool. The old code derived each primary's global history index from an **internal, mutable counter**:

```c
/* src/beam/runtime/osh_beam_runtime.c — before */
for (i = 0u; i < n; ++i) {
    uint64_t const prim_idx   = rt->primaries_generated + i;   /* <-- shared cursor */
    uint64_t const hist_index = seeding->hist_base + prim_idx;
    ...
    osh_rng_seed_history(&pool->rng[slot], ..., hist_index, OSH_RNG_PURPOSE_PHYSICS);
}
rt->primaries_generated += n;   /* <-- mutated, shared across all callers */
```

The per-history seed is therefore `hist_base + primaries_generated + i`. With **one** worker over `[0, nstat)` this is exactly right. But the moment two workers share one `beam_rt`:

- both set `seeding.hist_base = rndoffset + hist_lo` for their own slice, **and** `prim_idx` adds the **shared** `primaries_generated` that counts primaries across *both* workers — so `hist_lo` gets double-counted and the global index space collides and gaps;
- `rt->primaries_generated += n` is itself a write race.

Net effect: the per-history determinism that the entire parallel design rests on (the `run_history_range()` docstring: *"a history sees the same random draws on any pool capacity, thread, or rank"*) silently breaks across workers. The result would be neither correct nor reproducible — and worse, it would still *run*, just produce subtly wrong tallies. This was flagged in the Codex review on #162 (the docstring there was corrected to stop claiming arbitrary sliced ranges were safe; this PR makes them actually safe).

### The fix: pass the index in, don't look it up

The history index is *information the caller already has* — a worker knows its range base (`hist_lo`) and how many primaries it has emitted so far. So we let the caller supply it:

```c
/* New: the i-th primary's global index is global_prim_base + i. No cursor. */
enum osh_status osh_beam_runtime_fill_pool_at(struct osh_beam_runtime *rt,
                                              struct osh_rng_seeding const *seeding,
                                              struct osh_particle_pool *pool,
                                              size_t n,
                                              uint64_t global_prim_base);

/* Retained: thin serial wrapper that bases off / advances the cursor. */
enum osh_status osh_beam_runtime_fill_pool(struct osh_beam_runtime *rt,
                                           struct osh_rng_seeding const *seeding,
                                           struct osh_particle_pool *pool,
                                           size_t n);
```

`_at()` neither reads nor writes `rt->primaries_generated`, so it is safe for many workers to call concurrently over disjoint, explicitly-based ranges. The old `fill_pool()` stays as a one-line convenience wrapper (`base = cursor; fill; cursor += n`) so every existing serial call site is untouched.

In the wavefront loop, the global index is now assembled in **exactly one place**. Per the design choice discussed in #165, `seeding.hist_base` keeps just `rndoffset` and the worker's `hist_lo` rides in the explicit base:

```c
/* src/transport/osh_transport_ion.c — after */
seeding.hist_base = (uint64_t) params->rndoffset;            /* no hist_lo here */
...
rc = osh_beam_runtime_fill_pool_at(beam_rt, &seeding, pool, n_fill,
        (uint64_t) wctx->hist_lo + (uint64_t) primaries_done);  /* full global index */
```

For the single worker we ship today (`hist_lo == 0`), `hist_base + (0 + primaries_done + i)` equals the old `hist_base(+0) + (primaries_generated + i)` — **bit-for-bit identical output**, which the reference suite confirms. The difference only matters once a second worker exists, and then it is correct by construction.

### Why this is the right shape for what comes next

This is the §5a item from the #162 vision comment. With it in place, the per-worker beam fill in the future threaded driver is simply:

```c
osh_worker_context_init(&wctx, lo, hi, ...);
/* inside run_history_range: */
osh_beam_runtime_fill_pool_at(beam_rt, &seeding, pool, n, wctx.hist_lo + done);
```

and the same `_at()` call serves the MPI path (each rank passes its rank-offset base) and a sequential profiling replica (run `[0,N/2)` then `[N/2,N)` and check they fold to the whole). The beam runtime drops off the list of shared-mutable state entirely — it is now shared **read-only**.

After this, the remaining couplings before threads can be switched on are **#166** (deposit target → per-worker accumulators) and **#167** (per-worker profile counters), gated by **#168** (reproducibility CI).

---

## Changes

| File | Change |
|------|--------|
| `src/beam/runtime/osh_beam_runtime.{c,h}` | Add `osh_beam_runtime_fill_pool_at()`; make `fill_pool()` a thin cursor-owning wrapper; `fill_from_spots`/`fill_from_phsp` take the explicit base; document `primaries_generated` as serial-path bookkeeping not consulted by `_at()`. |
| `src/transport/osh_transport_ion.c` | `run_history_range()` fills via `_at()` with `hist_lo + primaries_done`; `hist_base` reduced to `rndoffset`; docstrings updated. |
| `src/transport/osh_worker_context.h` | Drop the beam cursor from the list of remaining parallel couplings. |
| `src/beam/CMakeLists.txt` | Declare the previously-missing `osh_random` dependency of `osh_beam` (it samples via `osh_rng_*` and exposes `struct osh_rng` in its public API; it only linked before because another target pulled `osh_random` in first — surfaced by the new standalone test). |
| `tests/unit/test_osh_beam_runtime_fill.c` | New unit test. |

## Tests

New `test_osh_beam_runtime_fill` covers the contract directly:

- **`split_matches_single`** — filling `[0,k)` then `[k,n)` reproduces a single `[0,n)` fill exactly: `prim_idx`, full phase space, and the carried PHYSICS RNG stream, slot by slot.
- **`order_independent`** — producing the high slice into a fresh pool (without the low slice, in a different order) yields identical histories; the index is the only thing that matters.
- **`wrapper_advances_cursor`** — the serial wrapper chains through `primaries_generated` and lands byte-identical to two explicit-base `_at()` calls, which leave the cursor untouched.
- **`at_does_not_touch_rt`** — `_at()` never mutates the cursor; `n == 0` is a no-op; NULL operands are rejected.

(RNG streams are compared by engine state, not raw `memcmp`, because seeding deliberately leaves the gauss cache / unused union tail uninitialised.)

Full debug build is green. Unit + case suites pass, **including the `bench::profile_bit_identity` and `bench::capacity_invariance` reproducibility guards** and every serial reference case (`00_minimal`, `06_minimal_nucre`, `08_minimal_cyl`, `01_simple_detect`, `09_diff_scoring`). The only failing tests are the pre-existing DICOM-fixture (`test_osh_dicom`, `test_osh_geometry_dcm`, `05_dicom_simple`) and tagless version-string tests, all untouched by and unrelated to this change.

Part of the parallelism roadmap (#161).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkQBjCbD2m7j9DHQqFfAsF

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkQBjCbD2m7j9DHQqFfAsF)_