### PR TITLE
scoring: make voxel-crossing scratch per-worker (caller-owned), off the runtime

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -86,7 +86,12 @@ i.e. inside `osh_scoring_score_step()`, `osh_transport_step()`, or anything they
 call. Per-step `calloc`/`free` of scratch buffers was found to dominate CPU time
 (zeroing via `memset` accounted for ~60 % of all instructions in a CT transport
 run). All scratch buffers must be pre-allocated at compile/setup time and stored
-in the corresponding runtime struct (e.g. `osh_scoring_runtime.crossing_buf`).
+where the hot-path code can reuse them. Buffers that traversal *mutates* per step
+are caller-owned so they can be made per-worker without churn: the voxel-crossing
+scratch lives in a `struct osh_scoring_scratch` passed into
+`osh_scoring_score_step()`, with the serial driver's long-lived copy pre-sized at
+compile time in `osh_scoring_runtime.master_scratch` (exposed via
+`osh_scoring_runtime_master_scratch()`) and a parallel worker owning its own.
 
 #### API Stability
 

--- a/src/scoring/README.md
+++ b/src/scoring/README.md
@@ -32,6 +32,11 @@ layer parses input and hands the save backends fully-resolved paths.
   for layout, mutable `acc_set` for storage): the serial driver passes the
   master view (`osh_scoring_runtime_master_accumulators()`, a per-page alias
   array built once at compile time), while a worker passes its own private set.
+  The per-step voxel-crossing traversal scratch is caller-owned the same way: a
+  `struct osh_scoring_scratch` is passed in alongside `acc_set`, so neither the
+  deposit target nor the traversal scratch is shared mutable state on `rt` and
+  multiple workers can share one read-only `rt`. The serial driver passes
+  `osh_scoring_runtime_master_scratch()` (pre-sized once at compile time).
 - **One deposit seam.** Every tally funnels through `osh_score_deposit()` —
   today a plain `+=`, tomorrow the single place an atomic / private / locked
   write policy plugs in.

--- a/src/scoring/runtime/osh_scoring_compile.c
+++ b/src/scoring/runtime/osh_scoring_compile.c
@@ -591,7 +591,7 @@ void osh_scoring_runtime_free(struct osh_scoring_runtime *rt) {
         }
     }
     free(rt->outputs);
-    free(rt->crossing_buf);
+    free(rt->master_scratch.crossing_buf);
     /* master_acc only shallow-aliases the per-page accumulators (freed above);
      * release the view array itself, not the arrays it points into. */
     free(rt->master_acc);
@@ -1018,11 +1018,15 @@ enum osh_status osh_scoring_compile(struct osh_scoring_workspace const *ws,
     free(geom_page_counts);
     free(prepared_pages);
 
-    /* Pre-allocate the per-step voxel-crossing scratch buffer.  The maximum
-     * capacity needed is the sum of nbins across all axes of the largest
-     * geometry (matching the cap = n[0]+n[1]+n[2] formula in osh_scoring_step.c).
-     * One buffer is reused for every geometry on every physics step, eliminating
-     * the calloc/free pair that was spending ~60% of total CPU time on memset. */
+    /* Pre-allocate the serial driver's per-step voxel-crossing scratch buffer.
+     * The maximum capacity needed is the sum of nbins across all axes of the
+     * largest geometry (matching the cap = n[0]+n[1]+n[2] formula in
+     * osh_scoring_step.c).  One buffer is reused for every geometry on every
+     * physics step, eliminating the calloc/free pair that was spending ~60% of
+     * total CPU time on memset.  It lives in rt->master_scratch and is handed to
+     * osh_scoring_score_step() by the serial driver via
+     * osh_scoring_runtime_master_scratch(); a parallel worker owns its own scratch
+     * instead, so the buffer is never shared mutable state on the deposit path. */
     {
         size_t max_cap = 0;
         for (i = 0; i < rt->ngeometries; ++i) {
@@ -1049,12 +1053,13 @@ enum osh_status osh_scoring_compile(struct osh_scoring_workspace const *ws,
             }
         }
         if (max_cap > 0) {
-            rt->crossing_buf = (struct osh_voxel_crossing *) malloc(max_cap * sizeof(*rt->crossing_buf));
-            if (!rt->crossing_buf) {
+            rt->master_scratch.crossing_buf =
+                (struct osh_voxel_crossing *) malloc(max_cap * sizeof(*rt->master_scratch.crossing_buf));
+            if (!rt->master_scratch.crossing_buf) {
                 osh_scoring_runtime_free(rt);
                 return OSH_ENOMEM;
             }
-            rt->crossing_cap = max_cap;
+            rt->master_scratch.crossing_cap = max_cap;
         }
     }
 

--- a/src/scoring/runtime/osh_scoring_compile.c
+++ b/src/scoring/runtime/osh_scoring_compile.c
@@ -1019,9 +1019,11 @@ enum osh_status osh_scoring_compile(struct osh_scoring_workspace const *ws,
     free(prepared_pages);
 
     /* Pre-allocate the serial driver's per-step voxel-crossing scratch buffer.
-     * The maximum capacity needed is the sum of nbins across all axes of the
-     * largest geometry (matching the cap = n[0]+n[1]+n[2] formula in
-     * osh_scoring_step.c).  One buffer is reused for every geometry on every
+     * Size it to the largest per-geometry cap, computed with the same formula
+     * each traversal path uses in osh_scoring_step.c: mesh needs n[0]+n[1]+n[2]
+     * (sum of axis nbins), while CYL needs 2*nr+nz (== 2*n[0]+n[2]).  The two
+     * cases are handled separately below; keep both in sync with score_step so
+     * the buffer never overflows.  One buffer is reused for every geometry on every
      * physics step, eliminating the calloc/free pair that was spending ~60% of
      * total CPU time on memset.  It lives in rt->master_scratch and is handed to
      * osh_scoring_score_step() by the serial driver via

--- a/src/scoring/runtime/osh_scoring_runtime.h
+++ b/src/scoring/runtime/osh_scoring_runtime.h
@@ -14,6 +14,29 @@
 extern "C" {
 #endif
 
+/* ---- Per-worker traversal scratch ---------------------------------------- */
+
+/**
+ * @brief Caller-owned voxel-crossing scratch for one @ref osh_scoring_score_step call.
+ *
+ * @details
+ * Holds the reusable per-step buffer that raytrace / voxel-crossing traversal
+ * writes into before the per-group deposits consume it.  It is mutated on every
+ * step, so it must be private to the worker doing the traversal: the serial
+ * single-worker driver hands the long-lived @ref osh_scoring_runtime.master_scratch
+ * (built once at compile time, see @ref osh_scoring_runtime_master_scratch), while a
+ * parallel worker passes its own instance.  Keeping this off the read-only compiled
+ * descriptor is what lets multiple workers share one @c rt without racing on the
+ * traversal scratch.
+ *
+ * @c crossing_buf is grown to fit by the owner (the serial scratch is pre-sized at
+ * compile time to the largest geometry, so the serial hot path never reallocates).
+ */
+struct osh_scoring_scratch {
+    struct osh_voxel_crossing *crossing_buf; /* reusable per-step voxel-crossing scratch buffer */
+    size_t crossing_cap;                     /* allocated length of crossing_buf */
+};
+
 /* ---- Top-level compiled runtime ------------------------------------------ */
 
 /**
@@ -39,8 +62,13 @@ struct osh_scoring_runtime {
     size_t ngeometries;
     size_t npages;
     size_t noutputs;
-    struct osh_voxel_crossing *crossing_buf;       /* reusable per-step scratch buffer */
-    size_t crossing_cap;                           /* allocated length of crossing_buf */
+    /* Serial single-worker traversal scratch: the long-lived per-step voxel-crossing
+     * buffer the serial driver passes to osh_scoring_score_step() (see
+     * osh_scoring_runtime_master_scratch).  Pre-sized once by osh_scoring_compile() to
+     * the largest geometry, so the serial hot path never reallocates.  Not consulted
+     * by the deposit path itself: score_step uses the caller-supplied scratch, so a
+     * parallel worker passes its own and this stays the serial driver's private copy. */
+    struct osh_scoring_scratch master_scratch;
     struct osh_material_runtime const *mat_tables; /* SP tables; NULL until wired by simulation */
     /* Master accumulator view: an npages-long array whose element i shallow-aliases
      * pages[i].acc (same data pointers).  Built once by osh_scoring_compile() so the
@@ -62,6 +90,20 @@ struct osh_scoring_runtime {
  */
 static inline struct osh_scoring_accumulator *osh_scoring_runtime_master_accumulators(struct osh_scoring_runtime *rt) {
     return rt ? rt->master_acc : NULL;
+}
+
+/**
+ * @brief Serial single-worker traversal scratch, pre-sized for the largest geometry.
+ *
+ * @details
+ * The serial driver passes this to @ref osh_scoring_score_step as its per-step
+ * voxel-crossing scratch, mirroring @ref osh_scoring_runtime_master_accumulators for the
+ * deposit target.  A parallel worker passes its own @ref osh_scoring_scratch instead, so
+ * the compiled @c rt is never the source of the mutable traversal scratch.  Built once by
+ * @ref osh_scoring_compile; never allocated on the hot path.
+ */
+static inline struct osh_scoring_scratch *osh_scoring_runtime_master_scratch(struct osh_scoring_runtime *rt) {
+    return rt ? &rt->master_scratch : NULL;
 }
 
 #ifdef __cplusplus

--- a/src/scoring/runtime/osh_scoring_step.c
+++ b/src/scoring/runtime/osh_scoring_step.c
@@ -99,6 +99,11 @@ enum osh_status osh_scoring_score_step(struct osh_scoring_runtime const *rt,
     if (rt->npages > 0u && !acc_set) {
         return OSH_EINVAL;
     }
+    /* Traversal writes into the caller-owned scratch; require it whenever there
+     * is geometry to traverse, alongside the other argument checks. */
+    if (rt->ngeometries > 0u && !scratch) {
+        return OSH_EINVAL;
+    }
     if (!(st->ds > 0.0)) {
         return OSH_EINVAL;
     }
@@ -144,7 +149,7 @@ enum osh_status osh_scoring_score_step(struct osh_scoring_runtime const *rt,
             if (cap == 0u) {
                 continue;
             }
-            if (!scratch || cap > scratch->crossing_cap || !scratch->crossing_buf) {
+            if (cap > scratch->crossing_cap || !scratch->crossing_buf) {
                 return OSH_ESTATE;
             }
             crossings = scratch->crossing_buf;
@@ -164,7 +169,7 @@ enum osh_status osh_scoring_score_step(struct osh_scoring_runtime const *rt,
             if (cap == 0u) {
                 continue;
             }
-            if (!scratch || cap > scratch->crossing_cap || !scratch->crossing_buf) {
+            if (cap > scratch->crossing_cap || !scratch->crossing_buf) {
                 return OSH_ESTATE;
             }
             crossings = scratch->crossing_buf;

--- a/src/scoring/runtime/osh_scoring_step.c
+++ b/src/scoring/runtime/osh_scoring_step.c
@@ -78,6 +78,7 @@ static enum osh_status score_group_tqeff(struct osh_scoring_runtime const *rt,
 
 enum osh_status osh_scoring_score_step(struct osh_scoring_runtime const *rt,
                                        struct osh_scoring_accumulator *acc_set,
+                                       struct osh_scoring_scratch *scratch,
                                        struct particle const *part,
                                        struct step const *st) {
     size_t i;
@@ -143,10 +144,10 @@ enum osh_status osh_scoring_score_step(struct osh_scoring_runtime const *rt,
             if (cap == 0u) {
                 continue;
             }
-            if (cap > rt->crossing_cap || !rt->crossing_buf) {
+            if (!scratch || cap > scratch->crossing_cap || !scratch->crossing_buf) {
                 return OSH_ESTATE;
             }
-            crossings = rt->crossing_buf;
+            crossings = scratch->crossing_buf;
             hit = osh_raytrace_traverse(&grid, p_trace, dir_trace, score_len, crossings, &ncross);
             if (!hit || ncross == 0u) {
                 continue;
@@ -163,10 +164,10 @@ enum osh_status osh_scoring_score_step(struct osh_scoring_runtime const *rt,
             if (cap == 0u) {
                 continue;
             }
-            if (cap > rt->crossing_cap || !rt->crossing_buf) {
+            if (!scratch || cap > scratch->crossing_cap || !scratch->crossing_buf) {
                 return OSH_ESTATE;
             }
-            crossings = rt->crossing_buf;
+            crossings = scratch->crossing_buf;
             hit = osh_raytrace_cyl_traverse(&grid, p_trace, dir_trace, score_len, crossings, &ncross);
             if (!hit || ncross == 0u) {
                 continue;

--- a/src/scoring/runtime/osh_scoring_step.h
+++ b/src/scoring/runtime/osh_scoring_step.h
@@ -23,14 +23,20 @@ extern "C" {
  * @p rt is the read-only compiled descriptor (bin layout, filters, geometry,
  * group ranges); the deposit path never writes through it.  @p acc_set is the
  * mutable accumulator storage to deposit into, indexed in lockstep with
- * @c rt->pages (length @c rt->npages).  The single-worker serial driver passes
- * the master view (@ref osh_scoring_runtime_master_accumulators) so deposits land
- * straight in the shared master pages; a parallel worker passes its own private
- * set and the driver folds it into the master afterwards with
- * @ref osh_scoring_accumulator_merge.
+ * @c rt->pages (length @c rt->npages).  @p scratch is the caller-owned per-step
+ * voxel-crossing scratch traversal writes into; it must be private to the worker
+ * calling this function.  The single-worker serial driver passes the master views
+ * (@ref osh_scoring_runtime_master_accumulators and
+ * @ref osh_scoring_runtime_master_scratch) so deposits land straight in the shared
+ * master pages; a parallel worker passes its own private accumulator set and scratch,
+ * and the driver folds the accumulators into the master afterwards with
+ * @ref osh_scoring_accumulator_merge.  Because both the deposit target and the
+ * traversal scratch are caller-owned, multiple workers may share one read-only
+ * @p rt without racing.
  */
 enum osh_status osh_scoring_score_step(struct osh_scoring_runtime const *rt,
                                        struct osh_scoring_accumulator *acc_set,
+                                       struct osh_scoring_scratch *scratch,
                                        struct particle const *part,
                                        struct step const *st);
 

--- a/src/transport/osh_transport_ion_step.c
+++ b/src/transport/osh_transport_ion_step.c
@@ -888,7 +888,11 @@ static enum osh_status ion_step_commit(struct ion_step_ctx const *ctx,
         st.w[2] = ctx->nuclear_event.primary_dir[2];
     }
 
-    rc = osh_scoring_score_step(score_rt, osh_scoring_runtime_master_accumulators(score_rt), ctx->part, &st);
+    rc = osh_scoring_score_step(score_rt,
+                                osh_scoring_runtime_master_accumulators(score_rt),
+                                osh_scoring_runtime_master_scratch(score_rt),
+                                ctx->part,
+                                &st);
     if (rc != OSH_OK) {
         OSH_DIAG_ERRORF(transport_ctx->diag,
                         "transport: scoring rejected step rc=%d ds=%.17g p=(%.17g, %.17g, %.17g) "

--- a/src/transport/osh_transport_neutron.c
+++ b/src/transport/osh_transport_neutron.c
@@ -109,7 +109,11 @@ static enum osh_status score_neutron_step(struct osh_scoring_runtime *score_rt,
     st.gen = pool->gen[k];
     st.has_voxel = (zone_ref && zone_ref->has_hu) ? 1u : 0u;
 
-    return osh_scoring_score_step(score_rt, osh_scoring_runtime_master_accumulators(score_rt), &k_neutron_species, &st);
+    return osh_scoring_score_step(score_rt,
+                                  osh_scoring_runtime_master_accumulators(score_rt),
+                                  osh_scoring_runtime_master_scratch(score_rt),
+                                  &k_neutron_species,
+                                  &st);
 }
 
 /*

--- a/tests/unit/test_osh_scoring_step.c
+++ b/tests/unit/test_osh_scoring_step.c
@@ -85,7 +85,8 @@ static void test_score_mesh_energy_and_fluence_with_filters(void) {
     st.prim_idx = 7u;
     st.gen = 0u;
 
-    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &part, &st);
+    rc = osh_scoring_score_step(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
     energy0_idx = rt.outputs[0].page_indices[0];
@@ -110,7 +111,8 @@ static void test_score_mesh_energy_and_fluence_with_filters(void) {
     assert_close(rt.pages[filtered_idx].acc.data[2], 0.125);
 
     st.gen = 1u;
-    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &part, &st);
+    rc = osh_scoring_score_step(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
     rc = osh_scoring_postprocess(&rt);
@@ -199,7 +201,8 @@ static void test_score_mesh_uses_step_chord_after_bending(void) {
     st.prim_idx = 7u;
     st.gen = 0u;
 
-    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &part, &st);
+    rc = osh_scoring_score_step(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
     energy0_idx = rt.outputs[0].page_indices[0];
@@ -287,7 +290,8 @@ static void test_score_mesh_neutron_id_filter(void) {
     st.prim_idx = 1u;
     st.gen = 1u;
 
-    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &neutron, &st);
+    rc = osh_scoring_score_step(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &neutron, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
     fluence_idx = rt.outputs[0].page_indices[0];
@@ -301,7 +305,8 @@ static void test_score_mesh_neutron_id_filter(void) {
     assert_close(rt.pages[neutron_idx].acc.data[2], 0.5);
 
     neutron.pdg = OSH_PART_PDG_PROTON;
-    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &neutron, &st);
+    rc = osh_scoring_score_step(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &neutron, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
     assert_close(rt.pages[fluence_idx].acc.data[0], 1.0);
@@ -373,7 +378,8 @@ static void test_score_mesh_dose_and_let_geometric(void) {
     st.wt = 1.0;
     st.medium = 0;
 
-    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &part, &st);
+    rc = osh_scoring_score_step(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
     rc = osh_scoring_postprocess(&rt);
@@ -494,7 +500,8 @@ static void test_score_mesh_dqeff_tqeff(void) {
     st.wt = 1.0;
     st.medium = 0;
 
-    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &part, &st);
+    rc = osh_scoring_score_step(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
     rc = osh_scoring_postprocess(&rt);
@@ -608,13 +615,14 @@ static void test_score_private_then_merge_equals_direct(void) {
     st.medium = 0;
 
     /* Direct: deposit straight into the master view (rt->pages[*].acc). */
-    rc = osh_scoring_score_step(&rt, osh_scoring_runtime_master_accumulators(&rt), &part, &st);
+    rc = osh_scoring_score_step(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
     /* Private: deposit into a private set, then fold into a zeroed master. */
     priv = alloc_private_acc_set(&rt);
     merged = alloc_private_acc_set(&rt); /* starts zeroed */
-    rc = osh_scoring_score_step(&rt, priv, &part, &st);
+    rc = osh_scoring_score_step(&rt, priv, osh_scoring_runtime_master_scratch(&rt), &part, &st);
     ASSERT_TRUE(rc == OSH_OK);
     for (i = 0; i < rt.npages; ++i) {
         ASSERT_TRUE(osh_scoring_accumulator_merge(&merged[i], &priv[i]) == OSH_OK);


### PR DESCRIPTION
## What & why

Follow-up to #166 / PR #184. Closes #185.

PR #184 redirected scoring **deposits** through an explicit `acc_set` and made the compiled descriptor `rt` read-only for *storage*. But `osh_scoring_score_step()` still mutated one more piece of shared runtime state on the hot path: the voxel-crossing scratch buffer `rt->crossing_buf`. With the read-only-`rt` / private-`acc_set` usage #184 enables, multiple workers sharing one `rt` (even with different private `acc_set`s) would race on this buffer — torn raytrace results, corrupted crossing counts / `vol_inv`, ThreadSanitizer failures. Unlike the profile counters (#167), this is a **correctness blocker**, not just diagnostics.

This change closes that gap so the read-only-`rt` guarantee holds for the whole deposit path, not just the deposit sites.

## How

Mirror the `acc_set` / `master_acc` deposit-target seam (option 1 from the issue):

- Add `struct osh_scoring_scratch { crossing_buf, crossing_cap }`.
- `osh_scoring_score_step()` takes a `struct osh_scoring_scratch *scratch` parameter and traverses through it (both **mesh** and **cyl** paths); it no longer reads `rt` for the scratch.
- The serial driver's long-lived copy lives in `rt->master_scratch`, pre-sized once at compile time to the largest geometry and exposed via `osh_scoring_runtime_master_scratch()` — analogous to `osh_scoring_runtime_master_accumulators()`. Serial callers pass it, so the hot path stays allocation-free and bit-identical. A parallel worker passes its own scratch, so the buffer is never shared mutable state on the deposit path.
- `crossing_buf` / `crossing_cap` removed from `struct osh_scoring_runtime`.
- Update the two transport call sites and the scoring-step unit tests.
- Update `DEVELOPER.md` (the `:89` note) and `src/scoring/README.md` to reflect the new caller-owned ownership.

No physics change.

## Acceptance criteria

- [x] `osh_scoring_score_step()` no longer reads/writes a crossing scratch shared between workers — scratch is caller-owned (per-worker).
- [x] `crossing_buf` / `crossing_cap` removed from `struct osh_scoring_runtime`.
- [x] Serial path stays **bit-identical** (`bench::profile_bit_identity` passes) and allocation-free on the hot path.
- [x] Both mesh and cyl traversal paths use the per-worker scratch (`cases::08_minimal_cyl` and the mesh cases pass).
- [x] DEVELOPER.md note updated to reflect the new ownership.
- [ ] Threaded `-fsanitize=thread` validation — deferred until the threaded driver lands (verified by construction + serial bit-identity for now, per the issue).

## Testing

`cmake --preset debug && ctest` — all scoring/cases/bench tests pass, including `test_osh_scoring_step`, `cases::*` (mesh + cyl), `bench::profile_bit_identity`, and `bench::capacity_invariance`. The only failing tests (`version_components_in_string`, DICOM cases) are pre-existing and unrelated — confirmed they fail identically on the base branch without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X73D8keeCW5KMAjotKzUjB

---
_Generated by [Claude Code](https://claude.ai/code/session_01X73D8keeCW5KMAjotKzUjB)_