### PR TITLE
transport: make profile counters per-worker (avoid data race under threads)

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -93,6 +93,17 @@ scratch lives in a `struct osh_scoring_scratch` passed into
 compile time in `osh_scoring_runtime.master_scratch` (exposed via
 `osh_scoring_runtime_master_scratch()`) and a parallel worker owning its own.
 
+The same caller-owned discipline applies to mutable counters on the hot path.
+The transport profile (`struct osh_transport_profile`) is per-worker: a worker
+accumulates phase timers and event counters into its own profile carried on
+`osh_worker_context.profile` (and threaded into `osh_transport_ion_step()`), never
+a shared one, so concurrent workers do not race. The serial worker points its
+profile straight at the run's master, so its values are unchanged; a parallel
+driver gives each worker a private profile and folds them in afterwards with
+`osh_transport_profile_merge()` (counters and per-phase `*_s` sum as aggregate
+work; `total_s` combines by maximum, since concurrent workers overlap in
+wall-clock time).
+
 #### API Stability
 
 The public API is still early and **not yet frozen**.

--- a/src/transport/osh_transport.h
+++ b/src/transport/osh_transport.h
@@ -111,6 +111,14 @@ struct osh_transport_params {
  * Profiling reads only the monotonic clock and pre-existing counters; it
  * never touches the RNG streams or any physics state, so instrumented runs
  * are bit-identical to un-instrumented ones.
+ *
+ * A profile is per-worker mutable state: each transport worker accumulates into
+ * its own instance on the hot path (carried on @ref osh_worker_context), never
+ * into a shared one, so concurrent workers do not race on these counters.  The
+ * driver folds the per-worker profiles into the run's master profile after the
+ * workers finish, with osh_transport_profile_merge().  In the single-worker
+ * build the lone worker writes straight into the master, so there is nothing to
+ * merge and the values are identical to the un-parallelised path.
  */
 struct osh_transport_profile {
     double fill_s;                     /**< Time spent refilling the pool [s]. */
@@ -124,6 +132,30 @@ struct osh_transport_profile {
     unsigned long long nuclear_events; /**< Nuclear interactions sampled (any kind). */
     unsigned long long secondaries;    /**< Secondaries produced by nuclear events. */
 };
+
+/**
+ * @brief Fold one worker's transport profile into a destination profile.
+ *
+ * @details
+ * The reduce step that combines per-worker profiles after a parallel run,
+ * mirroring osh_scoring_accumulator_merge() for scoring tallies.  Counters and
+ * per-phase timers are summed: the phase @c *_s fields therefore report
+ * aggregate work-in-phase across workers (their sum can exceed the elapsed wall
+ * time, which is the point — it exposes parallel efficiency).
+ *
+ * @c total_s is the exception.  Workers run concurrently, so elapsed time is the
+ * span of the longest worker, not the sum of their spans; it is combined by
+ * **maximum**, not addition.  A parallel driver that measures a single
+ * wall-clock span around the whole parallel region may overwrite @c total_s with
+ * that span afterwards; until then the max of the per-worker spans is a faithful
+ * lower-bound proxy.  Merging one worker into a zeroed destination reproduces
+ * that worker's values exactly (sum with zero; max with zero), so the
+ * single-worker path is bit-identical whether or not the merge is used.
+ *
+ * @param[in,out] dst  Destination profile (accumulates @p src).  No-op if NULL.
+ * @param[in]     src  Source profile to fold in.  No-op if NULL.
+ */
+void osh_transport_profile_merge(struct osh_transport_profile *dst, struct osh_transport_profile const *src);
 
 /**
  * @brief Per-run transport context: immutable knobs plus mutable run state.
@@ -148,7 +180,11 @@ struct osh_transport_context {
     struct osh_zone_ref *zone_refs;                    /**< Transport scratch: zone/material per slot. */
     double *dist_batch;                                /**< Transport scratch: boundary distance per slot. */
     size_t scratch_capacity;                           /**< Number of entries in zone_refs and dist_batch. */
-    struct osh_transport_profile *profile;             /**< Borrowed; NULL disables phase timers/counters. */
+    struct osh_transport_profile *profile;             /**< Borrowed master/destination profile; NULL disables
+                                                            phase timers/counters.  Written by a worker (the lone
+                                                            serial worker points its own profile here) or by the
+                                                            driver merging per-worker profiles — not on the hot
+                                                            path through this pointer. */
     char warned_boundary_demin_override;
 };
 

--- a/src/transport/osh_transport_ion.c
+++ b/src/transport/osh_transport_ion.c
@@ -57,12 +57,15 @@ static enum osh_status validate_transport_modes(struct osh_transport_context con
  * particle pool and per-step batch scratch — for one slice [hist_lo, hist_hi).
  * Primary generation is already partition-safe: this loop fills the pool through
  * osh_beam_runtime_fill_pool_at() with an explicit global base derived from the
- * worker's own range, never the shared beam cursor.  Two pieces of shared state
- * still stand between this and concurrent execution: @p score_rt's accumulators
- * (deposits land in the shared master) and @p transport_ctx->profile (its
- * counters are summed in place).  Both want per-worker copies merged at the end;
- * see the @c accumulators field on @ref osh_worker_context.  Today a single worker
- * covers [0, nstat), so none of that sharing is yet exercised.
+ * worker's own range, never the shared beam cursor.  Profile counters are
+ * per-worker too: this loop accumulates into @c wctx->profile, never a shared
+ * profile, so workers do not race on them; the driver folds them into the run's
+ * master with osh_transport_profile_merge().  One piece of shared state still
+ * stands between this and concurrent execution: @p score_rt's accumulators
+ * (deposits land in the shared master); per-worker copies merged at the end are
+ * the plan, see the @c accumulators field on @ref osh_worker_context.  Today a
+ * single worker covers [0, nstat) and points its profile straight at the master,
+ * so none of that sharing is yet exercised.
  *
  *   1. When the pool is empty and primaries remain, fill it from beam_runtime
  *      (up to the worker's pool capacity).
@@ -106,7 +109,7 @@ static enum osh_status run_history_range(struct osh_worker_context *wctx,
     size_t progress_chunk;
     size_t next_report_completed;
     struct osh_step_segment step_seg;
-    struct osh_transport_profile *prof = transport_ctx->profile;
+    struct osh_transport_profile *prof = wctx->profile; /* per-worker; never the shared master on the hot path */
     double t_start;
     double t_last_report;
     double t_phase = 0.0;
@@ -227,8 +230,17 @@ static enum osh_status run_history_range(struct osh_worker_context *wctx,
             /* Each slot draws from its own carried stream, so the random
              * sequence a history sees does not depend on its position in the
              * wavefront or on how many secondaries its siblings spawned. */
-            rc = osh_transport_ion_step(
-                pool, i, &zone_refs[i], &step_seg, 1u, geom_rt, transport_ctx, material_rt, score_rt, &pool->rng[i]);
+            rc = osh_transport_ion_step(pool,
+                                        i,
+                                        &zone_refs[i],
+                                        &step_seg,
+                                        1u,
+                                        geom_rt,
+                                        transport_ctx,
+                                        prof,
+                                        material_rt,
+                                        score_rt,
+                                        &pool->rng[i]);
             if (rc != OSH_OK) {
                 OSH_DIAG_ERRORF(transport_ctx->diag,
                                 "transport: slot %zu failed with rc=%d zone=%zu boundary_ds=%.17g e=%.17g pos=(%.17g, "
@@ -323,6 +335,31 @@ static enum osh_status run_history_range(struct osh_worker_context *wctx,
     return rc;
 }
 
+/* ---- Per-worker profile reduction ---------------------------------------- */
+
+void osh_transport_profile_merge(struct osh_transport_profile *dst, struct osh_transport_profile const *src) {
+    if (!dst || !src) {
+        return;
+    }
+    /* Per-phase timers and event counters are additive: their sum across workers
+     * is aggregate work-in-phase (which legitimately exceeds elapsed wall time). */
+    dst->fill_s += src->fill_s;
+    dst->zone_ref_s += src->zone_ref_s;
+    dst->distance_s += src->distance_s;
+    dst->step_s += src->step_s;
+    dst->compact_s += src->compact_s;
+    dst->steps += src->steps;
+    dst->iterations += src->iterations;
+    dst->nuclear_events += src->nuclear_events;
+    dst->secondaries += src->secondaries;
+    /* Wall time is not additive across concurrent workers — elapsed time is the
+     * longest worker's span, so combine by maximum.  Merging into a zeroed dst
+     * (the single-worker case) reproduces src->total_s exactly. */
+    if (src->total_s > dst->total_s) {
+        dst->total_s = src->total_s;
+    }
+}
+
 /* ---- Public entry: single-worker run over the whole history range -------- */
 
 /**
@@ -374,6 +411,12 @@ enum osh_status osh_transport_ion_run_minimal(struct osh_transport_context *tran
     transport_ctx->ion_pool->n = 0u;
     osh_worker_context_attach(
         &wctx, 0u, params->nstat, transport_ctx->ion_pool, transport_ctx->zone_refs, transport_ctx->dist_batch);
+
+    /* Single worker: point its profile straight at the run's master so counters
+     * land there directly — bit-identical to the un-parallelised path, no merge.
+     * A parallel driver would instead give each worker a private profile and fold
+     * them into transport_ctx->profile with osh_transport_profile_merge(). */
+    wctx.profile = transport_ctx->profile;
 
     rc = run_history_range(&wctx, transport_ctx, beam_rt, geom_rt, material_rt, score_rt);
 

--- a/src/transport/osh_transport_ion_step.c
+++ b/src/transport/osh_transport_ion_step.c
@@ -202,6 +202,7 @@ enum osh_status osh_transport_ion_step(struct osh_particle_pool *pool,
                                        size_t n_step_segments,
                                        struct osh_gemca_runtime const *geom_rt,
                                        struct osh_transport_context *transport_ctx,
+                                       struct osh_transport_profile *prof,
                                        struct osh_material_runtime const *material_rt,
                                        struct osh_scoring_runtime *score_rt,
                                        struct osh_rng *rng) {
@@ -246,10 +247,11 @@ enum osh_status osh_transport_ion_step(struct osh_particle_pool *pool,
         return rc;
     }
 
-    /* Profiling counters only; never touches RNG or physics state. */
-    if (transport_ctx->profile && ctx.nuclear_event.kind != OSH_NUCLEAR_EVENT_NONE) {
-        transport_ctx->profile->nuclear_events++;
-        transport_ctx->profile->secondaries += (unsigned long long) ctx.nuclear_event.n_secondaries;
+    /* Profiling counters only; never touches RNG or physics state.  The profile
+     * is the caller's (per-worker), so concurrent workers do not race here. */
+    if (prof && ctx.nuclear_event.kind != OSH_NUCLEAR_EVENT_NONE) {
+        prof->nuclear_events++;
+        prof->secondaries += (unsigned long long) ctx.nuclear_event.n_secondaries;
     }
 
     /* Inject secondaries produced by a nuclear event (pp elastic recoil,

--- a/src/transport/osh_transport_ion_step.h
+++ b/src/transport/osh_transport_ion_step.h
@@ -15,6 +15,7 @@
 struct osh_particle_pool;
 struct osh_gemca_runtime;
 struct osh_transport_context;
+struct osh_transport_profile;
 struct osh_material_runtime;
 struct osh_scoring_runtime;
 struct osh_rng;
@@ -43,6 +44,11 @@ struct osh_rng;
  * pool->e[slot] is zeroed and OSH_OK is returned; the slot is collected by
  * the next osh_particle_pool_compact() call.  Only allocation or I/O errors
  * from scoring propagate as non-OK status.
+ *
+ * @p prof is the caller's (per-worker) profile for the nuclear-event counters;
+ * pass NULL to disable, or the worker's own profile so concurrent workers never
+ * race on shared counters.  It is read-only diagnostics: it never touches the
+ * RNG or physics state.
  */
 enum osh_status osh_transport_ion_step(struct osh_particle_pool *pool,
                                        size_t slot,
@@ -51,6 +57,7 @@ enum osh_status osh_transport_ion_step(struct osh_particle_pool *pool,
                                        size_t n_step_segments,
                                        struct osh_gemca_runtime const *geom_rt,
                                        struct osh_transport_context *transport_ctx,
+                                       struct osh_transport_profile *prof,
                                        struct osh_material_runtime const *material_rt,
                                        struct osh_scoring_runtime *score_rt,
                                        struct osh_rng *rng);

--- a/src/transport/osh_worker_context.c
+++ b/src/transport/osh_worker_context.c
@@ -19,4 +19,5 @@ void osh_worker_context_attach(struct osh_worker_context *wctx,
     wctx->dist_batch = dist_batch; /* borrowed */
     wctx->accumulators = NULL;
     wctx->naccumulators = 0u;
+    wctx->profile = NULL; /* caller wires this to the master (serial) or a private profile (parallel). */
 }

--- a/src/transport/osh_worker_context.h
+++ b/src/transport/osh_worker_context.h
@@ -12,20 +12,23 @@ extern "C" {
 struct osh_particle_pool;
 struct osh_zone_ref;
 struct osh_scoring_accumulator;
+struct osh_transport_profile;
 
 /**
  * @brief Everything one transport worker needs to run an assigned slice of histories.
  *
  * @details
- * Bundles the *transport-local* mutable state — the particle pool and per-step
- * batch scratch — for one slice of the run, so this state stops being a barrier
- * to partitioning work across workers (threads, MPI ranks, or sequential
- * profiling replicas) over disjoint history ranges.  It is one building block,
- * not the whole story: the scoring accumulators in score_rt and
- * transport_ctx->profile are owned elsewhere and remain shared, so concurrent
- * execution will additionally need per-worker or coordinated scoring/profile
- * state (the @ref accumulators field below is where per-worker scoring memory
- * will attach).  Beam primary generation is no longer in that list — a worker
+ * Bundles the *transport-local* mutable state — the particle pool, per-step
+ * batch scratch, and the run-profile counters — for one slice of the run, so
+ * this state stops being a barrier to partitioning work across workers (threads,
+ * MPI ranks, or sequential profiling replicas) over disjoint history ranges.  It
+ * is one building block, not the whole story: the scoring accumulators in
+ * score_rt are owned elsewhere and remain shared, so concurrent execution will
+ * additionally need per-worker scoring state (the @ref accumulators field below
+ * is where per-worker scoring memory will attach).  The profile counters are no
+ * longer in that list — each worker accumulates into its own @ref profile and
+ * the driver merges them (see osh_transport_profile_merge).  Beam primary
+ * generation is no longer in that list either — a worker
  * fills its pool through osh_beam_runtime_fill_pool_at() with an explicit global
  * base from its own range, so the beam runtime is shared read-only.
  *
@@ -59,6 +62,15 @@ struct osh_worker_context {
      * here without touching the transport loop. */
     struct osh_scoring_accumulator *accumulators;
     size_t naccumulators;
+
+    /* Per-worker transport profile (phase timers + event counters).  The worker
+     * accumulates here on the hot path, never into a shared profile, so workers
+     * do not race on these counters; the driver folds them into the run's master
+     * profile with osh_transport_profile_merge() once the range completes.  NULL
+     * disables profiling.  In the single-worker baseline this points straight at
+     * the simulation's master profile (transport_ctx->profile), so the lone
+     * worker writes the master directly and no merge is needed. */
+    struct osh_transport_profile *profile;
 };
 
 /**
@@ -70,8 +82,10 @@ struct osh_worker_context {
  * simulation's pre-allocated ion pool and scratch (transport_ctx->ion_pool /
  * zone_refs / dist_batch), so nothing here is owned and there is nothing to free.
  * @ref capacity is taken from @p pool->capacity; the scratch arrays must be at
- * least that long.  The private scoring accumulators are left NULL (shared-master
- * scoring, the current baseline).  A future parallel worker that owns a private
+ * least that long.  The private scoring accumulators and the profile are left
+ * NULL; the caller wires @ref profile to the run's master profile (serial) or to
+ * a private one (parallel), and the accumulators stay NULL for shared-master
+ * scoring (the current baseline).  A future parallel worker that owns a private
  * pool would use a separate owning constructor.
  *
  * @param[out] wctx       Context to populate (overwritten; must be non-NULL).

--- a/tests/unit/test_osh_transport_profile_merge.c
+++ b/tests/unit/test_osh_transport_profile_merge.c
@@ -8,8 +8,17 @@
  *                           exactly (the single-worker / serial case)
  *   test_merge_sums       — counters and per-phase timers add across workers
  *   test_merge_total_max  — total_s combines by maximum, not addition
- *   test_merge_commutative— merge order does not change the result
+ *   test_merge_commutative— merge order does not change the result for these
+ *                           integer-valued test vectors (see note below)
  *   test_merge_null       — NULL operands are no-ops, not crashes
+ *
+ * Note on bit-exact assertions: production phase timers are arbitrary doubles
+ * read from the monotonic clock, and double addition is not associative, so the
+ * real merge is only invariant up to summation order, not byte-for-byte.  These
+ * tests deliberately use small integer-valued seconds, which fit exactly in a
+ * double and sum without rounding, so `==` comparisons and the order-independence
+ * checks below are exact here — a property of the chosen vectors, not a claim
+ * about measured timings.
  */
 
 #include <stdio.h>
@@ -18,8 +27,10 @@
 #include "test_assert.h"
 #include "transport/osh_transport.h"
 
-/* Bit-exact comparison: the merge only adds integer-valued doubles or takes a
- * max, so results must reproduce exactly. */
+/* Bit-exact comparison: these test vectors use integer-valued seconds, which sum
+ * in a double without rounding (and max is always exact), so equal results must
+ * reproduce exactly here.  This is not true of production timers — see the file
+ * header note on summation order. */
 static void assert_profile_equal(struct osh_transport_profile const *a, struct osh_transport_profile const *b) {
     ASSERT_TRUE(a->fill_s == b->fill_s);
     ASSERT_TRUE(a->zone_ref_s == b->zone_ref_s);
@@ -95,8 +106,10 @@ static void test_merge_commutative(void) {
     struct osh_transport_profile dst1 = base;
     struct osh_transport_profile dst2 = base;
 
-    /* dst1: +b then +c ; dst2: +c then +b.  Integer-valued sums and max are
-     * order-independent, so the two must be bit-equal. */
+    /* dst1: +b then +c ; dst2: +c then +b.  For these integer-valued vectors the
+     * sums incur no rounding and max is order-free, so the two must be bit-equal.
+     * Arbitrary measured timings would only match up to summation order, not
+     * byte-for-byte (see the file header note). */
     osh_transport_profile_merge(&dst1, &b);
     osh_transport_profile_merge(&dst1, &c);
     osh_transport_profile_merge(&dst2, &c);

--- a/tests/unit/test_osh_transport_profile_merge.c
+++ b/tests/unit/test_osh_transport_profile_merge.c
@@ -1,0 +1,130 @@
+/*
+ * Unit tests for osh_transport_profile_merge() — the reduce that folds per-worker
+ * transport profiles into a master after a parallel run.  Pure arithmetic, so
+ * these run identically on every OS.
+ *
+ * Coverage:
+ *   test_merge_into_zero  — merging one worker into a zeroed dst reproduces it
+ *                           exactly (the single-worker / serial case)
+ *   test_merge_sums       — counters and per-phase timers add across workers
+ *   test_merge_total_max  — total_s combines by maximum, not addition
+ *   test_merge_commutative— merge order does not change the result
+ *   test_merge_null       — NULL operands are no-ops, not crashes
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "test_assert.h"
+#include "transport/osh_transport.h"
+
+/* Bit-exact comparison: the merge only adds integer-valued doubles or takes a
+ * max, so results must reproduce exactly. */
+static void assert_profile_equal(struct osh_transport_profile const *a, struct osh_transport_profile const *b) {
+    ASSERT_TRUE(a->fill_s == b->fill_s);
+    ASSERT_TRUE(a->zone_ref_s == b->zone_ref_s);
+    ASSERT_TRUE(a->distance_s == b->distance_s);
+    ASSERT_TRUE(a->step_s == b->step_s);
+    ASSERT_TRUE(a->compact_s == b->compact_s);
+    ASSERT_TRUE(a->total_s == b->total_s);
+    ASSERT_TRUE(a->steps == b->steps);
+    ASSERT_TRUE(a->iterations == b->iterations);
+    ASSERT_TRUE(a->nuclear_events == b->nuclear_events);
+    ASSERT_TRUE(a->secondaries == b->secondaries);
+}
+
+/* ---- Single-worker case: merge into zero reproduces the source exactly --- */
+
+static void test_merge_into_zero(void) {
+    struct osh_transport_profile dst;
+    struct osh_transport_profile src = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7u, 8u, 9u, 10u};
+
+    memset(&dst, 0, sizeof(dst));
+    osh_transport_profile_merge(&dst, &src);
+    /* sum-with-zero and max-with-zero both yield src — the serial path is
+     * bit-identical whether or not the merge is used. */
+    assert_profile_equal(&dst, &src);
+}
+
+/* ---- Counters and per-phase timers add across workers -------------------- */
+
+static void test_merge_sums(void) {
+    struct osh_transport_profile dst = {1.0, 2.0, 3.0, 4.0, 5.0, 100.0, 7u, 8u, 9u, 10u};
+    struct osh_transport_profile src = {10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70u, 80u, 90u, 100u};
+
+    osh_transport_profile_merge(&dst, &src);
+
+    ASSERT_TRUE(dst.fill_s == 11.0);
+    ASSERT_TRUE(dst.zone_ref_s == 22.0);
+    ASSERT_TRUE(dst.distance_s == 33.0);
+    ASSERT_TRUE(dst.step_s == 44.0);
+    ASSERT_TRUE(dst.compact_s == 55.0);
+    ASSERT_TRUE(dst.steps == 77u);
+    ASSERT_TRUE(dst.iterations == 88u);
+    ASSERT_TRUE(dst.nuclear_events == 99u);
+    ASSERT_TRUE(dst.secondaries == 110u);
+    /* total_s is the max (100 vs 60), not the sum. */
+    ASSERT_TRUE(dst.total_s == 100.0);
+}
+
+/* ---- total_s combines by maximum in both directions ---------------------- */
+
+static void test_merge_total_max(void) {
+    struct osh_transport_profile a = {0};
+    struct osh_transport_profile b = {0};
+
+    /* dst smaller than src: dst takes src's larger span. */
+    a.total_s = 3.0;
+    b.total_s = 9.0;
+    osh_transport_profile_merge(&a, &b);
+    ASSERT_TRUE(a.total_s == 9.0);
+
+    /* dst larger than src: dst keeps its own larger span. */
+    a.total_s = 12.0;
+    b.total_s = 4.0;
+    osh_transport_profile_merge(&a, &b);
+    ASSERT_TRUE(a.total_s == 12.0);
+}
+
+/* ---- Merge order does not change the result ------------------------------ */
+
+static void test_merge_commutative(void) {
+    struct osh_transport_profile base = {1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1u, 1u, 1u, 1u};
+    struct osh_transport_profile b = {2.0, 3.0, 4.0, 5.0, 6.0, 9.0, 2u, 3u, 4u, 5u};
+    struct osh_transport_profile c = {20.0, 30.0, 40.0, 50.0, 60.0, 7.0, 20u, 30u, 40u, 50u};
+    struct osh_transport_profile dst1 = base;
+    struct osh_transport_profile dst2 = base;
+
+    /* dst1: +b then +c ; dst2: +c then +b.  Integer-valued sums and max are
+     * order-independent, so the two must be bit-equal. */
+    osh_transport_profile_merge(&dst1, &b);
+    osh_transport_profile_merge(&dst1, &c);
+    osh_transport_profile_merge(&dst2, &c);
+    osh_transport_profile_merge(&dst2, &b);
+
+    assert_profile_equal(&dst1, &dst2);
+    /* total_s is the max of all three spans (9 vs 7 vs 2). */
+    ASSERT_TRUE(dst1.total_s == 9.0);
+}
+
+/* ---- NULL operands are no-ops, not crashes ------------------------------- */
+
+static void test_merge_null(void) {
+    struct osh_transport_profile a = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7u, 8u, 9u, 10u};
+    struct osh_transport_profile snapshot = a;
+
+    osh_transport_profile_merge(NULL, &a); /* must not crash */
+    osh_transport_profile_merge(&a, NULL); /* must not modify a */
+    osh_transport_profile_merge(NULL, NULL);
+    assert_profile_equal(&a, &snapshot);
+}
+
+int main(void) {
+    test_merge_into_zero();
+    test_merge_sums();
+    test_merge_total_max();
+    test_merge_commutative();
+    test_merge_null();
+    printf("All osh_transport_profile_merge tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## What & why

Closes #167. Follow-up to the parallelism groundwork (#161 / PR #162) and the per-worker-state series #165 (beam cursor) / #166 (deposit target) / #185 (crossing scratch, PR #186).

`run_history_range()` and `osh_transport_ion_step()` accumulated phase timers and event counters into a single shared `transport_ctx->profile` with `+=` / `++` on the hot path (`prof->iterations++`, `prof->step_s += …`, `prof->nuclear_events++`, …). If multiple workers shared one transport context, those read-modify-writes would race: lost counter updates, torn timings, ThreadSanitizer failures. Unlike the deposit-path blockers, this is **diagnostics only** — but it is the last piece of shared-mutable hot-path state, and `#161` lists it as a Phase-1c prerequisite that must be resolved before the threaded driver is enabled (or TSan will flag it).

This closes that gap so every hot-path mutation goes through per-worker state.

## How

Mirror the private-then-merge pattern used for scoring accumulators (#159):

- **Carry the profile on `osh_worker_context`.** The worker accumulates into its own instance, never a shared one. `osh_transport_ion_step()` now takes the profile as an explicit parameter instead of reaching through `transport_ctx->profile`, so the read-only-shared-context contract holds for the whole hot path.
- **`transport_ctx->profile` becomes the master/destination** — written by a worker (the serial worker points its own profile here) or by the driver merging per-worker profiles, never on the hot path through that pointer. The serial worker points its profile straight at the master, so the hot path stays allocation-free and the values are **bit-identical** to before; no merge in the single-worker path (consistent with how `master_accumulators` / `master_scratch` are passed directly in serial).
- **Add `osh_transport_profile_merge()`** (the reduce the parallel driver will use): counters and per-phase `*_s` sum as aggregate work-in-phase (their sum can exceed wall time — that's the parallel-efficiency signal); `total_s` combines by **maximum**, since concurrent workers overlap in wall-clock time. Merging one worker into a zeroed destination reproduces it exactly. Documented in the struct docstring, `DEVELOPER.md`, and a unit test.

No physics change.

## Acceptance criteria (from #167)

- [x] `run_history_range()` no longer writes to a profile shared between workers; each worker accumulates into private profile state (`wctx->profile`, threaded into `osh_transport_ion_step()`).
- [x] `osh_transport_profile_merge()` added with a unit test (additive counters sum; `total_s` max; verified against hand-computed totals).
- [x] Serial path: single-worker profile output is bit-identical to today (the lone worker writes the master directly).
- [ ] Threaded `-fsanitize=thread` validation — deferred until the threaded driver lands (verified by construction + serial bit-identity for now, per the issue: this race is latent until threads are enabled).
- [x] Profile `*_s` vs. wall-clock threaded semantics documented (struct docstring + DEVELOPER.md): `*_s`/counters summed as aggregate work, `total_s` combined by maximum.

## Testing

`cmake --preset debug && ctest` — `test_osh_transport_profile_merge`, all `cases::*` (mesh + cyl), `bench::profile_bit_identity`, and `bench::capacity_invariance` pass. The only failing tests (`version_components_in_string`, the DICOM cases) are pre-existing and unrelated — confirmed they fail identically on the base branch without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzmNWB6jJ4U8sJmiVFjosH)_