### PR TITLE
scoring: deposit-target redirection via explicit acc_set in score_step (#166)

### DIFF
--- a/src/scoring/README.md
+++ b/src/scoring/README.md
@@ -27,7 +27,11 @@ layer parses input and hands the save backends fully-resolved paths.
   arrays live in a `struct osh_scoring_accumulator` (`page->acc`), distinct
   from the page *descriptor* (geometry indices, strides, differential-axis
   config). That storage is the unit a future parallel worker owns privately and
-  folds back with `osh_scoring_accumulator_merge()`.
+  folds back with `osh_scoring_accumulator_merge()`. `osh_scoring_score_step()`
+  takes the deposit target as an explicit `acc_set` parameter (read-only `rt`
+  for layout, mutable `acc_set` for storage): the serial driver passes the
+  master view (`osh_scoring_runtime_master_accumulators()`, a per-page alias
+  array built once at compile time), while a worker passes its own private set.
 - **One deposit seam.** Every tally funnels through `osh_score_deposit()` —
   today a plain `+=`, tomorrow the single place an atomic / private / locked
   write policy plugs in.

--- a/src/scoring/runtime/osh_scoring_compile.c
+++ b/src/scoring/runtime/osh_scoring_compile.c
@@ -592,6 +592,9 @@ void osh_scoring_runtime_free(struct osh_scoring_runtime *rt) {
     }
     free(rt->outputs);
     free(rt->crossing_buf);
+    /* master_acc only shallow-aliases the per-page accumulators (freed above);
+     * release the view array itself, not the arrays it points into. */
+    free(rt->master_acc);
 
     memset(rt, 0, sizeof(*rt));
 }
@@ -1091,6 +1094,21 @@ enum osh_status osh_scoring_compile(struct osh_scoring_workspace const *ws,
                 double r1 = r0 + dr;
                 g->cyl_vol_inv[ir] = 1.0 / (OSH_M_PI * (r1 * r1 - r0 * r0) * dz);
             }
+        }
+    }
+
+    /* Build the master accumulator view: one entry per page, shallow-aliasing
+     * each page's accumulator storage.  The serial driver hands this to
+     * osh_scoring_score_step() so the deposit path has the same shape as a
+     * parallel worker's private set, with no per-step allocation. */
+    if (rt->npages > 0u) {
+        rt->master_acc = (struct osh_scoring_accumulator *) calloc(rt->npages, sizeof(*rt->master_acc));
+        if (!rt->master_acc) {
+            osh_scoring_runtime_free(rt);
+            return OSH_ENOMEM;
+        }
+        for (i = 0; i < rt->npages; ++i) {
+            rt->master_acc[i] = rt->pages[i].acc;
         }
     }
 

--- a/src/scoring/runtime/osh_scoring_runtime.h
+++ b/src/scoring/runtime/osh_scoring_runtime.h
@@ -42,7 +42,27 @@ struct osh_scoring_runtime {
     struct osh_voxel_crossing *crossing_buf;       /* reusable per-step scratch buffer */
     size_t crossing_cap;                           /* allocated length of crossing_buf */
     struct osh_material_runtime const *mat_tables; /* SP tables; NULL until wired by simulation */
+    /* Master accumulator view: an npages-long array whose element i shallow-aliases
+     * pages[i].acc (same data pointers).  Built once by osh_scoring_compile() so the
+     * single-worker serial driver can hand osh_scoring_score_step() a deposit target
+     * that is identical in shape to a parallel worker's private set, with no per-step
+     * allocation.  NULL when npages == 0.  Owns only the array; the arrays it points
+     * into are owned by the pages. */
+    struct osh_scoring_accumulator *master_acc;
 };
+
+/**
+ * @brief Master accumulator-set view (length npages) aliasing each page's storage.
+ *
+ * @details
+ * The serial single-worker driver passes this to @ref osh_scoring_score_step so its
+ * deposits land straight in the shared master pages, while a parallel worker passes
+ * its own private set instead.  Built once by @ref osh_scoring_compile; never
+ * allocated on the hot path.  Returns NULL when there are no pages.
+ */
+static inline struct osh_scoring_accumulator *osh_scoring_runtime_master_accumulators(struct osh_scoring_runtime *rt) {
+    return rt ? rt->master_acc : NULL;
+}
 
 #ifdef __cplusplus
 }

--- a/src/scoring/runtime/osh_scoring_step.c
+++ b/src/scoring/runtime/osh_scoring_step.c
@@ -19,49 +19,56 @@ static enum osh_status mesh_geometry_to_grid(struct osh_scoring_geometry_runtime
                                              double *voxel_volume_inv_out);
 static enum osh_status cyl_geometry_to_grid(struct osh_scoring_geometry_runtime const *geo,
                                             struct osh_raytrace_grid *grid);
-static enum osh_status score_group_energy(struct osh_scoring_runtime *rt,
+static enum osh_status score_group_energy(struct osh_scoring_runtime const *rt,
+                                          struct osh_scoring_accumulator *acc_set,
                                           struct osh_scoring_geometry_score_group const *group,
                                           struct osh_voxel_crossing const *crossings,
                                           size_t ncross,
                                           struct particle const *part,
                                           struct step const *st,
                                           double score_len);
-static enum osh_status score_group_fluence(struct osh_scoring_runtime *rt,
+static enum osh_status score_group_fluence(struct osh_scoring_runtime const *rt,
+                                           struct osh_scoring_accumulator *acc_set,
                                            struct osh_scoring_geometry_score_group const *group,
                                            struct osh_voxel_crossing const *crossings,
                                            size_t ncross,
                                            struct particle const *part,
                                            struct step const *st,
                                            double score_len);
-static enum osh_status score_group_dose(struct osh_scoring_runtime *rt,
+static enum osh_status score_group_dose(struct osh_scoring_runtime const *rt,
+                                        struct osh_scoring_accumulator *acc_set,
                                         struct osh_scoring_geometry_score_group const *group,
                                         struct osh_voxel_crossing const *crossings,
                                         size_t ncross,
                                         struct particle const *part,
                                         struct step const *st,
                                         double score_len);
-static enum osh_status score_group_dlet(struct osh_scoring_runtime *rt,
+static enum osh_status score_group_dlet(struct osh_scoring_runtime const *rt,
+                                        struct osh_scoring_accumulator *acc_set,
                                         struct osh_scoring_geometry_score_group const *group,
                                         struct osh_voxel_crossing const *crossings,
                                         size_t ncross,
                                         struct particle const *part,
                                         struct step const *st,
                                         double score_len);
-static enum osh_status score_group_tlet(struct osh_scoring_runtime *rt,
+static enum osh_status score_group_tlet(struct osh_scoring_runtime const *rt,
+                                        struct osh_scoring_accumulator *acc_set,
                                         struct osh_scoring_geometry_score_group const *group,
                                         struct osh_voxel_crossing const *crossings,
                                         size_t ncross,
                                         struct particle const *part,
                                         struct step const *st,
                                         double score_len);
-static enum osh_status score_group_dqeff(struct osh_scoring_runtime *rt,
+static enum osh_status score_group_dqeff(struct osh_scoring_runtime const *rt,
+                                         struct osh_scoring_accumulator *acc_set,
                                          struct osh_scoring_geometry_score_group const *group,
                                          struct osh_voxel_crossing const *crossings,
                                          size_t ncross,
                                          struct particle const *part,
                                          struct step const *st,
                                          double score_len);
-static enum osh_status score_group_tqeff(struct osh_scoring_runtime *rt,
+static enum osh_status score_group_tqeff(struct osh_scoring_runtime const *rt,
+                                         struct osh_scoring_accumulator *acc_set,
                                          struct osh_scoring_geometry_score_group const *group,
                                          struct osh_voxel_crossing const *crossings,
                                          size_t ncross,
@@ -69,8 +76,10 @@ static enum osh_status score_group_tqeff(struct osh_scoring_runtime *rt,
                                          struct step const *st,
                                          double score_len);
 
-enum osh_status
-osh_scoring_score_step(struct osh_scoring_runtime *rt, struct particle const *part, struct step const *st) {
+enum osh_status osh_scoring_score_step(struct osh_scoring_runtime const *rt,
+                                       struct osh_scoring_accumulator *acc_set,
+                                       struct particle const *part,
+                                       struct step const *st) {
     size_t i;
     size_t j;
     size_t cap;
@@ -84,6 +93,9 @@ osh_scoring_score_step(struct osh_scoring_runtime *rt, struct particle const *pa
     int is_cyl;
 
     if (!rt || !part || !st) {
+        return OSH_EINVAL;
+    }
+    if (rt->npages > 0u && !acc_set) {
         return OSH_EINVAL;
     }
     if (!(st->ds > 0.0)) {
@@ -169,26 +181,26 @@ osh_scoring_score_step(struct osh_scoring_runtime *rt, struct particle const *pa
         for (g = 0; g < geo->ngroups; ++g) {
             switch (geo->groups[g].score_kind) {
             case OSH_SCORING_SCORE_ENERGY:
-                rc = score_group_energy(rt, &geo->groups[g], crossings, ncross, part, st, score_len);
+                rc = score_group_energy(rt, acc_set, &geo->groups[g], crossings, ncross, part, st, score_len);
                 break;
             case OSH_SCORING_SCORE_FLUENCE:
-                rc = score_group_fluence(rt, &geo->groups[g], crossings, ncross, part, st, score_len);
+                rc = score_group_fluence(rt, acc_set, &geo->groups[g], crossings, ncross, part, st, score_len);
                 break;
             case OSH_SCORING_SCORE_DOSE:
             case OSH_SCORING_SCORE_DOSEGY:
-                rc = score_group_dose(rt, &geo->groups[g], crossings, ncross, part, st, score_len);
+                rc = score_group_dose(rt, acc_set, &geo->groups[g], crossings, ncross, part, st, score_len);
                 break;
             case OSH_SCORING_SCORE_DLET:
-                rc = score_group_dlet(rt, &geo->groups[g], crossings, ncross, part, st, score_len);
+                rc = score_group_dlet(rt, acc_set, &geo->groups[g], crossings, ncross, part, st, score_len);
                 break;
             case OSH_SCORING_SCORE_TLET:
-                rc = score_group_tlet(rt, &geo->groups[g], crossings, ncross, part, st, score_len);
+                rc = score_group_tlet(rt, acc_set, &geo->groups[g], crossings, ncross, part, st, score_len);
                 break;
             case OSH_SCORING_SCORE_DQEFF:
-                rc = score_group_dqeff(rt, &geo->groups[g], crossings, ncross, part, st, score_len);
+                rc = score_group_dqeff(rt, acc_set, &geo->groups[g], crossings, ncross, part, st, score_len);
                 break;
             case OSH_SCORING_SCORE_TQEFF:
-                rc = score_group_tqeff(rt, &geo->groups[g], crossings, ncross, part, st, score_len);
+                rc = score_group_tqeff(rt, acc_set, &geo->groups[g], crossings, ncross, part, st, score_len);
                 break;
             default:
                 rc = OSH_ENOTSUP;
@@ -658,7 +670,8 @@ static double diff2_step_val(struct osh_scoring_page_runtime const *page,
  *
  * Distributes st->de proportionally to path length in each crossed voxel.
  */
-static enum osh_status score_group_energy(struct osh_scoring_runtime *rt,
+static enum osh_status score_group_energy(struct osh_scoring_runtime const *rt,
+                                          struct osh_scoring_accumulator *acc_set,
                                           struct osh_scoring_geometry_score_group const *group,
                                           struct osh_voxel_crossing const *crossings,
                                           size_t ncross,
@@ -672,10 +685,12 @@ static enum osh_status score_group_energy(struct osh_scoring_runtime *rt,
     int dv_ok;
     double dv;
     double frac;
-    struct osh_scoring_page_runtime *page;
+    struct osh_scoring_page_runtime const *page;
+    struct osh_scoring_accumulator *acc;
 
     for (i = 0; i < group->npages; ++i) {
         page = &rt->pages[group->first_page + i];
+        acc = &acc_set[group->first_page + i];
         if (!osh_scoring_page_passes_filters(page, part, st)) {
             continue;
         }
@@ -712,9 +727,8 @@ static enum osh_status score_group_energy(struct osh_scoring_runtime *rt,
             /* Flat index: spatial_idx + db * diff_stride + db2 * diff2_stride.
              * When differential axes are inactive the extra terms evaluate to 0. */
             frac = crossings[j].path_len / score_len;
-            osh_score_deposit(page->acc.data,
-                              crossings[j].idx + (db * page->diff_stride) + (db2 * page->diff2_stride),
-                              st->de * frac);
+            osh_score_deposit(
+                acc->data, crossings[j].idx + (db * page->diff_stride) + (db2 * page->diff2_stride), st->de * frac);
         }
     }
     return OSH_OK;
@@ -726,7 +740,8 @@ static enum osh_status score_group_energy(struct osh_scoring_runtime *rt,
  * Scores track_length * vol_inv per voxel crossing.  vol_inv is pre-filled into
  * each crossing by the caller (uniform for Mesh; per-R-bin LUT for Cyl).
  */
-static enum osh_status score_group_fluence(struct osh_scoring_runtime *rt,
+static enum osh_status score_group_fluence(struct osh_scoring_runtime const *rt,
+                                           struct osh_scoring_accumulator *acc_set,
                                            struct osh_scoring_geometry_score_group const *group,
                                            struct osh_voxel_crossing const *crossings,
                                            size_t ncross,
@@ -739,11 +754,13 @@ static enum osh_status score_group_fluence(struct osh_scoring_runtime *rt,
     size_t db2; /* diff2 bin index for current page (0 when no second diff axis) */
     int dv_ok;  /* flag: differential axis value is physically valid for this step */
     double dv;  /* value on the diff axis (energy, LET, or Qeff at step midpoint) */
-    struct osh_scoring_page_runtime *page;
+    struct osh_scoring_page_runtime const *page;
+    struct osh_scoring_accumulator *acc;
     (void) score_len; /* unused for non-differential fluence; kept for diff LET/QEFF */
 
     for (i = 0; i < group->npages; ++i) {
         page = &rt->pages[group->first_page + i];
+        acc = &acc_set[group->first_page + i];
         if (!osh_scoring_page_passes_filters(page, part, st)) {
             continue;
         }
@@ -779,7 +796,7 @@ static enum osh_status score_group_fluence(struct osh_scoring_runtime *rt,
             }
             /* Flat index: spatial_idx + db * diff_stride + db2 * diff2_stride.
              * When differential axes are inactive the extra terms evaluate to 0. */
-            osh_score_deposit(page->acc.data,
+            osh_score_deposit(acc->data,
                               crossings[j].idx + (db * page->diff_stride) + (db2 * page->diff2_stride),
                               crossings[j].path_len * crossings[j].vol_inv);
         }
@@ -798,7 +815,8 @@ static enum osh_status score_group_fluence(struct osh_scoring_runtime *rt,
  * dose-to-medium scoring.  Pure density overrides do not change the dose
  * (Fano theorem).
  */
-static enum osh_status score_group_dose(struct osh_scoring_runtime *rt,
+static enum osh_status score_group_dose(struct osh_scoring_runtime const *rt,
+                                        struct osh_scoring_accumulator *acc_set,
                                         struct osh_scoring_geometry_score_group const *group,
                                         struct osh_voxel_crossing const *crossings,
                                         size_t ncross,
@@ -819,7 +837,8 @@ static enum osh_status score_group_dose(struct osh_scoring_runtime *rt,
     double sp_ovr;
     size_t proj_idx;
     int have_proj;
-    struct osh_scoring_page_runtime *page;
+    struct osh_scoring_page_runtime const *page;
+    struct osh_scoring_accumulator *acc;
     struct osh_scoring_page_override const *sset; /* per-page settings override pointer */
     struct osh_material_runtime const *mat_tables = rt->mat_tables;
     e_per_nuc = 0.0; /* initialized to satisfy MSVC C4701; overwritten when table-based projectile data is available */
@@ -846,6 +865,7 @@ static enum osh_status score_group_dose(struct osh_scoring_runtime *rt,
 
     for (i = 0; i < group->npages; ++i) {
         page = &rt->pages[group->first_page + i];
+        acc = &acc_set[group->first_page + i];
         if (!osh_scoring_page_passes_filters(page, part, st)) {
             continue;
         }
@@ -892,7 +912,7 @@ static enum osh_status score_group_dose(struct osh_scoring_runtime *rt,
             }
             /* Flat index: spatial_idx + db * diff_stride + db2 * diff2_stride.
              * When differential axes are inactive the extra terms evaluate to 0. */
-            osh_score_deposit(page->acc.data,
+            osh_score_deposit(acc->data,
                               crossings[j].idx + (db * page->diff_stride) + (db2 * page->diff2_stride),
                               crossings[j].path_len * crossings[j].vol_inv * dose_scale);
         }
@@ -906,7 +926,8 @@ static enum osh_status score_group_dose(struct osh_scoring_runtime *rt,
  * Uses S(medium,E)·ρ from the SP tables when available; falls back to de/score_len.
  * Per-page Settings overrides apply S(ovr,E)·ρ_ovr (medium) or S(tr,E)·ρ_ovr (density-only).
  */
-static enum osh_status score_group_dlet(struct osh_scoring_runtime *rt,
+static enum osh_status score_group_dlet(struct osh_scoring_runtime const *rt,
+                                        struct osh_scoring_accumulator *acc_set,
                                         struct osh_scoring_geometry_score_group const *group,
                                         struct osh_voxel_crossing const *crossings,
                                         size_t ncross,
@@ -924,7 +945,8 @@ static enum osh_status score_group_dlet(struct osh_scoring_runtime *rt,
     double w;
     size_t proj_idx;
     int have_proj;
-    struct osh_scoring_page_runtime *page;
+    struct osh_scoring_page_runtime const *page;
+    struct osh_scoring_accumulator *acc;
     struct osh_scoring_page_override const *sset; /* per-page settings override pointer */
     struct osh_material_runtime const *mat_tables = rt->mat_tables;
     e_per_nuc = 0.0; /* initialized to satisfy MSVC C4701; overwritten when table-based projectile data is available */
@@ -953,6 +975,7 @@ static enum osh_status score_group_dlet(struct osh_scoring_runtime *rt,
 
     for (i = 0; i < group->npages; ++i) {
         page = &rt->pages[group->first_page + i];
+        acc = &acc_set[group->first_page + i];
         if (!osh_scoring_page_passes_filters(page, part, st)) {
             continue;
         }
@@ -976,8 +999,8 @@ static enum osh_status score_group_dlet(struct osh_scoring_runtime *rt,
              *   data2 = sum(dose_weight)          [MeV]
              * osh_scoring_postprocess() divides data by data2 to yield LETd. */
             w = st->de * crossings[j].path_len / score_len;
-            osh_score_deposit(page->acc.data, crossings[j].idx, let_step * w);
-            osh_score_deposit(page->acc.data2, crossings[j].idx, w);
+            osh_score_deposit(acc->data, crossings[j].idx, let_step * w);
+            osh_score_deposit(acc->data2, crossings[j].idx, w);
         }
     }
     return OSH_OK;
@@ -989,7 +1012,8 @@ static enum osh_status score_group_dlet(struct osh_scoring_runtime *rt,
  * Same table lookup as score_group_dlet(); uses track-length ds_vox as the weight
  * rather than dose weight.
  */
-static enum osh_status score_group_tlet(struct osh_scoring_runtime *rt,
+static enum osh_status score_group_tlet(struct osh_scoring_runtime const *rt,
+                                        struct osh_scoring_accumulator *acc_set,
                                         struct osh_scoring_geometry_score_group const *group,
                                         struct osh_voxel_crossing const *crossings,
                                         size_t ncross,
@@ -1007,7 +1031,8 @@ static enum osh_status score_group_tlet(struct osh_scoring_runtime *rt,
     double ds_vox;
     size_t proj_idx;
     int have_proj;
-    struct osh_scoring_page_runtime *page;
+    struct osh_scoring_page_runtime const *page;
+    struct osh_scoring_accumulator *acc;
     struct osh_scoring_page_override const *sset; /* per-page settings override pointer */
     struct osh_material_runtime const *mat_tables = rt->mat_tables;
     e_per_nuc = 0.0; /* initialized to satisfy MSVC C4701; overwritten when table-based projectile data is available */
@@ -1034,6 +1059,7 @@ static enum osh_status score_group_tlet(struct osh_scoring_runtime *rt,
 
     for (i = 0; i < group->npages; ++i) {
         page = &rt->pages[group->first_page + i];
+        acc = &acc_set[group->first_page + i];
         if (!osh_scoring_page_passes_filters(page, part, st)) {
             continue;
         }
@@ -1057,8 +1083,8 @@ static enum osh_status score_group_tlet(struct osh_scoring_runtime *rt,
              *   data2 = sum(ds_vox)         [cm]
              * osh_scoring_postprocess() divides data by data2 to yield LETt. */
             ds_vox = st->ds * crossings[j].path_len / score_len;
-            osh_score_deposit(page->acc.data, crossings[j].idx, let_step * ds_vox);
-            osh_score_deposit(page->acc.data2, crossings[j].idx, ds_vox);
+            osh_score_deposit(acc->data, crossings[j].idx, let_step * ds_vox);
+            osh_score_deposit(acc->data2, crossings[j].idx, ds_vox);
         }
     }
     return OSH_OK;
@@ -1074,7 +1100,8 @@ static enum osh_status score_group_tlet(struct osh_scoring_runtime *rt,
  *      https://doi.org/10.1002/mp.16029
  *
  */
-static enum osh_status score_group_dqeff(struct osh_scoring_runtime *rt,
+static enum osh_status score_group_dqeff(struct osh_scoring_runtime const *rt,
+                                         struct osh_scoring_accumulator *acc_set,
                                          struct osh_scoring_geometry_score_group const *group,
                                          struct osh_voxel_crossing const *crossings,
                                          size_t ncross,
@@ -1088,7 +1115,8 @@ static enum osh_status score_group_dqeff(struct osh_scoring_runtime *rt,
     double qeff;
     double w;
     size_t proj_idx;
-    struct osh_scoring_page_runtime *page;
+    struct osh_scoring_page_runtime const *page;
+    struct osh_scoring_accumulator *acc;
     struct osh_material_runtime const *mat_tables = rt->mat_tables;
 
     if (part->z == 0) {
@@ -1110,6 +1138,7 @@ static enum osh_status score_group_dqeff(struct osh_scoring_runtime *rt,
 
     for (i = 0; i < group->npages; ++i) {
         page = &rt->pages[group->first_page + i];
+        acc = &acc_set[group->first_page + i];
         if (!osh_scoring_page_passes_filters(page, part, st)) {
             continue;
         }
@@ -1122,8 +1151,8 @@ static enum osh_status score_group_dqeff(struct osh_scoring_runtime *rt,
              *   data2 = sum(dose_weight)           [MeV]
              * osh_scoring_postprocess() divides to yield the dose-averaged value. */
             w = st->de * crossings[j].path_len / score_len;
-            osh_score_deposit(page->acc.data, crossings[j].idx, qeff * w);
-            osh_score_deposit(page->acc.data2, crossings[j].idx, w);
+            osh_score_deposit(acc->data, crossings[j].idx, qeff * w);
+            osh_score_deposit(acc->data2, crossings[j].idx, w);
         }
     }
     return OSH_OK;
@@ -1138,7 +1167,8 @@ static enum osh_status score_group_dqeff(struct osh_scoring_runtime *rt,
  *      https://doi.org/10.1002/mp.16029
  *
  */
-static enum osh_status score_group_tqeff(struct osh_scoring_runtime *rt,
+static enum osh_status score_group_tqeff(struct osh_scoring_runtime const *rt,
+                                         struct osh_scoring_accumulator *acc_set,
                                          struct osh_scoring_geometry_score_group const *group,
                                          struct osh_voxel_crossing const *crossings,
                                          size_t ncross,
@@ -1152,7 +1182,8 @@ static enum osh_status score_group_tqeff(struct osh_scoring_runtime *rt,
     double qeff;
     double ds_vox;
     size_t proj_idx;
-    struct osh_scoring_page_runtime *page;
+    struct osh_scoring_page_runtime const *page;
+    struct osh_scoring_accumulator *acc;
     struct osh_material_runtime const *mat_tables = rt->mat_tables;
 
     if (part->z == 0) {
@@ -1174,6 +1205,7 @@ static enum osh_status score_group_tqeff(struct osh_scoring_runtime *rt,
 
     for (i = 0; i < group->npages; ++i) {
         page = &rt->pages[group->first_page + i];
+        acc = &acc_set[group->first_page + i];
         if (!osh_scoring_page_passes_filters(page, part, st)) {
             continue;
         }
@@ -1186,8 +1218,8 @@ static enum osh_status score_group_tqeff(struct osh_scoring_runtime *rt,
              *   data2 = sum(ds_vox)           [cm]
              * osh_scoring_postprocess() divides to yield the track-averaged value. */
             ds_vox = st->ds * crossings[j].path_len / score_len;
-            osh_score_deposit(page->acc.data, crossings[j].idx, qeff * ds_vox);
-            osh_score_deposit(page->acc.data2, crossings[j].idx, ds_vox);
+            osh_score_deposit(acc->data, crossings[j].idx, qeff * ds_vox);
+            osh_score_deposit(acc->data2, crossings[j].idx, ds_vox);
         }
     }
     return OSH_OK;

--- a/src/scoring/runtime/osh_scoring_step.h
+++ b/src/scoring/runtime/osh_scoring_step.h
@@ -4,6 +4,7 @@
 #include "common/osh_step.h"
 #include "openshieldhit/status.h"
 #include "particle/osh_particle.h"
+#include "scoring/runtime/osh_scoring_accumulator.h"
 #include "scoring/runtime/osh_scoring_runtime.h"
 
 #ifdef __cplusplus
@@ -18,9 +19,20 @@ extern "C" {
  * implementation supports Mesh (X,Y,Z) and Cyl (R,Z) geometries and the
  * step-based page kinds implemented in osh_scoring_step.c (ENERGY, FLUENCE,
  * DOSE, DOSEGY, DLET, TLET, DQEFF, TQEFF).
+ *
+ * @p rt is the read-only compiled descriptor (bin layout, filters, geometry,
+ * group ranges); the deposit path never writes through it.  @p acc_set is the
+ * mutable accumulator storage to deposit into, indexed in lockstep with
+ * @c rt->pages (length @c rt->npages).  The single-worker serial driver passes
+ * the master view (@ref osh_scoring_runtime_master_accumulators) so deposits land
+ * straight in the shared master pages; a parallel worker passes its own private
+ * set and the driver folds it into the master afterwards with
+ * @ref osh_scoring_accumulator_merge.
  */
-enum osh_status
-osh_scoring_score_step(struct osh_scoring_runtime *rt, struct particle const *part, struct step const *st);
+enum osh_status osh_scoring_score_step(struct osh_scoring_runtime const *rt,
+                                       struct osh_scoring_accumulator *acc_set,
+                                       struct particle const *part,
+                                       struct step const *st);
 
 /**
  * @brief Score one point event into the compiled scoring runtime.

--- a/src/transport/osh_transport_ion_step.c
+++ b/src/transport/osh_transport_ion_step.c
@@ -888,7 +888,7 @@ static enum osh_status ion_step_commit(struct ion_step_ctx const *ctx,
         st.w[2] = ctx->nuclear_event.primary_dir[2];
     }
 
-    rc = osh_scoring_score_step(score_rt, ctx->part, &st);
+    rc = osh_scoring_score_step(score_rt, osh_scoring_runtime_master_accumulators(score_rt), ctx->part, &st);
     if (rc != OSH_OK) {
         OSH_DIAG_ERRORF(transport_ctx->diag,
                         "transport: scoring rejected step rc=%d ds=%.17g p=(%.17g, %.17g, %.17g) "

--- a/src/transport/osh_transport_neutron.c
+++ b/src/transport/osh_transport_neutron.c
@@ -109,7 +109,7 @@ static enum osh_status score_neutron_step(struct osh_scoring_runtime *score_rt,
     st.gen = pool->gen[k];
     st.has_voxel = (zone_ref && zone_ref->has_hu) ? 1u : 0u;
 
-    return osh_scoring_score_step(score_rt, &k_neutron_species, &st);
+    return osh_scoring_score_step(score_rt, osh_scoring_runtime_master_accumulators(score_rt), &k_neutron_species, &st);
 }
 
 /*

--- a/tests/unit/test_osh_scoring_step.c
+++ b/tests/unit/test_osh_scoring_step.c
@@ -531,7 +531,8 @@ static struct osh_scoring_accumulator *alloc_private_acc_set(struct osh_scoring_
     size_t i;
 
     set = (struct osh_scoring_accumulator *) calloc(rt->npages, sizeof(*set));
-    ASSERT_TRUE(set != NULL);
+    /* calloc(0, ...) may legitimately return NULL; an empty set is valid. */
+    ASSERT_TRUE(set != NULL || rt->npages == 0u);
     for (i = 0; i < rt->npages; ++i) {
         ASSERT_TRUE(osh_scoring_accumulator_alloc(&set[i], rt->pages[i].len, rt->pages[i].has_data2) == OSH_OK);
     }
@@ -552,8 +553,11 @@ static void assert_arrays_bit_equal(double const *a, double const *b, size_t n) 
         ASSERT_TRUE(a == b);
         return;
     }
+    /* Compare the IEEE-754 representations bytewise: this is a true bit-for-bit
+     * check (distinguishes +0.0 from -0.0, matches identical NaN payloads) rather
+     * than the value comparison == would do. */
     for (i = 0; i < n; ++i) {
-        ASSERT_TRUE(a[i] == b[i]);
+        ASSERT_TRUE(memcmp(&a[i], &b[i], sizeof(double)) == 0);
     }
 }
 

--- a/tests/unit/test_osh_scoring_step.c
+++ b/tests/unit/test_osh_scoring_step.c
@@ -1,4 +1,5 @@
 #include <math.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -553,11 +554,17 @@ static void assert_arrays_bit_equal(double const *a, double const *b, size_t n) 
         ASSERT_TRUE(a == b);
         return;
     }
-    /* Compare the IEEE-754 representations bytewise: this is a true bit-for-bit
+    /* Compare the IEEE-754 representations as integers: this is a true bit-for-bit
      * check (distinguishes +0.0 from -0.0, matches identical NaN payloads) rather
-     * than the value comparison == would do. */
+     * than the value comparison == would do.  memcpy into uint64_t avoids both the
+     * value comparison and the bugprone-suspicious-memory-comparison clang-tidy
+     * diagnostic that memcmp on a double (no unique object representation) trips. */
     for (i = 0; i < n; ++i) {
-        ASSERT_TRUE(memcmp(&a[i], &b[i], sizeof(double)) == 0);
+        uint64_t ua;
+        uint64_t ub;
+        memcpy(&ua, &a[i], sizeof(ua));
+        memcpy(&ub, &b[i], sizeof(ub));
+        ASSERT_TRUE(ua == ub);
     }
 }
 

--- a/tests/unit/test_osh_scoring_step.c
+++ b/tests/unit/test_osh_scoring_step.c
@@ -84,7 +84,7 @@ static void test_score_mesh_energy_and_fluence_with_filters(void) {
     st.prim_idx = 7u;
     st.gen = 0u;
 
-    rc = osh_scoring_score_step(&rt, &part, &st);
+    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &part, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
     energy0_idx = rt.outputs[0].page_indices[0];
@@ -109,7 +109,7 @@ static void test_score_mesh_energy_and_fluence_with_filters(void) {
     assert_close(rt.pages[filtered_idx].acc.data[2], 0.125);
 
     st.gen = 1u;
-    rc = osh_scoring_score_step(&rt, &part, &st);
+    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &part, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
     rc = osh_scoring_postprocess(&rt);
@@ -198,7 +198,7 @@ static void test_score_mesh_uses_step_chord_after_bending(void) {
     st.prim_idx = 7u;
     st.gen = 0u;
 
-    rc = osh_scoring_score_step(&rt, &part, &st);
+    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &part, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
     energy0_idx = rt.outputs[0].page_indices[0];
@@ -286,7 +286,7 @@ static void test_score_mesh_neutron_id_filter(void) {
     st.prim_idx = 1u;
     st.gen = 1u;
 
-    rc = osh_scoring_score_step(&rt, &neutron, &st);
+    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &neutron, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
     fluence_idx = rt.outputs[0].page_indices[0];
@@ -300,7 +300,7 @@ static void test_score_mesh_neutron_id_filter(void) {
     assert_close(rt.pages[neutron_idx].acc.data[2], 0.5);
 
     neutron.pdg = OSH_PART_PDG_PROTON;
-    rc = osh_scoring_score_step(&rt, &neutron, &st);
+    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &neutron, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
     assert_close(rt.pages[fluence_idx].acc.data[0], 1.0);
@@ -372,7 +372,7 @@ static void test_score_mesh_dose_and_let_geometric(void) {
     st.wt = 1.0;
     st.medium = 0;
 
-    rc = osh_scoring_score_step(&rt, &part, &st);
+    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &part, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
     rc = osh_scoring_postprocess(&rt);
@@ -493,7 +493,7 @@ static void test_score_mesh_dqeff_tqeff(void) {
     st.wt = 1.0;
     st.medium = 0;
 
-    rc = osh_scoring_score_step(&rt, &part, &st);
+    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &part, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
     rc = osh_scoring_postprocess(&rt);
@@ -523,11 +523,110 @@ static void test_score_mesh_dqeff_tqeff(void) {
     osh_scoring_workspace_free(ws);
 }
 
+/* Allocate a private accumulator set cloning the shape of every page in rt
+ * (same len and data2 presence), zero-initialised.  Mirrors what a future
+ * worker_accumulators_alloc() does, but inline for the test. */
+static struct osh_scoring_accumulator *alloc_private_acc_set(struct osh_scoring_runtime const *rt) {
+    struct osh_scoring_accumulator *set;
+    size_t i;
+
+    set = (struct osh_scoring_accumulator *) calloc(rt->npages, sizeof(*set));
+    ASSERT_TRUE(set != NULL);
+    for (i = 0; i < rt->npages; ++i) {
+        ASSERT_TRUE(osh_scoring_accumulator_alloc(&set[i], rt->pages[i].len, rt->pages[i].has_data2) == OSH_OK);
+    }
+    return set;
+}
+
+static void free_acc_set(struct osh_scoring_accumulator *set, size_t n) {
+    size_t i;
+    for (i = 0; i < n; ++i) {
+        osh_scoring_accumulator_free(&set[i]);
+    }
+    free(set);
+}
+
+static void assert_arrays_bit_equal(double const *a, double const *b, size_t n) {
+    size_t i;
+    if (!a || !b) {
+        ASSERT_TRUE(a == b);
+        return;
+    }
+    for (i = 0; i < n; ++i) {
+        ASSERT_TRUE(a[i] == b[i]);
+    }
+}
+
+/* Acceptance criterion: scoring a step into a private acc_set and then merging
+ * that set into a zeroed master must equal scoring the same step directly into
+ * the master.  Both paths run identical floating-point ops and the merge is a
+ * plain add onto zero, so the two results are bit-for-bit identical. */
+static void test_score_private_then_merge_equals_direct(void) {
+    char path[512];
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle part;
+    struct step st;
+    struct osh_scoring_accumulator *priv;
+    struct osh_scoring_accumulator *merged;
+    enum osh_status rc;
+    size_t i;
+
+    snprintf(path, sizeof(path), "%s/tests/fixtures/test_let/detect.dat", OSH_PROJECT_SOURCE_DIR);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&part, 0, sizeof(part));
+    part.z = 1u;
+    part.a = 1u;
+
+    memset(&st, 0, sizeof(st));
+    st.p[2] = 0.5;
+    st.p[3] = 150.0;
+    st.q[2] = 2.5;
+    st.q[3] = 148.0;
+    st.v[2] = 1.0;
+    st.ds = 2.0;
+    st.de = 2.0;
+    st.rho = 1.0;
+    st.wt = 1.0;
+    st.medium = 0;
+
+    /* Direct: deposit straight into the master view (rt->pages[*].acc). */
+    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &part, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    /* Private: deposit into a private set, then fold into a zeroed master. */
+    priv = alloc_private_acc_set(&rt);
+    merged = alloc_private_acc_set(&rt); /* starts zeroed */
+    rc = osh_scoring_score_step(&rt, priv, &part, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+    for (i = 0; i < rt.npages; ++i) {
+        ASSERT_TRUE(osh_scoring_accumulator_merge(&merged[i], &priv[i]) == OSH_OK);
+    }
+
+    /* merged (zero + private) must equal the direct master deposit, bit-for-bit. */
+    for (i = 0; i < rt.npages; ++i) {
+        assert_arrays_bit_equal(merged[i].data, rt.pages[i].acc.data, rt.pages[i].len);
+        assert_arrays_bit_equal(merged[i].data2, rt.pages[i].acc.data2, rt.pages[i].len);
+    }
+
+    free_acc_set(priv, rt.npages);
+    free_acc_set(merged, rt.npages);
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+}
+
 int main(void) {
     test_score_mesh_energy_and_fluence_with_filters();
     test_score_mesh_uses_step_chord_after_bending();
     test_score_mesh_neutron_id_filter();
     test_score_mesh_dose_and_let_geometric();
     test_score_mesh_dqeff_tqeff();
+    test_score_private_then_merge_equals_direct();
     return 0;
 }


### PR DESCRIPTION
Closes #166.

Completes the deposit seam from the parallelism groundwork (#161 / PR #162): a worker can now deposit into its **own private** accumulator set instead of the shared master — the second of the two history-binding couplings (alongside the beam cursor, #165).

## What changed

`osh_scoring_score_step()` now takes the target accumulators as an explicit parameter, separating the **read-only descriptor** from the **mutable storage**:

```c
enum osh_status osh_scoring_score_step(struct osh_scoring_runtime const *rt,
                                       struct osh_scoring_accumulator *acc_set,  /* NEW */
                                       struct particle const *part,
                                       struct step const *st);
```

- `rt` is the read-only compiled descriptor (bin layout, filters, geometry, group ranges) — now `const`-qualified through the whole deposit path, including the page descriptor in every `score_group_*` helper.
- `acc_set` is the mutable accumulator storage, indexed in lockstep with `rt->pages` (length `rt->npages`).
- All **11 deposit sites** across the seven `score_group_*` helpers write through `acc_set[page_idx]` instead of `rt->pages[i].acc`.

## Serial path stays bit-identical

`osh_scoring_compile()` builds a **master accumulator view** once — an `npages`-long array whose element *i* shallow-aliases `pages[i].acc` — stored on `rt` and released with the runtime. It's exposed via `osh_scoring_runtime_master_accumulators()` (Option 1 from the issue: branch-free hot path, no per-step allocation). The transport ion (`osh_transport_ion_step.c`) and neutron call sites pass that view, so deposits land straight in the shared master exactly as before.

A parallel worker will instead pass `wctx->accumulators` and the driver will fold it into the master with `osh_scoring_accumulator_merge()` (#159) after join.

## Acceptance criteria

- [x] `osh_scoring_score_step()` takes an explicit accumulator-set parameter; all 11 deposit sites write through it.
- [x] `rt` treated as read-only by the deposit path; `const`-qualified where the compiler allows (`rt` + page descriptor).
- [x] Serial reference suite bit-identical (`cases::*` and bench `profile_bit_identity` pass).
- [x] No new per-step heap allocation; the view is built once at compile time.
- [x] Unit test: scoring into a private `acc_set` then `osh_scoring_accumulator_merge()` into a zeroed master equals scoring directly into the master (bit-for-bit).
- [x] `osh_transport_ion_step.c` commit call site updated to pass the master view.

## Testing

- `test_osh_scoring_step` (incl. new `test_score_private_then_merge_equals_direct`) and `test_osh_scoring_accumulator_merge` pass.
- Full `ctest`: the only failures are pre-existing and environmental in this container (DICOM fixtures present only as LFS pointers → "missing DICM preamble"; `version_components_in_string` depends on `git describe`). They are identical on the untouched base tree and unrelated to scoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KiSoFY79rHHJsuYyzrn5dJ)_