### PR TITLE
scoring: fix four latent shadow/snapshot findings from closed PR #197

### DIFF
--- a/src/scoring/runtime/osh_scoring_accumulator.c
+++ b/src/scoring/runtime/osh_scoring_accumulator.c
@@ -4,10 +4,13 @@
 #include <string.h>
 
 enum osh_status osh_scoring_accumulator_alloc(struct osh_scoring_accumulator *acc, size_t len, int want_data2) {
-    size_t const n = len ? len : 1u; /* never allocate a zero-length array */
+    size_t n = len; /* never allocate a zero-length array */
 
     if (!acc) {
         return OSH_EINVAL;
+    }
+    if (n == 0u) {
+        n = 1u;
     }
 
     acc->data = NULL;

--- a/src/scoring/runtime/osh_scoring_compile.c
+++ b/src/scoring/runtime/osh_scoring_compile.c
@@ -231,11 +231,18 @@ enum osh_status osh_scoring_estimate_memory(struct osh_scoring_workspace const *
                 }
             }
 
-            if (len == 0u) {
-                page_bytes = 0u;
-            } else {
+            {
+                /* Size this page exactly as osh_scoring_accumulator_alloc() would,
+                 * so the estimate cannot drift from the real allocation (an
+                 * invariant the header documents). */
+                uint64_t n = len;
+                /* alloc never makes a zero-length array: a degenerate (bins==0)
+                 * page still gets one element per array, so round len up to one. */
+                if (n == 0u) {
+                    n = 1u;
+                }
                 uint64_t const bytes_per_bin = (uint64_t) sizeof(double) * (uint64_t) arrays;
-                page_bytes = (len <= UINT64_MAX / bytes_per_bin) ? (len * bytes_per_bin) : UINT64_MAX;
+                page_bytes = (n <= UINT64_MAX / bytes_per_bin) ? (n * bytes_per_bin) : UINT64_MAX;
             }
 
             out->accum_bytes =
@@ -244,13 +251,29 @@ enum osh_status osh_scoring_estimate_memory(struct osh_scoring_workspace const *
 
             /* A mid-run snapshot copies only the `data` array (one, never data2)
              * of pages whose postprocess writes data — DOSEGY and the LET/Qeff
-             * averages.  Same per-page bin count as above, so the estimate cannot
-             * drift from the shadow's real allocation. */
-            if (len > 0u && osh_scoring_postprocess_writes_data(kind)) {
-                uint64_t const shadow_page =
-                    (len <= UINT64_MAX / (uint64_t) sizeof(double)) ? (len * (uint64_t) sizeof(double)) : UINT64_MAX;
-                out->shadow_bytes =
-                    (out->shadow_bytes <= UINT64_MAX - shadow_page) ? (out->shadow_bytes + shadow_page) : UINT64_MAX;
+             * averages — at the same per-page bin count used above. */
+            if (osh_scoring_postprocess_writes_data(kind)) {
+                uint64_t shadow_n = len;
+                uint64_t shadow_page;
+                /* osh_scoring_shadow_refresh() grabs one double even for a len==0
+                 * page, so round up to keep the estimate matched to it. */
+                if (shadow_n == 0u) {
+                    shadow_n = 1u;
+                }
+                /* Bytes for this page's single shadow data array.  Guard the
+                 * multiply: saturate at UINT64_MAX rather than wrap on overflow. */
+                if (shadow_n <= UINT64_MAX / (uint64_t) sizeof(double)) {
+                    shadow_page = shadow_n * (uint64_t) sizeof(double);
+                } else {
+                    shadow_page = UINT64_MAX;
+                }
+                /* Fold into the running total, again saturating instead of
+                 * wrapping if the addition would overflow. */
+                if (out->shadow_bytes <= UINT64_MAX - shadow_page) {
+                    out->shadow_bytes += shadow_page;
+                } else {
+                    out->shadow_bytes = UINT64_MAX;
+                }
             }
 
             if (page_bytes > out->largest_page_bytes) {

--- a/src/scoring/runtime/osh_scoring_shadow.c
+++ b/src/scoring/runtime/osh_scoring_shadow.c
@@ -12,6 +12,17 @@ enum osh_status osh_scoring_shadow_init(struct osh_scoring_shadow *shadow, struc
     }
 
     shadow->view = *live; /* alias outputs/geometries/settings/etc. */
+    /* The view is a read-only presentation snapshot consumed only through
+     * view.pages (osh_scoring_postprocess_into + the sink).  The struct-copy
+     * above also carried master_acc (a shallow alias of the *live* per-page
+     * accumulators) and master_scratch.crossing_buf (the *live* traversal
+     * scratch), so a consumer reaching the view via
+     * osh_scoring_runtime_master_accumulators() / _master_scratch() would
+     * silently read live state, not the snapshot.  Drop those aliases so the
+     * view is self-consistent; redirect happens only on the page array below. */
+    shadow->view.master_acc = NULL;
+    shadow->view.master_scratch.crossing_buf = NULL;
+    shadow->view.master_scratch.crossing_cap = 0u;
     shadow->live = live;
     shadow->npages = live->npages;
     shadow->pages = NULL;
@@ -55,8 +66,12 @@ enum osh_status osh_scoring_shadow_refresh(struct osh_scoring_shadow *shadow) {
         for (i = 0; i < shadow->npages; ++i) {
             struct osh_scoring_page_runtime const *lp = &shadow->live->pages[i];
             if (osh_scoring_postprocess_writes_data(lp->score_kind)) {
-                size_t const n = lp->acc.len ? lp->acc.len : 1u;
-                double *buf = (double *) malloc(n * sizeof(*buf));
+                size_t n = lp->acc.len; /* never allocate a zero-length buffer */
+                double *buf;
+                if (n == 0u) {
+                    n = 1u;
+                }
+                buf = (double *) malloc(n * sizeof(*buf));
                 if (!buf) {
                     /* Roll back this attempt: free the scratch allocated so far and
                      * restore the aliased data pointers, leaving the shadow in its
@@ -92,7 +107,13 @@ uint64_t osh_scoring_shadow_bytes(struct osh_scoring_shadow const *shadow) {
     for (i = 0; i < shadow->npages; ++i) {
         struct osh_scoring_page_runtime const *lp = &shadow->live->pages[i];
         if (osh_scoring_postprocess_writes_data(lp->score_kind)) {
-            uint64_t const n = (uint64_t) lp->acc.len;
+            uint64_t n = (uint64_t) lp->acc.len;
+            /* osh_scoring_shadow_refresh() allocates one double even for a len==0
+             * page (it never makes a zero-length buffer), so count one here too;
+             * plain len would advertise 0 bytes and desync from the real scratch. */
+            if (n == 0u) {
+                n = 1u;
+            }
             uint64_t const b =
                 (n <= UINT64_MAX / (uint64_t) sizeof(double)) ? (n * (uint64_t) sizeof(double)) : UINT64_MAX;
             total = (total <= UINT64_MAX - b) ? (total + b) : UINT64_MAX;
@@ -124,4 +145,14 @@ void osh_scoring_shadow_free(struct osh_scoring_shadow *shadow) {
     shadow->npages = 0u;
     shadow->live = NULL;
     shadow->scratch_ready = 0;
+
+    /* view.pages was set to shadow->pages (just freed); leaving it dangling
+     * makes a post-free osh_scoring_shadow_view() hand back a runtime whose
+     * page array points at freed memory.  Reset the view to a benign empty
+     * snapshot so inspecting a freed shadow is well-defined, not a UAF. */
+    shadow->view.pages = NULL;
+    shadow->view.npages = 0u;
+    shadow->view.master_acc = NULL;
+    shadow->view.master_scratch.crossing_buf = NULL;
+    shadow->view.master_scratch.crossing_cap = 0u;
 }

--- a/tests/fixtures/scoring_estimate/detect_zero_bins.dat
+++ b/tests/fixtures/scoring_estimate/detect_zero_bins.dat
@@ -1,0 +1,23 @@
+# Fixture for the osh_scoring_estimate_memory() zero-bin (degenerate) test.
+#
+# Geometry "G" has a Z axis with 0 bins, so geometry_nbins() == 0 and every
+# page's len is 0.  osh_scoring_accumulator_alloc() still allocates one element
+# per array (it never makes a zero-length array), and osh_scoring_shadow_refresh()
+# still grabs one double, so the estimate must round len==0 up to one too:
+#   Dose  -> 1 accumulator  => max(0,1) * 8 * 1 =  8 bytes
+#   DLET  -> 2 accumulators => max(0,1) * 8 * 2 = 16 bytes
+# Expected: accum_bytes = 24, npages = 2, largest_page_bytes = 16, geometry "G",
+#           shadow_bytes = 8 (DLET's single data array; Dose is a no-op).
+
+Geometry Mesh
+    Name G
+    X -1.0   1.0     1
+    Y -1.0   1.0     1
+    Z  0.0  10.0     0
+
+Output
+    Filename est.dat
+    Fileformat TEXT
+    Geo G
+    Quantity Dose
+    Quantity DLET

--- a/tests/unit/test_osh_scoring_estimate.c
+++ b/tests/unit/test_osh_scoring_estimate.c
@@ -46,6 +46,38 @@ static void test_estimate_known_fixture(void) {
     osh_scoring_workspace_free(ws);
 }
 
+/*
+ * A degenerate geometry (an axis with 0 bins) gives every page len==0.  The
+ * allocator and the shadow both round that up to one element, so the estimate
+ * must too — counting a flat 0 bytes would understate what is really allocated
+ * and break the "cannot drift from the real allocation" invariant the header
+ * documents.  Mirrors osh_scoring_accumulator_alloc()'s `len ? len : 1`.
+ */
+static void test_estimate_zero_bins(void) {
+    char path[1024];
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_mem_estimate est;
+
+    (void) snprintf(path, sizeof(path), "%s/scoring_estimate/detect_zero_bins.dat", OSH_TEST_FIXTURES_DIR);
+
+    ASSERT_TRUE(osh_scoring_setup_from_path(path, NULL, &ws) == OSH_OK);
+    ASSERT_TRUE(ws != NULL);
+
+    ASSERT_TRUE(osh_scoring_estimate_memory(ws, &est) == OSH_OK);
+
+    /* len==0 rounds to one element: Dose = 1*8*1 = 8, DLET = 1*8*2 = 16. */
+    ASSERT_TRUE(est.npages == 2u);
+    ASSERT_TRUE(est.accum_bytes == 24u);
+    ASSERT_TRUE(est.largest_page_bytes == 16u);
+    ASSERT_TRUE(strcmp(est.largest_geometry, "G") == 0);
+
+    /* Shadow copies DLET's single data array (rounded to one double); Dose is a
+     * no-op postprocess and contributes nothing. */
+    ASSERT_TRUE(est.shadow_bytes == 8u);
+
+    osh_scoring_workspace_free(ws);
+}
+
 static void test_estimate_null_args(void) {
     struct osh_scoring_mem_estimate est;
     ASSERT_TRUE(osh_scoring_estimate_memory(NULL, &est) == OSH_EINVAL);
@@ -53,6 +85,7 @@ static void test_estimate_null_args(void) {
 
 int main(void) {
     test_estimate_known_fixture();
+    test_estimate_zero_bins();
     test_estimate_null_args();
     return 0;
 }

--- a/tests/unit/test_osh_scoring_shadow.c
+++ b/tests/unit/test_osh_scoring_shadow.c
@@ -10,6 +10,10 @@
  *   test_snapshot_selector          — the output selector (G2) is passed to the sink
  *   test_snapshot_errors            — NULL sink / sink->save / shadow are rejected
  *   test_shadow_edge_args           — NULL / empty-runtime paths on every entry point
+ *   test_shadow_view_self_consistent— view drops the live master_acc/master_scratch
+ *                                     aliases; free() leaves the view benign (#1/#3)
+ *   test_shadow_bytes_zero_len_page — a len==0 page is counted as its rounded-up
+ *                                     one-element allocation, not 0 bytes (#2)
  *   test_snapshot_refresh_failure   — a postprocess error propagates out, no save
  *
  * Uses a mock sink so no files are written; pure arithmetic, identical on every OS.
@@ -315,6 +319,77 @@ static void test_shadow_edge_args(void) {
     live_fixture_free(&f);
 }
 
+/* ---- The view never aliases live master state; free() leaves it benign ----- */
+
+static void test_shadow_view_self_consistent(void) {
+    struct live_fixture f;
+    struct osh_scoring_shadow shadow;
+    struct osh_scoring_accumulator sentinel_acc;
+    struct osh_voxel_crossing sentinel_cross;
+
+    live_fixture_init(&f);
+
+    /* Give the live runtime the master views the serial driver would hold, so we
+     * can prove the shadow does NOT carry them into its presentation view: those
+     * aliases point at live (un-snapshotted) state. */
+    memset(&sentinel_acc, 0, sizeof(sentinel_acc));
+    memset(&sentinel_cross, 0, sizeof(sentinel_cross));
+    f.rt.master_acc = &sentinel_acc;
+    f.rt.master_scratch.crossing_buf = &sentinel_cross;
+    f.rt.master_scratch.crossing_cap = 7u;
+
+    ASSERT_TRUE(osh_scoring_shadow_init(&shadow, &f.rt) == OSH_OK);
+
+    /* Copilot #1: a consumer reaching the view via the master accessors must not
+     * get the live state back — the snapshot redirects only the page array. */
+    ASSERT_TRUE(shadow.view.master_acc == NULL);
+    ASSERT_TRUE(shadow.view.master_scratch.crossing_buf == NULL);
+    ASSERT_TRUE(shadow.view.master_scratch.crossing_cap == 0u);
+    ASSERT_TRUE(osh_scoring_runtime_master_accumulators(&shadow.view) == NULL);
+    ASSERT_TRUE(osh_scoring_runtime_master_scratch(&shadow.view)->crossing_buf == NULL);
+
+    ASSERT_TRUE(osh_scoring_shadow_refresh(&shadow) == OSH_OK);
+    ASSERT_TRUE(shadow.view.master_acc == NULL); /* refresh keeps it clear */
+
+    osh_scoring_shadow_free(&shadow);
+
+    /* Copilot #3: after free the view is a benign empty snapshot — pages no
+     * longer dangle at the freed array, so inspecting a freed shadow is safe. */
+    ASSERT_TRUE(osh_scoring_shadow_view(&shadow) == &shadow.view);
+    ASSERT_TRUE(shadow.view.pages == NULL);
+    ASSERT_TRUE(shadow.view.npages == 0u);
+
+    live_fixture_free(&f);
+}
+
+/* ---- shadow_bytes counts the rounded-up allocation for a len==0 page -------- */
+
+static void test_shadow_bytes_zero_len_page(void) {
+    struct osh_scoring_page_runtime page;
+    struct osh_scoring_runtime rt;
+    struct osh_scoring_shadow shadow;
+
+    /* DOSEGY page with len==0: osh_scoring_accumulator_alloc() still allocates one
+     * element and osh_scoring_shadow_refresh() one double, so shadow_bytes must
+     * report 8 (Copilot #2), not the 0 a plain `len` count would give. */
+    make_page(&page, OSH_SCORING_SCORE_DOSEGY, 0u, 0);
+    memset(&rt, 0, sizeof(rt));
+    rt.pages = &page;
+    rt.npages = 1u;
+
+    ASSERT_TRUE(osh_scoring_shadow_init(&shadow, &rt) == OSH_OK);
+    ASSERT_TRUE(osh_scoring_shadow_bytes(&shadow) == 8u);
+
+    /* The advertised size matches the real allocation: refresh grabs a private
+     * one-double buffer and redirects the page off the live data. */
+    ASSERT_TRUE(osh_scoring_shadow_refresh(&shadow) == OSH_OK);
+    ASSERT_TRUE(shadow.scratch[0] != NULL);
+    ASSERT_TRUE(shadow.pages[0].acc.data != page.acc.data);
+
+    osh_scoring_shadow_free(&shadow);
+    osh_scoring_accumulator_free(&page.acc);
+}
+
 /* ---- A postprocess error during refresh propagates; the sink is not called - */
 
 static void test_snapshot_refresh_failure(void) {
@@ -351,6 +426,8 @@ int main(void) {
     test_snapshot_selector();
     test_snapshot_errors();
     test_shadow_edge_args();
+    test_shadow_view_self_consistent();
+    test_shadow_bytes_zero_len_page();
     test_snapshot_refresh_failure();
     printf("All osh_scoring_shadow tests passed.\n");
     return 0;


### PR DESCRIPTION
## Summary

Closes #201.

Four Copilot review findings left on closed PR #197 reached `main` unaddressed (via #189 / #194). All four are latent — no current consumer trips them — but a couple violate the `osh_scoring_estimate_memory` invariant the header documents ("the estimate cannot drift from the real allocation"), and two are real (if dormant) memory-safety hazards. This cleans up all four together.

## Findings & fixes

**1. Shadow view aliased live `master_acc` / `master_scratch`** — `src/scoring/runtime/osh_scoring_shadow.c`
`osh_scoring_shadow_init()` struct-copies the whole live runtime into `view`, which carried `master_acc` (a shallow alias of the *live* per-page accumulators) and `master_scratch.crossing_buf` (the live traversal scratch). A consumer reaching the view via `osh_scoring_runtime_master_accumulators()` / `_master_scratch()` would silently read live state instead of the snapshot. Fix: clear those aliases in `shadow_init()` — the view is consumed only through `view.pages`, and only the page array is redirected.

**2. `shadow_bytes` undercounted `len==0` pages** — `osh_scoring_shadow.c`
`osh_scoring_shadow_refresh()` allocates `len ? len : 1` doubles per writes-data page, but `osh_scoring_shadow_bytes()` counted plain `len` → 0 bytes for a `len==0` page. Fix: count `len ? len : 1`.

**3. `shadow_free` left `view.pages` dangling** — `osh_scoring_shadow.c`
`osh_scoring_shadow_free()` freed `shadow->pages` but never reset `view.pages` (set to it in `init`), so a post-free `osh_scoring_shadow_view()` handed back a runtime whose page array pointed at freed memory. Fix: reset the view to a benign empty snapshot on free.

**4. `estimate_memory` undercounted `len==0` (accum **and** shadow)** — `src/scoring/runtime/osh_scoring_compile.c`
For `len==0`, `accum_bytes` counted 0 (alloc still makes one element) and `shadow_bytes` skipped the page entirely (refresh still grabs one double). Same root cause as #2. Fix: mirror the `len ? len : 1` alloc semantics for both, restoring the no-drift invariant for degenerate (`bins==0`) geometry.

## Tests

- `tests/unit/test_osh_scoring_shadow.c`: `test_shadow_view_self_consistent` (view drops the live master aliases; free leaves the view benign — findings #1/#3) and `test_shadow_bytes_zero_len_page` (a `len==0` page is counted as its rounded-up one-element allocation — finding #2).
- `tests/unit/test_osh_scoring_estimate.c`: `test_estimate_zero_bins` against a new `scoring_estimate/detect_zero_bins.dat` fixture (degenerate geometry → rounded-up `accum_bytes`/`shadow_bytes` — finding #4).

All scoring unit tests pass; `clang-format` and `clang-tidy` (changed-line) are clean. (One pre-existing, unrelated failure in `test_osh_main::version_components_in_string` stems from the version string being derived from `git describe` with no tags in a fresh clone — not touched by this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017jdmNCByLvG5W4D3hQgMos)_