### PR TITLE
scoring: settle variance representation & make accumulator merge representation-aware

### DIFF
--- a/docs/dev/scoring.md
+++ b/docs/dev/scoring.md
@@ -33,10 +33,11 @@ The accumulator arrays are:
 
 | Array | Meaning |
 |---|---|
-| `data` | Primary accumulator (always allocated). |
+| `data` | Primary accumulator (always allocated): running sum of per-history deposits Σx per bin. |
 | `data2` | Secondary weight accumulator for two-pass averages (D/T-LET, D/T-Qeff); `NULL` for simple scorers. |
-| `data_var`, `data2_var` | Running sum-of-squares for variance; `NULL` until the variance feature wires them. |
+| `data_var`, `data2_var` | Welford **M2** (sum of squared deviations from the mean) for `data` / `data2`; `NULL` until the variance feature wires them. See §3. |
 | `len` | Element count of every allocated array. |
+| `weight`, `nbatch` | Per-accumulator scalars: statistical weight `W` (history count) and number of batches `B` folded in. See §3. |
 
 Bins are row-major (`idx = ix + nx*(iy + ny*iz)`), with differential axes
 appended as outer strides.
@@ -77,7 +78,78 @@ each page simply owns one accumulator inline and no merge happens.
 See [issue #161](https://github.com/openshieldhit/openshieldhit/issues/161) for
 the parallelism roadmap these seams unblock.
 
-## 3. Output formats: normalisation and multi-run merging
+## 3. Uncertainty: batch-means variance and the merge contract
+
+Monte-Carlo results need an error bar, and the representation chosen for it is
+what the merge above must compute. OpenShieldHIT uses a **batch-means** estimate
+(decision recorded in
+[issue #169](https://github.com/openshieldhit/openshieldhit/issues/169)).
+
+### Why batch-means (not per-history)
+
+The textbook MC uncertainty is the variance of the per-primary mean over
+**independent histories**. Computing it exactly needs each history's complete
+per-bin tally before squaring — an `nbins × live-histories` scratch buffer, which
+is prohibitive for the wavefront/pool transport (many histories are in flight at
+once, depositing per step). So instead a **batch** — one independent unit of work
+— is treated as a single observation, and the spread *between batches* estimates
+the error. A batch is any of:
+
+- a parallel worker's history range (threads / MPI ranks),
+- a periodic partial-dump interval (see the run-control work, #170),
+- an internal sub-split of a single serial run,
+- a separate independent run.
+
+Because every bin is exposed to the **same** set of histories (most depositing
+zero), the observation count is identical across bins — so the batch weight `W`
+and batch count `B` are **per-accumulator scalars** (`weight`, `nbatch`), not
+per-bin arrays. The only per-bin variance state is one extra array, the Welford
+**M2** (`data_var`), reusing the scaffold already present.
+
+### Representation and the merge contract
+
+Per bin the accumulator stores the running sum `data` (= Σx) and the Welford
+`M2` (`data_var`); the per-primary mean is `data / weight`. Two batches are
+combined with the numerically-stable parallel formula of
+**Schubert & Gertz (2018)** (the single-batch fold is the weighted update of
+**West (1979)**):
+
+```
+w  = wA + wB
+δ  = meanB − meanA            (means = data/weight)
+M2 = M2_A + M2_B + δ² · wA·wB / w      ← the cross-term a plain += cannot express
+data, data2, weight, nbatch  → additive
+```
+
+`osh_scoring_accumulator_merge()` applies exactly this: the raw sums and the
+batch bookkeeping are additive, but the M2 arrays use the cross-term. A blanket
+`+=` over `data_var` would silently drop `δ²·wA·wB/w` and corrupt the variance —
+the reason the merge is representation-aware rather than a flat element-wise add.
+The `wA·wB/w` weighting handles **unequal-size batches by construction**, which
+is the normal case under heterogeneous CPU cores and arbitrary dump boundaries.
+
+### Degrees of freedom and finalisation
+
+At save time the standard error of the per-primary mean in a bin is
+
+```
+SE = sqrt( M2 / ((nbatch − 1) · weight) )
+```
+
+so a single batch (`nbatch == 1`, e.g. a plain serial run with no sub-splitting)
+has **zero degrees of freedom and no error estimate** — at least two batches are
+required. This finalisation, and the deposit-side writes into `data_var`, are the
+*variance feature* itself, still unwired; this section and the merge define the
+**contract** the feature will plug into, so wiring it is a local change, not a
+representation hunt.
+
+> **MPI / GPU note.** The additive fields can ride `MPI_Reduce(MPI_SUM)`, but the
+> M2 arrays cannot — a rank reduction needs a custom `MPI_Op_create` that applies
+> the same combine to the whole accumulator (sums + weight + M2 together). On GPU,
+> per-worker private accumulators reduced on the host with this same merge avoid
+> needing float atomics entirely.
+
+## 4. Output formats: normalisation and multi-run merging
 
 `osh_scoring_save()` dispatches on each output's `fileformat`. The two
 general-purpose formats take deliberately different positions on normalisation;
@@ -121,7 +193,7 @@ layer), replaces the pixel data with scored values normalised by `nstat` and
 preserved unchanged. Only single-page (single-quantity) outputs are supported;
 multi-page output returns `OSH_ENOTSUP`.
 
-## 4. Unit handling and post-processing
+## 5. Unit handling and post-processing
 
 `osh_scoring_postprocess()` applies physics transforms once per bin before
 saving:
@@ -142,7 +214,7 @@ After post-processing, page buffers are in one of these states:
 because `data2` is discarded at post-process; merging requires re-weighting by
 each file's `nstat`.
 
-## 5. Lifecycle and module boundaries
+## 6. Lifecycle and module boundaries
 
 ```
 osh_scoring_workspace_create()   allocate cold workspace

--- a/docs/dev/scoring.md
+++ b/docs/dev/scoring.md
@@ -1,10 +1,8 @@
 # Scoring in OpenShieldHIT
 
-This page documents the scoring layer (`src/scoring/`): how cold detector and
-filter definitions are compiled into runtime **accumulators**, how transport
-deposits into them, how results are normalised and post-processed, and how the
-accumulator / deposit / merge seams make history-level parallelism a small,
-local change rather than a rewrite.
+This page documents the scoring layer (`src/scoring/`): the structures that hold
+tallied results, how transport writes into them, how per-worker results combine
+for parallelism, and how results are normalised, post-processed, and saved.
 
 It complements the short orientation README next to the code
 (`src/scoring/README.md`) — start there for the file map.
@@ -18,16 +16,58 @@ It complements the short orientation README next to the code
 
 ---
 
-## 1. Pages, accumulators, and the deposit seam
+## 1. Overview: the data hierarchy, and "cold" vs "hot"
 
-Compilation (`osh_scoring_compile()`) turns each scored quantity into a
-**page**. A page is split into two parts on purpose:
+A single OpenShieldHIT run produces one or more **outputs**, each written to its
+own file. Within an output are one or more **pages**:
 
-- The **descriptor** (`struct osh_scoring_page_runtime`) — geometry indices,
-  bin strides, differential-axis configuration, scorer kind. Read-only during
-  transport.
-- The **accumulator** (`struct osh_scoring_accumulator`, embedded as
-  `page->acc`) — the mutable, per-history storage.
+```
+run ─┬─ output (file) ─┬─ page  (quantity + particle filters, over a shared geometry)
+     │                 ├─ page
+     │                 └─ …
+     ├─ output (file) ─── page
+     └─ …
+```
+
+All pages of an output share the same **scorer geometry** — the binning grid,
+e.g. a 100×1×1 mesh along depth, or a cylindrical R×Z grid. A page then picks
+*which physical quantity* it tallies (dose, fluence, LET, …) and *which particles
+count* (filters on charge, generation, …). Some pages also carry a
+**differential axis** — for example dose *as a function of energy* — which
+multiplies the bin count by the number of differential bins; such a page has a
+higher dimensionality than its plain siblings (one or two differential axes are
+supported).
+
+The code runs in two phases, at two "temperatures":
+
+- **Cold** code runs once at setup. It parses the user's detector and filter
+  definitions and *compiles* them into runtime structures. Clarity matters here,
+  speed does not.
+- **Hot** code runs inside the transport loop, once per particle step — millions
+  to billions of times per run. This is where scoring writes results. Every
+  instruction counts.
+
+Three terms used throughout:
+
+- A **tally** is the running total a bin holds: the sum of every contribution
+  written into it so far.
+- A **deposit** is one such contribution (e.g. the energy a single step leaves in
+  a voxel). Depositing is the hot-path write.
+- An **accumulator** is the block of storage holding one page's tallies.
+
+`osh_scoring_compile()` is the cold step that turns each scored quantity into a
+page. The rest of this document follows a page from compilation, through
+hot-path deposits, optional parallel merge, post-processing, and save.
+
+## 2. Pages and accumulators
+
+A page is split into two parts on purpose:
+
+- The **descriptor** (`struct osh_scoring_page_runtime`) — geometry indices, bin
+  strides, differential-axis configuration, scorer kind. Read-only during
+  transport (cold data consumed on the hot path).
+- The **accumulator** (`struct osh_scoring_accumulator`, embedded as `page->acc`)
+  — the mutable, per-history storage written by deposits.
 
 The accumulator arrays are:
 
@@ -35,14 +75,16 @@ The accumulator arrays are:
 |---|---|
 | `data` | Primary accumulator (always allocated): running sum of per-history deposits Σx per bin. |
 | `data2` | Secondary weight accumulator for two-pass averages (D/T-LET, D/T-Qeff); `NULL` for simple scorers. |
-| `data_var`, `data2_var` | Welford **M2** (sum of squared deviations from the mean) for `data` / `data2`; `NULL` until the variance feature wires them. See §3. |
+| `data_var`, `data2_var` | Welford **M2** (sum of squared deviations from the mean) for `data` / `data2`; `NULL` until the variance feature wires them. See §4. |
 | `len` | Element count of every allocated array. |
-| `weight`, `nbatch` | Per-accumulator scalars: statistical weight `W` (history count) and number of batches `B` folded in. See §3. |
+| `weight`, `nbatch` | Per-accumulator scalars: statistical weight `W` (history count) and number of batches `B` folded in. See §4. |
 
 Bins are row-major (`idx = ix + nx*(iy + ny*iz)`), with differential axes
 appended as outer strides.
 
-Every tally goes through one inline seam:
+Every deposit funnels through one tiny inline function. We call this a **seam**:
+a single point all writes pass through, so the write *policy* can be changed in
+one place instead of at every call site.
 
 ```c
 static inline void osh_score_deposit(double *arr, size_t idx, double value) {
@@ -51,39 +93,59 @@ static inline void osh_score_deposit(double *arr, size_t idx, double value) {
 ```
 
 Today it inlines to a plain array store (zero overhead). Concentrating all
-deposits here means a future parallel backend can swap in an atomic fetch-add,
-a per-worker private store, or a locked update without touching any hot-path
-call site.
+deposits here means a future parallel backend can swap in an atomic fetch-add, a
+per-worker private store, or a locked update without touching any hot-path call
+site.
 
-## 2. Why storage is separate from the descriptor (parallel scoring)
+## 3. Private accumulators and merging (parallel scoring)
 
-Giving the per-history-written storage its own identity makes the accumulator
-the unit a parallel worker can own **privately**: each worker scores its
-assigned histories into a private accumulator set, then folds them into the
-master with a single reduce:
+Giving the per-history-written storage its own identity (separate from the
+read-only descriptor) makes the accumulator the unit a parallel worker can own
+**privately**: each worker scores its assigned histories into a private
+accumulator set, then folds them into the master with a single reduce:
 
 ```c
 enum osh_status
 osh_scoring_accumulator_merge(struct osh_scoring_accumulator *dst,
                               struct osh_scoring_accumulator const *src);
-/* dst += src, element-wise over data / data2 / data_var / data2_var */
+/* dst ⊕ src: sums add element-wise; variance state combines (§4). */
 ```
 
 Because Monte Carlo histories are independent and the deposits commute, merging
 in any order yields the same totals (up to floating-point summation order). The
-same primitive serves threads (join then merge), MPI (`MPI_Reduce(MPI_SUM)`),
-and — eventually — GPU block reductions. In the current single-worker build
-each page simply owns one accumulator inline and no merge happens.
+same primitive serves threads (join then merge), MPI (`MPI_Reduce` on the raw
+sums), and — eventually — GPU block reductions. In the current single-worker
+build each page simply owns one accumulator inline and no merge happens.
 
 See [issue #161](https://github.com/openshieldhit/openshieldhit/issues/161) for
-the parallelism roadmap these seams unblock.
+the parallelism roadmap this descriptor/storage split unblocks.
 
-## 3. Uncertainty: batch-means variance and the merge contract
+## 4. Statistical uncertainty
 
-Monte-Carlo results need an error bar, and the representation chosen for it is
-what the merge above must compute. OpenShieldHIT uses a **batch-means** estimate
-(decision recorded in
-[issue #169](https://github.com/openshieldhit/openshieldhit/issues/169)).
+A Monte Carlo result needs an error bar. The representation chosen for it is what
+the merge in §3 must compute, so the two are designed together (decision recorded
+in [issue #169](https://github.com/openshieldhit/openshieldhit/issues/169)).
+
+### Background: online (running) variance
+
+Computing a variance the textbook way needs every sample in memory: take the
+mean, then sum the squared deviations. **Welford's online algorithm**
+(Welford, 1962) avoids storing samples: it keeps only a running count, a running
+mean, and **M2** — the running *sum of squared deviations from the current mean*
+— and updates all three with each new sample in a single pass. The variance is
+then `M2 / (n − 1)`. So whenever this document says **M2**, it means that one
+running quantity from Welford's method.
+
+Two extensions make it fit a parallel Monte Carlo:
+
+- **West (1979)** generalised the update to *weighted* samples — each sample
+  carries a weight, not just an implicit count of one.
+- **Schubert & Gertz (2018)** gave the numerically stable rule for **combining
+  two independently-accumulated partials** — two `(weight, mean, M2)` results —
+  into one. That is exactly a parallel reduction.
+
+OpenShieldHIT stores `M2` per bin (in `data_var`) and combines partials with the
+Schubert–Gertz formula below.
 
 ### Why batch-means (not per-history)
 
@@ -92,8 +154,8 @@ The textbook MC uncertainty is the variance of the per-primary mean over
 per-bin tally before squaring — an `nbins × live-histories` scratch buffer, which
 is prohibitive for the wavefront/pool transport (many histories are in flight at
 once, depositing per step). So instead a **batch** — one independent unit of work
-— is treated as a single observation, and the spread *between batches* estimates
-the error. A batch is any of:
+— is treated as a single (weighted) observation, and the spread *between batches*
+estimates the error. A batch is any of:
 
 - a parallel worker's history range (threads / MPI ranks),
 - a periodic partial-dump interval (see the run-control work, #170),
@@ -104,29 +166,28 @@ Because every bin is exposed to the **same** set of histories (most depositing
 zero), the observation count is identical across bins — so the batch weight `W`
 and batch count `B` are **per-accumulator scalars** (`weight`, `nbatch`), not
 per-bin arrays. The only per-bin variance state is one extra array, the Welford
-**M2** (`data_var`), reusing the scaffold already present.
+`M2` (`data_var`).
 
-### Representation and the merge contract
+### The merge contract
 
 Per bin the accumulator stores the running sum `data` (= Σx) and the Welford
-`M2` (`data_var`); the per-primary mean is `data / weight`. Two batches are
-combined with the numerically-stable parallel formula of
-**Schubert & Gertz (2018)** (the single-batch fold is the weighted update of
-**West (1979)**):
+`M2` (`data_var`); the per-primary mean is `data / weight`. Two batches A and B
+combine with the Schubert–Gertz formula (the single-batch fold is West's weighted
+update with one observation):
 
 ```
 w  = wA + wB
-δ  = meanB − meanA            (means = data/weight)
+δ  = meanB − meanA            (means = data / weight)
 M2 = M2_A + M2_B + δ² · wA·wB / w      ← the cross-term a plain += cannot express
 data, data2, weight, nbatch  → additive
 ```
 
 `osh_scoring_accumulator_merge()` applies exactly this: the raw sums and the
-batch bookkeeping are additive, but the M2 arrays use the cross-term. A blanket
+batch bookkeeping are additive, but the `M2` arrays use the cross-term. A blanket
 `+=` over `data_var` would silently drop `δ²·wA·wB/w` and corrupt the variance —
 the reason the merge is representation-aware rather than a flat element-wise add.
-The `wA·wB/w` weighting handles **unequal-size batches by construction**, which
-is the normal case under heterogeneous CPU cores and arbitrary dump boundaries.
+The `wA·wB/w` weighting handles **unequal-size batches by construction**, which is
+the normal case under heterogeneous CPU cores and arbitrary dump boundaries.
 
 ### Degrees of freedom and finalisation
 
@@ -140,16 +201,16 @@ so a single batch (`nbatch == 1`, e.g. a plain serial run with no sub-splitting)
 has **zero degrees of freedom and no error estimate** — at least two batches are
 required. This finalisation, and the deposit-side writes into `data_var`, are the
 *variance feature* itself, still unwired; this section and the merge define the
-**contract** the feature will plug into, so wiring it is a local change, not a
-representation hunt.
+**contract** the feature will plug into, so wiring it later is a local change, not
+a representation hunt.
 
 > **MPI / GPU note.** The additive fields can ride `MPI_Reduce(MPI_SUM)`, but the
-> M2 arrays cannot — a rank reduction needs a custom `MPI_Op_create` that applies
-> the same combine to the whole accumulator (sums + weight + M2 together). On GPU,
-> per-worker private accumulators reduced on the host with this same merge avoid
-> needing float atomics entirely.
+> `M2` arrays cannot — a rank reduction needs a custom `MPI_Op_create` that
+> applies the combine above to the whole accumulator (sums + weight + M2
+> together). On GPU, per-worker private accumulators reduced on the host with this
+> same merge avoid needing float atomics entirely.
 
-## 4. Output formats: normalisation and multi-run merging
+## 5. Output formats: normalisation and multi-run merging
 
 `osh_scoring_save()` dispatches on each output's `fileformat`. The two
 general-purpose formats take deliberately different positions on normalisation;
@@ -171,7 +232,7 @@ accumulated** (raw sums) and the primary count is embedded as the
 supports two merging paths:
 
 1. **Native multi-worker** (future): each worker accumulates into its own
-   accumulator set, the simulation layer merges them (§2), and one BDO file is
+   accumulator set, the simulation layer merges them (§3), and one BDO file is
    written with the total `nstat`.
 2. **Embarrassingly-parallel / multi-node**: independent runs each emit a
    `.bdo`, and a merge tool weights per scorer kind using each file's `nstat`:
@@ -193,7 +254,7 @@ layer), replaces the pixel data with scored values normalised by `nstat` and
 preserved unchanged. Only single-page (single-quantity) outputs are supported;
 multi-page output returns `OSH_ENOTSUP`.
 
-## 5. Unit handling and post-processing
+## 6. Unit handling and post-processing
 
 `osh_scoring_postprocess()` applies physics transforms once per bin before
 saving:
@@ -214,7 +275,7 @@ After post-processing, page buffers are in one of these states:
 because `data2` is discarded at post-process; merging requires re-weighting by
 each file's `nstat`.
 
-## 6. Lifecycle and module boundaries
+## 7. Lifecycle and module boundaries
 
 ```
 osh_scoring_workspace_create()   allocate cold workspace
@@ -238,3 +299,16 @@ Boundaries:
 - Parsed scoring definitions stay separate from runtime scoring buffers.
 - Save / output code consumes the scoring workspace plus scoring runtime, not
   transport internals.
+
+## References
+
+- Welford, B. P. (1962). Note on a method for calculating corrected sums of
+  squares and products. *Technometrics* 4(3), 419–420.
+  doi:[10.1080/00401706.1962.10490022](https://doi.org/10.1080/00401706.1962.10490022)
+- West, D. H. D. (1979). Updating mean and variance estimates: an improved
+  method. *Communications of the ACM* 22(9), 532–535.
+  doi:[10.1145/359146.359153](https://doi.org/10.1145/359146.359153)
+- Schubert, E. & Gertz, M. (2018). Numerically stable parallel computation of
+  (co-)variance. *Proc. 30th Int. Conf. on Scientific and Statistical Database
+  Management (SSDBM '18)*, Article 10, 1–12.
+  doi:[10.1145/3221269.3223036](https://doi.org/10.1145/3221269.3223036)

--- a/docs/user/beam.dat.md
+++ b/docs/user/beam.dat.md
@@ -335,7 +335,7 @@ independent runs — the standard approach for Monte Carlo uncertainty estimatio
     random stream is a pure function of its global index, splitting the work into
     batches (across threads, dumps, or runs) does not bias the result — only the
     error estimate it makes possible.  The developer reference in
-    `docs/dev/scoring.md` (§3) documents the batch-means representation and the
+    `docs/dev/scoring.md` (§4) documents the batch-means representation and the
     numerically-stable parallel merge.
 
 ---

--- a/docs/user/beam.dat.md
+++ b/docs/user/beam.dat.md
@@ -326,6 +326,18 @@ Random number generator seed (integer).  Fixing the seed makes a run
 bit-for-bit reproducible.  Using different seeds produces statistically
 independent runs — the standard approach for Monte Carlo uncertainty estimation.
 
+!!! note "How statistical uncertainty is estimated"
+    OpenShieldHIT estimates the error bar on each scored bin from the spread
+    **between batches**, where a batch is one independent unit of work — a
+    parallel worker, a periodic intermediate dump, an internal sub-split of a
+    run, or a separate run with a different `RNDSEED`.  A single batch therefore
+    has **no error estimate**: at least two are needed.  Because each history's
+    random stream is a pure function of its global index, splitting the work into
+    batches (across threads, dumps, or runs) does not bias the result — only the
+    error estimate it makes possible.  The developer reference in
+    `docs/dev/scoring.md` (§3) documents the batch-means representation and the
+    numerically-stable parallel merge.
+
 ---
 
 ## Beam mode modifiers (advanced)

--- a/src/scoring/runtime/osh_scoring_accumulator.c
+++ b/src/scoring/runtime/osh_scoring_accumulator.c
@@ -94,10 +94,10 @@ static void merge_array(double *dst_arr, double const *src_arr, size_t len) {
 }
 
 /*
- * Schubert & Gertz (2018) numerically-stable parallel merge of two Welford M2
- * arrays, in place: dst_m2 becomes the combined M2 of batch A (dst_*, holding
- * running sum dst_sum and weight dst_w) and batch B (src_*).  Per-bin means are
- * derived as sum/weight; the weights are the batches' history counts.
+ * Numerically-stable parallel merge of two Welford M2 arrays, in place: dst_m2
+ * becomes the combined M2 of batch A (dst_*, holding running sum dst_sum and
+ * weight dst_w) and batch B (src_*).  Per-bin means are derived as sum/weight;
+ * the weights are the batches' history counts.
  *
  *   M2 = M2_A + M2_B + (mean_B − mean_A)² · w_A·w_B / (w_A + w_B)
  *
@@ -105,6 +105,10 @@ static void merge_array(double *dst_arr, double const *src_arr, size_t len) {
  * silently corrupts the variance.  This must run before the additive fields
  * (dst_sum / dst_w) are folded, since it reads dst's pre-merge values.  Empty
  * batches act as the identity.
+ *
+ * M2 is the running sum-of-squared-deviations of Welford's online variance
+ * (Welford 1962); the weighted form is West (1979); the pairwise combine below is
+ * Schubert & Gertz (2018).  Full citations in osh_scoring_accumulator.h.
  */
 static void merge_m2(double *dst_m2,
                      double const *dst_sum,

--- a/src/scoring/runtime/osh_scoring_accumulator.c
+++ b/src/scoring/runtime/osh_scoring_accumulator.c
@@ -15,6 +15,8 @@ enum osh_status osh_scoring_accumulator_alloc(struct osh_scoring_accumulator *ac
     acc->data_var = NULL;
     acc->data2_var = NULL;
     acc->len = len;
+    acc->weight = 0.0;
+    acc->nbatch = 0u;
 
     acc->data = (double *) calloc(n, sizeof(*acc->data));
     if (!acc->data) {
@@ -37,6 +39,8 @@ void osh_scoring_accumulator_zero(struct osh_scoring_accumulator *acc) {
     if (!acc || acc->len == 0u) {
         return;
     }
+    acc->weight = 0.0; /* a zeroed accumulator represents no batches yet */
+    acc->nbatch = 0u;
     if (acc->data) {
         memset(acc->data, 0, acc->len * sizeof(*acc->data));
     }
@@ -83,6 +87,50 @@ static void merge_array(double *dst_arr, double const *src_arr, size_t len) {
     }
 }
 
+/*
+ * Schubert & Gertz (2018) numerically-stable parallel merge of two Welford M2
+ * arrays, in place: dst_m2 becomes the combined M2 of batch A (dst_*, holding
+ * running sum dst_sum and weight dst_w) and batch B (src_*).  Per-bin means are
+ * derived as sum/weight; the weights are the batches' history counts.
+ *
+ *   M2 = M2_A + M2_B + (mean_B − mean_A)² · w_A·w_B / (w_A + w_B)
+ *
+ * The cross-term is what a plain element-wise += cannot express; dropping it
+ * silently corrupts the variance.  This must run before the additive fields
+ * (dst_sum / dst_w) are folded, since it reads dst's pre-merge values.  Empty
+ * batches act as the identity.
+ */
+static void merge_m2(double *dst_m2,
+                     double const *dst_sum,
+                     double dst_w,
+                     double const *src_m2,
+                     double const *src_sum,
+                     double src_w,
+                     size_t len) {
+    size_t i;
+    double w;
+    if (!dst_m2 || !src_m2 || !dst_sum || !src_sum) {
+        return;
+    }
+    if (src_w == 0.0) {
+        return; /* B empty: A unchanged */
+    }
+    if (dst_w == 0.0) {
+        /* A empty: the combined batch is B. */
+        for (i = 0; i < len; ++i) {
+            dst_m2[i] = src_m2[i];
+        }
+        return;
+    }
+    w = dst_w + src_w;
+    for (i = 0; i < len; ++i) {
+        double const mean_a = dst_sum[i] / dst_w;
+        double const mean_b = src_sum[i] / src_w;
+        double const delta = mean_b - mean_a;
+        dst_m2[i] += src_m2[i] + delta * delta * (dst_w * src_w / w);
+    }
+}
+
 enum osh_status osh_scoring_accumulator_merge(struct osh_scoring_accumulator *dst,
                                               struct osh_scoring_accumulator const *src) {
     if (!dst || !src) {
@@ -99,10 +147,19 @@ enum osh_status osh_scoring_accumulator_merge(struct osh_scoring_accumulator *ds
         || ((dst->data2_var == NULL) != (src->data2_var == NULL))) {
         return OSH_EINVAL;
     }
+    /* Variance (Welford M2) arrays first — they need dst's pre-merge sums and
+     * weight to form the Schubert-Gertz cross-term.  data_var pairs with data,
+     * data2_var with data2; both use the per-accumulator history weight.  NULL
+     * variance arrays (the current default) make these no-ops, leaving the plain
+     * additive reduction over data / data2. */
+    merge_m2(dst->data_var, dst->data, dst->weight, src->data_var, src->data, src->weight, dst->len);
+    merge_m2(dst->data2_var, dst->data2, dst->weight, src->data2_var, src->data2, src->weight, dst->len);
+
+    /* Additive fields: raw sums and the batch bookkeeping. */
     merge_array(dst->data, src->data, dst->len);
     merge_array(dst->data2, src->data2, dst->len);
-    merge_array(dst->data_var, src->data_var, dst->len);
-    merge_array(dst->data2_var, src->data2_var, dst->len);
+    dst->weight += src->weight;
+    dst->nbatch += src->nbatch;
     return OSH_OK;
 }
 
@@ -119,4 +176,6 @@ void osh_scoring_accumulator_free(struct osh_scoring_accumulator *acc) {
     acc->data_var = NULL;
     acc->data2_var = NULL;
     acc->len = 0u;
+    acc->weight = 0.0;
+    acc->nbatch = 0u;
 }

--- a/src/scoring/runtime/osh_scoring_accumulator.c
+++ b/src/scoring/runtime/osh_scoring_accumulator.c
@@ -172,10 +172,14 @@ enum osh_status osh_scoring_accumulator_merge(struct osh_scoring_accumulator *ds
     if (dst->len != src->len) {
         return OSH_EINVAL;
     }
+    /* data is documented as always allocated; a NULL here means freed/uninitialised. */
+    if (!dst->data || !src->data) {
+        return OSH_EINVAL;
+    }
     /* Reject mismatched optional-array presence: an array allocated on one side
      * but NULL on the other would silently drop tallies.  Accumulators cloned
      * from the same page descriptor always agree, so disagreement is a bug. */
-    if (((dst->data == NULL) != (src->data == NULL)) || ((dst->data2 == NULL) != (src->data2 == NULL))
+    if (((dst->data2 == NULL) != (src->data2 == NULL))
         || ((dst->data_var == NULL) != (src->data_var == NULL))
         || ((dst->data2_var == NULL) != (src->data2_var == NULL))) {
         return OSH_EINVAL;

--- a/src/scoring/runtime/osh_scoring_accumulator.c
+++ b/src/scoring/runtime/osh_scoring_accumulator.c
@@ -179,8 +179,7 @@ enum osh_status osh_scoring_accumulator_merge(struct osh_scoring_accumulator *ds
     /* Reject mismatched optional-array presence: an array allocated on one side
      * but NULL on the other would silently drop tallies.  Accumulators cloned
      * from the same page descriptor always agree, so disagreement is a bug. */
-    if (((dst->data2 == NULL) != (src->data2 == NULL))
-        || ((dst->data_var == NULL) != (src->data_var == NULL))
+    if (((dst->data2 == NULL) != (src->data2 == NULL)) || ((dst->data_var == NULL) != (src->data_var == NULL))
         || ((dst->data2_var == NULL) != (src->data2_var == NULL))) {
         return OSH_EINVAL;
     }

--- a/src/scoring/runtime/osh_scoring_accumulator.c
+++ b/src/scoring/runtime/osh_scoring_accumulator.c
@@ -36,11 +36,17 @@ enum osh_status osh_scoring_accumulator_alloc(struct osh_scoring_accumulator *ac
 }
 
 void osh_scoring_accumulator_zero(struct osh_scoring_accumulator *acc) {
-    if (!acc || acc->len == 0u) {
+    if (!acc) {
         return;
     }
-    acc->weight = 0.0; /* a zeroed accumulator represents no batches yet */
+    /* Reset the batch bookkeeping unconditionally: alloc() supports len==0 (it
+     * still allocates one element), so a zeroed accumulator must read as "no
+     * batches yet" even then. */
+    acc->weight = 0.0;
     acc->nbatch = 0u;
+    if (acc->len == 0u) {
+        return;
+    }
     if (acc->data) {
         memset(acc->data, 0, acc->len * sizeof(*acc->data));
     }
@@ -108,7 +114,9 @@ static void merge_m2(double *dst_m2,
                      double src_w,
                      size_t len) {
     size_t i;
-    double w;
+    double inv_dst_w;
+    double inv_src_w;
+    double cross;
     if (!dst_m2 || !src_m2 || !dst_sum || !src_sum) {
         return;
     }
@@ -122,13 +130,34 @@ static void merge_m2(double *dst_m2,
         }
         return;
     }
-    w = dst_w + src_w;
+    /* All three factors are loop-invariant; hoist them so the per-bin work is
+     * multiplies only (no divisions), which matters for large meshes. */
+    inv_dst_w = 1.0 / dst_w;
+    inv_src_w = 1.0 / src_w;
+    cross = dst_w * src_w / (dst_w + src_w);
     for (i = 0; i < len; ++i) {
-        double const mean_a = dst_sum[i] / dst_w;
-        double const mean_b = src_sum[i] / src_w;
+        double const mean_a = dst_sum[i] * inv_dst_w;
+        double const mean_b = src_sum[i] * inv_src_w;
         double const delta = mean_b - mean_a;
-        dst_m2[i] += src_m2[i] + delta * delta * (dst_w * src_w / w);
+        dst_m2[i] += src_m2[i] + delta * delta * cross;
     }
+}
+
+/* A variance-tracking accumulator must be self-consistent, or merge_m2() would
+ * silently short-circuit and produce wrong M2 state: an M2 array needs its
+ * companion sum array (it derives the mean from it), and a batch's weight and
+ * count must agree on emptiness (W == 0 iff B == 0). */
+static int variance_inconsistent(struct osh_scoring_accumulator const *a) {
+    if (a->data_var && !a->data) {
+        return 1;
+    }
+    if (a->data2_var && !a->data2) {
+        return 1;
+    }
+    if ((a->data_var || a->data2_var) && ((a->weight == 0.0) != (a->nbatch == 0u))) {
+        return 1;
+    }
+    return 0;
 }
 
 enum osh_status osh_scoring_accumulator_merge(struct osh_scoring_accumulator *dst,
@@ -145,6 +174,10 @@ enum osh_status osh_scoring_accumulator_merge(struct osh_scoring_accumulator *ds
     if (((dst->data == NULL) != (src->data == NULL)) || ((dst->data2 == NULL) != (src->data2 == NULL))
         || ((dst->data_var == NULL) != (src->data_var == NULL))
         || ((dst->data2_var == NULL) != (src->data2_var == NULL))) {
+        return OSH_EINVAL;
+    }
+    /* Reject inconsistent variance bookkeeping rather than silently mis-merging. */
+    if (variance_inconsistent(dst) || variance_inconsistent(src)) {
         return OSH_EINVAL;
     }
     /* Variance (Welford M2) arrays first — they need dst's pre-merge sums and

--- a/src/scoring/runtime/osh_scoring_accumulator.h
+++ b/src/scoring/runtime/osh_scoring_accumulator.h
@@ -209,7 +209,8 @@ void osh_scoring_accumulator_free(struct osh_scoring_accumulator *acc);
  *
  * @param[in,out] dst  Destination accumulator (must be non-NULL).
  * @param[in]     src  Source accumulator to fold in (must be non-NULL).
- * @returns OSH_OK on success, OSH_EINVAL if either pointer is NULL, the two
+ * @returns OSH_OK on success, OSH_EINVAL if either pointer is NULL, @c data is
+ *          NULL on either side (freed/uninitialised accumulator), the two
  *          accumulators have different @c len, or their optional arrays
  *          (@c data2 / @c data_var / @c data2_var) disagree on presence.
  */

--- a/src/scoring/runtime/osh_scoring_accumulator.h
+++ b/src/scoring/runtime/osh_scoring_accumulator.h
@@ -24,13 +24,54 @@ extern "C" {
  * Array layout matches the page descriptor: row-major spatial bins, with the
  * differential axes appended as outer strides (see osh_scoring_page_runtime).
  *
- *   - @p data      primary accumulator (always allocated).
+ *   - @p data      primary accumulator (always allocated): the running sum of
+ *                  per-history deposits Σx in each bin (additive across batches).
  *   - @p data2     secondary weight accumulator for two-pass averages
  *                  (dose/track-averaged LET and Qeff); NULL for simple scorers.
- *   - @p data_var  running sum-of-squares for @p data variance; NULL until the
- *                  variance (x²/σ) feature allocates it.
- *   - @p data2_var running sum-of-squares for @p data2 variance; NULL until then.
+ *   - @p data_var  Welford M2 (sum of squared deviations from the mean) for the
+ *                  @p data estimator; NULL until the variance feature allocates
+ *                  it.  See "Uncertainty representation" below.
+ *   - @p data2_var Welford M2 for the @p data2 estimator; NULL until then.
  *   - @p len       element count of every allocated array.
+ *   - @p weight    statistical weight (history count W) of the batch these
+ *                  accumulators represent — the Schubert–Gertz merge weight.
+ *   - @p nbatch    number of independent batches folded in so far (B); the
+ *                  degrees of freedom for the error estimate are B − 1.
+ *
+ * @par Uncertainty representation (batch-means, Welford/Schubert–Gertz)
+ * Monte-Carlo uncertainty here is a **batch-means** estimate: a *batch* is one
+ * independent unit of work — a parallel worker's history range, a periodic
+ * partial-dump interval, an internal sub-split of a serial run, or a separate
+ * run — and each batch is treated as a single weighted observation of the
+ * per-primary mean @c data/@c weight.  True per-history variance would need an
+ * @c nbins × live-histories scratch buffer (prohibitive for the wavefront
+ * design), so the spread *between batches* is the estimator instead.  This is
+ * why @p weight / @p nbatch are per-accumulator scalars, not per-bin arrays:
+ * every bin is exposed to the same set of histories (most depositing zero), so
+ * the observation count is identical across bins.
+ *
+ * The variance state is combined with the numerically-stable parallel formula of
+ * Schubert & Gertz (2018): merging batch A (weight @c wA, mean @c mA, M2 @c M2A)
+ * with batch B yields
+ *
+ *   w  = wA + wB
+ *   δ  = mB − mA                       (means derived as data/weight)
+ *   M2 = M2A + M2B + δ² · wA·wB / w
+ *
+ * The δ²·wA·wB/w cross-term is exactly what a plain element-wise @c += cannot
+ * express, and it handles **unequal-size batches by construction** — the normal
+ * case under heterogeneous CPU cores and arbitrary dump boundaries.  @p data and
+ * @p data2 (raw sums) and @p weight / @p nbatch stay additive; only the M2 arrays
+ * use the cross-term.  Folding a brand-new batch (one observation, M2 = 0) is the
+ * single-observation special case, equivalent to West's (1979) weighted update.
+ *
+ * A single batch (B = 1, e.g. a plain serial run with no sub-splitting) has zero
+ * degrees of freedom and therefore no error estimate — at least two batches
+ * (threads, dumps, sub-splits, or independent runs) are required.  At finalize
+ * time the standard error of the per-primary mean in a bin is
+ * @c sqrt(M2 / ((nbatch − 1) · weight)); this conversion lives in the (not-yet-
+ * wired) variance feature, not here — this struct stores only the sufficient
+ * statistics and the merge contract that combines them.
  */
 struct osh_scoring_accumulator {
     double *data;
@@ -38,6 +79,8 @@ struct osh_scoring_accumulator {
     double *data_var;
     double *data2_var;
     size_t len;
+    double weight;             /* Σ history weight (W) of the batches folded in; 0 when variance inactive. */
+    unsigned long long nbatch; /* Number of batches folded in (B); error-estimate dof is B − 1. */
 };
 
 /**
@@ -120,23 +163,41 @@ enum osh_status osh_scoring_accumulator_finalize_average(struct osh_scoring_accu
 void osh_scoring_accumulator_free(struct osh_scoring_accumulator *acc);
 
 /**
- * @brief Element-wise reduce: @p dst += @p src over every array.
+ * @brief Reduce @p src into @p dst: combine two batches' statistics.
  *
  * @details
  * The reduction at the heart of any parallel scoring scheme: each worker scores
- * its histories into a private accumulator, then the master set is formed by
- * merging every worker's set into one.  Because Monte Carlo histories are
- * independent and the deposits commute, merging in any order yields the same
+ * its histories into a private accumulator (one batch), then the master set is
+ * formed by merging every worker's set into one.  Because Monte Carlo histories
+ * are independent and the deposits commute, merging in any order yields the same
  * totals (up to floating-point summation order).
  *
- * Adds @p src into @p dst for @c data, @c data2, @c data_var and @c data2_var.
- * All four arrays must have matching presence between @p dst and @p src: an array
- * allocated on one side but NULL on the other is rejected (OSH_EINVAL) rather than
- * silently dropped, since that would lose the source's tally.  Accumulators
- * compiled from the same page descriptor always agree.
+ * The reduction is **representation-aware**, not a blanket element-wise add:
+ *   - @c data, @c data2 (raw sums) and @c weight, @c nbatch are **additive** —
+ *     @p dst += @p src.
+ *   - @c data_var, @c data2_var hold Welford M2 and are combined with the
+ *     Schubert–Gertz cross-term @c δ²·wA·wB/w (see @ref osh_scoring_accumulator),
+ *     using the pre-merge sums and weights to derive the batch means.  A plain
+ *     @c += over these arrays would silently drop the cross-term and corrupt the
+ *     variance, so it is deliberately *not* used.
+ *
+ * The variance arrays are combined first (they need @p dst's pre-merge @c data /
+ * @c weight), then the additive fields are folded.  Empty batches (@c weight 0)
+ * are handled as the identity.  When the variance arrays are NULL — the current
+ * default, since the variance feature is unwired — the merge reduces to the
+ * familiar additive behaviour over @c data / @c data2.
+ *
+ * All optional arrays must have matching presence between @p dst and @p src: an
+ * array allocated on one side but NULL on the other is rejected (OSH_EINVAL)
+ * rather than silently dropped.  Accumulators compiled from the same page
+ * descriptor always agree.
+ *
+ * @note MPI: the additive fields can ride @c MPI_SUM, but the M2 arrays cannot —
+ *       a rank-level reduction needs a custom @c MPI_Op_create that applies this
+ *       same combine to the whole accumulator (data + weight + M2 together).
  *
  * @param[in,out] dst  Destination accumulator (must be non-NULL).
- * @param[in]     src  Source accumulator to add (must be non-NULL).
+ * @param[in]     src  Source accumulator to fold in (must be non-NULL).
  * @returns OSH_OK on success, OSH_EINVAL if either pointer is NULL, the two
  *          accumulators have different @c len, or their optional arrays
  *          (@c data2 / @c data_var / @c data2_var) disagree on presence.

--- a/src/scoring/runtime/osh_scoring_accumulator.h
+++ b/src/scoring/runtime/osh_scoring_accumulator.h
@@ -50,7 +50,9 @@ extern "C" {
  * every bin is exposed to the same set of histories (most depositing zero), so
  * the observation count is identical across bins.
  *
- * The variance state is combined with the numerically-stable parallel formula of
+ * The per-bin variance state is the **M2** of Welford's online algorithm (the
+ * running sum of squared deviations from the mean; variance = M2/(n−1)).  It is
+ * combined across batches with the numerically-stable parallel formula of
  * Schubert & Gertz (2018): merging batch A (weight @c wA, mean @c mA, M2 @c M2A)
  * with batch B yields
  *
@@ -72,6 +74,15 @@ extern "C" {
  * @c sqrt(M2 / ((nbatch − 1) · weight)); this conversion lives in the (not-yet-
  * wired) variance feature, not here — this struct stores only the sufficient
  * statistics and the merge contract that combines them.
+ *
+ * @par References
+ * Welford BP. Note on a method for calculating corrected sums of squares and
+ * products. Technometrics. 1962;4(3):419-420. doi:10.1080/00401706.1962.10490022
+ * (the online mean/M2 update).
+ * West DHD. Updating mean and variance estimates: an improved method. Commun ACM.
+ * 1979;22(9):532-535. doi:10.1145/359146.359153 (weighted update).
+ * Schubert E, Gertz M. Numerically stable parallel computation of (co-)variance.
+ * SSDBM '18. 2018;Article 10:1-12. doi:10.1145/3221269.3223036 (parallel merge).
  */
 struct osh_scoring_accumulator {
     double *data;

--- a/tests/unit/test_osh_scoring_accumulator_merge.c
+++ b/tests/unit/test_osh_scoring_accumulator_merge.c
@@ -183,7 +183,7 @@ static void test_merge_null(void) {
         ASSERT_TRUE(osh_scoring_accumulator_alloc(&freed_src, 2u, 0) == OSH_OK);
         osh_scoring_accumulator_free(&freed_dst); /* data now NULL */
         osh_scoring_accumulator_free(&freed_src); /* data now NULL */
-        freed_dst.len = 2u; /* restore len so the len-mismatch guard doesn't fire first */
+        freed_dst.len = 2u;                       /* restore len so the len-mismatch guard doesn't fire first */
         freed_src.len = 2u;
 
         ASSERT_TRUE(osh_scoring_accumulator_merge(&freed_dst, &good) == OSH_EINVAL);

--- a/tests/unit/test_osh_scoring_accumulator_merge.c
+++ b/tests/unit/test_osh_scoring_accumulator_merge.c
@@ -13,14 +13,28 @@
  *   test_zero                  — zero() clears every allocated array, keeps len
  *   test_rescale               — rescale() scales data in place, NULL-safe
  *   test_finalize_average      — finalize_average() divides data/data2, guards eps
+ *   test_merge_variance_two_batches        — Welford M2 merge: exact dyadic case
+ *   test_merge_variance_unequal_single_pass — unequal batches match single-pass
+ *                                             weighted M2, order-independent
+ *   test_merge_variance_empty_identity     — a weight-0 batch is the merge identity
  */
 
+#include <math.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "openshieldhit/status.h"
 #include "scoring/runtime/osh_scoring_accumulator.h"
 #include "test_assert.h"
+
+/* Relative-tolerance compare: the Welford/Schubert-Gertz merge divides sums by
+ * weights, so results are bit-exact only for dyadic test vectors; non-dyadic
+ * cases and cross-order comparisons use this. */
+static int approx(double a, double b) {
+    double const d = fabs(a - b);
+    return d <= 1.0e-9 * (1.0 + fabs(b));
+}
 
 /* Bit-exact comparison: the merge only adds, so integer-valued doubles that fit
  * exactly in a double must reproduce exactly regardless of order. */
@@ -252,6 +266,134 @@ static void test_finalize_average(void) {
     osh_scoring_accumulator_free(&nodata2);
 }
 
+/* ---- Variance (Welford M2) merge: Schubert-Gertz cross-term ----------------
+ *
+ * The variance feature is unwired, so osh_scoring_accumulator_alloc() does not
+ * create the M2 arrays.  These tests build single-batch accumulators by hand:
+ * data + a calloc'd data_var (M2 = 0 for one observation), with weight = the
+ * batch's history count and nbatch = 1.  osh_scoring_accumulator_free() releases
+ * data_var, so teardown is the usual free().
+ */
+
+/* Build a one-observation batch: data = per-bin sum, M2 = 0, weight = w. */
+static void make_batch(struct osh_scoring_accumulator *acc, size_t len, double const *data, double weight) {
+    size_t i;
+    ASSERT_TRUE(osh_scoring_accumulator_alloc(acc, len, 0) == OSH_OK);
+    acc->data_var = (double *) calloc(len ? len : 1u, sizeof(double));
+    ASSERT_TRUE(acc->data_var != NULL);
+    for (i = 0; i < len; ++i) {
+        acc->data[i] = data[i];
+    }
+    acc->weight = weight;
+    acc->nbatch = 1u;
+}
+
+/* Two dyadic batches merge to the exact hand-computed M2 and additive fields. */
+static void test_merge_variance_two_batches(void) {
+    struct osh_scoring_accumulator a;
+    struct osh_scoring_accumulator b;
+    double const da[2] = {8.0, 4.0};  /* means 4, 2 at weight 2 */
+    double const db[2] = {16.0, 4.0}; /* means 8, 2 at weight 2 */
+
+    make_batch(&a, 2u, da, 2.0);
+    make_batch(&b, 2u, db, 2.0);
+
+    ASSERT_TRUE(osh_scoring_accumulator_merge(&a, &b) == OSH_OK);
+
+    /* bin0: δ = 8 − 4 = 4, M2 = 4² · (2·2/4) = 16.  bin1: δ = 0, M2 = 0. */
+    ASSERT_TRUE(a.data_var[0] == 16.0);
+    ASSERT_TRUE(a.data_var[1] == 0.0);
+    /* Additive fields. */
+    ASSERT_TRUE(a.data[0] == 24.0);
+    ASSERT_TRUE(a.data[1] == 8.0);
+    ASSERT_TRUE(a.weight == 4.0);
+    ASSERT_TRUE(a.nbatch == 2u);
+
+    osh_scoring_accumulator_free(&a);
+    osh_scoring_accumulator_free(&b);
+}
+
+/* Three unequal-size batches: pairwise merge reproduces the single-pass weighted
+ * M2, and the result is order-independent (within FP tolerance). */
+static void test_merge_variance_unequal_single_pass(void) {
+    struct osh_scoring_accumulator a, b, c;    /* order 1: (a⊕b)⊕c */
+    struct osh_scoring_accumulator a2, b2, c2; /* order 2: (c⊕b)⊕a */
+    /* weights 2,3,5; bin0 means 5,10,1; bin1 means 2,1,1. */
+    double const da[2] = {10.0, 4.0};
+    double const db[2] = {30.0, 3.0};
+    double const dc[2] = {5.0, 5.0};
+    /* Single-pass weighted M2 (hand-computed):
+     *   bin0: M = 45/10 = 4.5; M2 = 2·.25 + 3·30.25 + 5·12.25 = 152.5
+     *   bin1: M = 12/10 = 1.2; M2 = 2·.64 + 3·.04 + 5·.04 = 1.6           */
+    double const expect_m2[2] = {152.5, 1.6};
+
+    make_batch(&a, 2u, da, 2.0);
+    make_batch(&b, 2u, db, 3.0);
+    make_batch(&c, 2u, dc, 5.0);
+    ASSERT_TRUE(osh_scoring_accumulator_merge(&a, &b) == OSH_OK);
+    ASSERT_TRUE(osh_scoring_accumulator_merge(&a, &c) == OSH_OK);
+
+    ASSERT_TRUE(approx(a.data_var[0], expect_m2[0]));
+    ASSERT_TRUE(approx(a.data_var[1], expect_m2[1]));
+    ASSERT_TRUE(a.data[0] == 45.0); /* sums are exact */
+    ASSERT_TRUE(a.weight == 10.0);
+    ASSERT_TRUE(a.nbatch == 3u);
+
+    /* Reverse fold order must agree within tolerance (FP, not bit-exact). */
+    make_batch(&a2, 2u, da, 2.0);
+    make_batch(&b2, 2u, db, 3.0);
+    make_batch(&c2, 2u, dc, 5.0);
+    ASSERT_TRUE(osh_scoring_accumulator_merge(&c2, &b2) == OSH_OK);
+    ASSERT_TRUE(osh_scoring_accumulator_merge(&c2, &a2) == OSH_OK);
+
+    ASSERT_TRUE(approx(c2.data_var[0], a.data_var[0]));
+    ASSERT_TRUE(approx(c2.data_var[1], a.data_var[1]));
+    ASSERT_TRUE(c2.weight == 10.0);
+    ASSERT_TRUE(c2.nbatch == 3u);
+
+    osh_scoring_accumulator_free(&a);
+    osh_scoring_accumulator_free(&b);
+    osh_scoring_accumulator_free(&c);
+    osh_scoring_accumulator_free(&a2);
+    osh_scoring_accumulator_free(&b2);
+    osh_scoring_accumulator_free(&c2);
+}
+
+/* An empty batch (weight 0) is the merge identity in both directions. */
+static void test_merge_variance_empty_identity(void) {
+    struct osh_scoring_accumulator empty;
+    struct osh_scoring_accumulator b;
+    double const zero[2] = {0.0, 0.0};
+    double const db[2] = {30.0, 6.0};
+
+    /* empty ⊕ b  ⇒  empty becomes b. */
+    make_batch(&empty, 2u, zero, 0.0);
+    empty.nbatch = 0u; /* no batches yet */
+    make_batch(&b, 2u, db, 3.0);
+
+    ASSERT_TRUE(osh_scoring_accumulator_merge(&empty, &b) == OSH_OK);
+    ASSERT_TRUE(empty.data_var[0] == 0.0); /* single observation ⇒ M2 still 0 */
+    ASSERT_TRUE(empty.data[0] == 30.0);
+    ASSERT_TRUE(empty.weight == 3.0);
+    ASSERT_TRUE(empty.nbatch == 1u);
+
+    /* b ⊕ empty(weight 0)  ⇒  b unchanged. */
+    {
+        struct osh_scoring_accumulator e2;
+        make_batch(&e2, 2u, zero, 0.0);
+        e2.nbatch = 0u;
+        ASSERT_TRUE(osh_scoring_accumulator_merge(&empty, &e2) == OSH_OK);
+        ASSERT_TRUE(empty.data_var[0] == 0.0);
+        ASSERT_TRUE(empty.data[0] == 30.0);
+        ASSERT_TRUE(empty.weight == 3.0);
+        ASSERT_TRUE(empty.nbatch == 1u);
+        osh_scoring_accumulator_free(&e2);
+    }
+
+    osh_scoring_accumulator_free(&empty);
+    osh_scoring_accumulator_free(&b);
+}
+
 int main(void) {
     test_merge_identity();
     test_merge_correctness();
@@ -262,6 +404,9 @@ int main(void) {
     test_zero();
     test_rescale();
     test_finalize_average();
+    test_merge_variance_two_batches();
+    test_merge_variance_unequal_single_pass();
+    test_merge_variance_empty_identity();
     printf("All osh_scoring_accumulator tests passed.\n");
     return 0;
 }

--- a/tests/unit/test_osh_scoring_accumulator_merge.c
+++ b/tests/unit/test_osh_scoring_accumulator_merge.c
@@ -423,6 +423,23 @@ static void test_merge_variance_inconsistent_rejected(void) {
         osh_scoring_accumulator_free(&c);
         osh_scoring_accumulator_free(&e);
     }
+
+    /* data_var present without its companion data array (symmetric guard).  Both
+     * sides drop data so the presence check passes and the variance-consistency
+     * check is what rejects. */
+    {
+        struct osh_scoring_accumulator f;
+        struct osh_scoring_accumulator g;
+        make_batch(&f, 2u, d, 2.0);
+        make_batch(&g, 2u, d, 2.0);
+        free(f.data);
+        f.data = NULL;
+        free(g.data);
+        g.data = NULL;
+        ASSERT_TRUE(osh_scoring_accumulator_merge(&f, &g) == OSH_EINVAL);
+        osh_scoring_accumulator_free(&f);
+        osh_scoring_accumulator_free(&g);
+    }
 }
 
 int main(void) {

--- a/tests/unit/test_osh_scoring_accumulator_merge.c
+++ b/tests/unit/test_osh_scoring_accumulator_merge.c
@@ -17,6 +17,7 @@
  *   test_merge_variance_unequal_single_pass — unequal batches match single-pass
  *                                             weighted M2, order-independent
  *   test_merge_variance_empty_identity     — a weight-0 batch is the merge identity
+ *   test_merge_variance_inconsistent_rejected — malformed variance bookkeeping → EINVAL
  */
 
 #include <math.h>
@@ -394,6 +395,36 @@ static void test_merge_variance_empty_identity(void) {
     osh_scoring_accumulator_free(&b);
 }
 
+/* Inconsistent variance bookkeeping is rejected rather than silently mis-merged. */
+static void test_merge_variance_inconsistent_rejected(void) {
+    struct osh_scoring_accumulator a;
+    struct osh_scoring_accumulator b;
+    double const d[2] = {10.0, 4.0};
+
+    /* weight == 0 but nbatch != 0 is a malformed batch. */
+    make_batch(&a, 2u, d, 2.0);
+    make_batch(&b, 2u, d, 2.0);
+    a.weight = 0.0; /* nbatch stays 1 -> inconsistent */
+    ASSERT_TRUE(osh_scoring_accumulator_merge(&a, &b) == OSH_EINVAL);
+    ASSERT_TRUE(osh_scoring_accumulator_merge(&b, &a) == OSH_EINVAL); /* src side too */
+    osh_scoring_accumulator_free(&a);
+    osh_scoring_accumulator_free(&b);
+
+    /* data2_var present without its companion data2 array. */
+    {
+        struct osh_scoring_accumulator c;
+        struct osh_scoring_accumulator e;
+        make_batch(&c, 2u, d, 2.0); /* no data2 (alloc want_data2=0) */
+        make_batch(&e, 2u, d, 2.0);
+        c.data2_var = (double *) calloc(2u, sizeof(double));
+        e.data2_var = (double *) calloc(2u, sizeof(double));
+        ASSERT_TRUE(c.data2_var != NULL && e.data2_var != NULL);
+        ASSERT_TRUE(osh_scoring_accumulator_merge(&c, &e) == OSH_EINVAL);
+        osh_scoring_accumulator_free(&c);
+        osh_scoring_accumulator_free(&e);
+    }
+}
+
 int main(void) {
     test_merge_identity();
     test_merge_correctness();
@@ -407,6 +438,7 @@ int main(void) {
     test_merge_variance_two_batches();
     test_merge_variance_unequal_single_pass();
     test_merge_variance_empty_identity();
+    test_merge_variance_inconsistent_rejected();
     printf("All osh_scoring_accumulator tests passed.\n");
     return 0;
 }

--- a/tests/unit/test_osh_scoring_accumulator_merge.c
+++ b/tests/unit/test_osh_scoring_accumulator_merge.c
@@ -8,7 +8,7 @@
  *   test_merge_correctness     — three partial sums fold to the exact total
  *   test_merge_commutative     — merge order does not change the result
  *   test_merge_len_mismatch    — differing lengths are rejected (OSH_EINVAL)
- *   test_merge_null            — NULL operands are rejected without crashing
+ *   test_merge_null            — NULL operands and freed/uninitialised data are rejected
  *   test_merge_shape_mismatch  — mismatched optional-array presence is rejected
  *   test_zero                  — zero() clears every allocated array, keeps len
  *   test_rescale               — rescale() scales data in place, NULL-safe
@@ -161,7 +161,7 @@ static void test_merge_len_mismatch(void) {
     osh_scoring_accumulator_free(&b);
 }
 
-/* ---- Rejection: NULL operands -------------------------------------------- */
+/* ---- Rejection: NULL operands or freed/uninitialised data array ----------- */
 
 static void test_merge_null(void) {
     struct osh_scoring_accumulator a;
@@ -171,6 +171,27 @@ static void test_merge_null(void) {
     ASSERT_TRUE(osh_scoring_accumulator_merge(&a, NULL) == OSH_EINVAL);
     ASSERT_TRUE(osh_scoring_accumulator_merge(NULL, NULL) == OSH_EINVAL);
     osh_scoring_accumulator_free(&a);
+
+    /* data==NULL on either side (freed/uninitialised accumulator) is also rejected. */
+    {
+        struct osh_scoring_accumulator freed_dst;
+        struct osh_scoring_accumulator freed_src;
+        struct osh_scoring_accumulator good;
+
+        ASSERT_TRUE(osh_scoring_accumulator_alloc(&good, 2u, 0) == OSH_OK);
+        ASSERT_TRUE(osh_scoring_accumulator_alloc(&freed_dst, 2u, 0) == OSH_OK);
+        ASSERT_TRUE(osh_scoring_accumulator_alloc(&freed_src, 2u, 0) == OSH_OK);
+        osh_scoring_accumulator_free(&freed_dst); /* data now NULL */
+        osh_scoring_accumulator_free(&freed_src); /* data now NULL */
+        freed_dst.len = 2u; /* restore len so the len-mismatch guard doesn't fire first */
+        freed_src.len = 2u;
+
+        ASSERT_TRUE(osh_scoring_accumulator_merge(&freed_dst, &good) == OSH_EINVAL);
+        ASSERT_TRUE(osh_scoring_accumulator_merge(&good, &freed_src) == OSH_EINVAL);
+        ASSERT_TRUE(osh_scoring_accumulator_merge(&freed_dst, &freed_src) == OSH_EINVAL);
+
+        osh_scoring_accumulator_free(&good);
+    }
 }
 
 /* ---- Reuse: zero() clears every allocated array but keeps len ------------ */
@@ -424,9 +445,8 @@ static void test_merge_variance_inconsistent_rejected(void) {
         osh_scoring_accumulator_free(&e);
     }
 
-    /* data_var present without its companion data array (symmetric guard).  Both
-     * sides drop data so the presence check passes and the variance-consistency
-     * check is what rejects. */
+    /* data_var present without its companion data array: the explicit NULL-data
+     * guard fires first (before the variance-consistency check). */
     {
         struct osh_scoring_accumulator f;
         struct osh_scoring_accumulator g;


### PR DESCRIPTION
## What & why

Closes #169. Follow-up to the parallelism groundwork (#161 / PR #162), sibling of the deposit-target (#166) and per-worker-profile (#167 / PR #188) seam work.

The `osh_scoring_accumulator` scaffolds `data_var`/`data2_var` (variance state, **unwired**), and `osh_scoring_accumulator_merge()` folded them with a blanket element-wise `+=`. That's harmless today (the arrays are NULL), but it's a **latent trap**: the moment variance state lands in `data_var`, a plain `+=` silently drops the variance merge cross-term and corrupts the result. Because the merge is the heart of every parallel reduction, the representation has to be settled — and the merge made representation-aware — *now*, while it's a two-function change.

## Decision recorded

- **Granularity: batch-means.** A *batch* (a parallel worker's history range, a periodic dump interval, an internal sub-split, or an independent run) is one weighted observation; the spread *between* batches is the estimator. True per-history variance is out of scope — it would need an `nbins × live-histories` scratch buffer, prohibitive for the wavefront design.
- **Representation: Welford `M2` + Schubert–Gertz (2018) merge** (the single-batch fold is West's 1979 weighted update). Per-bin store `data` (Σx) and `M2` (`data_var`); the mean is `data/weight`.

**Why this, given heterogeneous CPUs:** under hybrid cores (and arbitrary dump boundaries) workers finish **unequal** numbers of histories, so the merge must be correct for unequal-size batches. The Schubert–Gertz cross-term `δ²·wA·wB/w` handles that by construction; an additive `+=` does not.

A nice simplification falls out: because every bin sees the *same* set of histories (most depositing zero), the observation count is a **per-accumulator scalar**, not a per-bin array — so the only new per-bin state is the `M2` array already scaffolded, plus two scalars.

## Changes

- Add per-accumulator scalars `weight` (W, history count = merge weight) and `nbatch` (B, batch count → `B−1` dof).
- Reinterpret `data_var`/`data2_var` as Welford `M2`; document the finalize formula `SE = sqrt(M2 / ((nbatch−1)·weight))` and that a single batch has **no** error estimate (needs ≥2 batches).
- Rewrite `osh_scoring_accumulator_merge()`: `data`/`data2`/`weight`/`nbatch` stay additive; the `M2` arrays use the Schubert–Gertz cross-term (computed *before* the additive fold, since it needs the pre-merge sums/weights). Empty batches are the identity. **NULL variance arrays (today's default) reduce it to the old additive behaviour**, so current outputs are bit-identical and the serial path is untouched.
- Unit tests: exact dyadic two-batch merge; three **unequal-size** batches reproduce the single-pass weighted `M2` and are order-independent within FP tolerance; weight-0 batch is the identity.
- Docs: header "Uncertainty representation" section; new `docs/dev/scoring.md` §3 (batch-means rationale, Welford/Schubert–Gertz, dof, MPI/GPU notes); user-facing note in `docs/user/beam.dat.md`.

The variance **deposit/finalisation** itself stays unwired — this PR settles the contract + merge only, exactly #169's scope. Wiring variance later is now a local change, not a representation hunt.

## Acceptance criteria (from #169)

- [x] Granularity decision recorded (batch vs per-history) with rationale.
- [x] Variance representation chosen (Welford/West) and documented in `osh_scoring_accumulator.h`.
- [x] `osh_scoring_accumulator_merge()` variance-field merge made representation-aware; the unconditional `+=` over `data_var`/`data2_var` removed.
- [x] Unit test: merge of two unequal-size batches reproduces the single-pass variance within tolerance (the test that would have caught the dropped cross term).
- [x] Welford: per-bin `M2` + per-accumulator `weight`/`nbatch` state; West weighted update is the single-observation fold.
- [x] MPI note captured (`MPI_SUM` for additive fields; custom `MPI_Op` for `M2`).

## Testing

`cmake --preset debug && ctest` — the extended `test_osh_scoring_accumulator_merge`, all `cases::*` (mesh + cyl), `bench::profile_bit_identity`, and `bench::capacity_invariance` pass. The 4 failing tests (`version_components_in_string`, DICOM) are pre-existing and unrelated — they fail identically on the base branch. No physics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzmNWB6jJ4U8sJmiVFjosH)_