### PR TITLE
docs: add CLAUDE.md agent brief and thin agent-config pointers (#205)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,17 @@
+# GitHub Copilot instructions
+
+The agent brief for this repository lives in **[`../CLAUDE.md`](../CLAUDE.md)**.
+Follow it (and the docs it links — [`DEVELOPER.md`](../DEVELOPER.md),
+[`llms.txt`](../llms.txt)) when suggesting or reviewing code here.
+
+The rules Copilot most often needs when generating C for this project:
+
+- C11, but declare variables at the **top of each block** (K&R); none inside `for`/`if`.
+- Use `struct foo` explicitly — **never** `typedef struct`.
+- Block comments `/* */` only; `//` is reserved for temporary notes.
+- `double const *p`, not `const double *p`.
+- No POSIX-only APIs (`strcasecmp`, `mkdtemp`, `getpid`, `<unistd.h>`, `<threads.h>`, …) — Windows is a target.
+- No heap allocation on the simulation hot path.
+- Predicates return `int` (1 = yes); operations return `enum osh_status` (`OSH_OK = 0`).
+
+See [`../CLAUDE.md`](../CLAUDE.md) for the full list and the build/test/format commands.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,14 +4,15 @@ The agent brief for this repository lives in **[`../CLAUDE.md`](../CLAUDE.md)**.
 Follow it (and the docs it links — [`DEVELOPER.md`](../DEVELOPER.md),
 [`llms.txt`](../llms.txt)) when suggesting or reviewing code here.
 
-The rules Copilot most often needs when generating C for this project:
+The rules Copilot most often needs when generating C for this project (each tagged
+with its authoritative section in [`DEVELOPER.md`](../DEVELOPER.md) — that § wins):
 
-- C11, but declare variables at the **top of each block** (K&R); none inside `for`/`if`.
-- Use `struct foo` explicitly — **never** `typedef struct`.
-- Block comments `/* */` only; `//` is reserved for temporary notes.
-- `double const *p`, not `const double *p`.
-- No non-portable APIs (POSIX-only or missing on MSVC): avoid `strcasecmp`/`<strings.h>`, `mkdtemp`, `getpid`, `<unistd.h>`, `<threads.h>`, … — Windows is a target.
-- No heap allocation on the simulation hot path.
-- Predicates return `int` (1 = yes); operations return `enum osh_status` (`OSH_OK = 0`).
+- C11, but declare variables at the **top of each block** (K&R); none inside `for`/`if`. — §1
+- Use `struct foo` explicitly — **never** `typedef struct`. — §2.1
+- Block comments `/* */` only; `//` is reserved for temporary notes. — §4.1
+- `double const *p`, not `const double *p`. — §2.2
+- No non-portable APIs (POSIX-only or missing on MSVC): avoid `strcasecmp`/`<strings.h>`, `mkdtemp`, `getpid`, `<unistd.h>`, `<threads.h>`, … — Windows is a target. — §11.1
+- No heap allocation on the simulation hot path. — §10
+- Predicates return `int` (1 = yes); operations return `enum osh_status` (`OSH_OK = 0`). — §5
 
 See [`../CLAUDE.md`](../CLAUDE.md) for the full list and the build/test/format commands.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ The rules Copilot most often needs when generating C for this project:
 - Use `struct foo` explicitly — **never** `typedef struct`.
 - Block comments `/* */` only; `//` is reserved for temporary notes.
 - `double const *p`, not `const double *p`.
-- No POSIX-only APIs (`strcasecmp`, `mkdtemp`, `getpid`, `<unistd.h>`, `<threads.h>`, …) — Windows is a target.
+- No non-portable APIs (POSIX-only or missing on MSVC): avoid `strcasecmp`/`<strings.h>`, `mkdtemp`, `getpid`, `<unistd.h>`, `<threads.h>`, … — Windows is a target.
 - No heap allocation on the simulation hot path.
 - Predicates return `int` (1 = yes); operations return `enum osh_status` (`OSH_OK = 0`).
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,14 @@
-.codex
-.claude
+# --- AI agent / tool configuration (local, not tracked) ---
+# Tool/runtime config areas — permissions, hooks, machine-specific settings —
+# stay out of version control. Project *guidance* for agents is tracked instead:
+# CLAUDE.md, AGENTS.md, and .github/copilot-instructions.md, all thin pointers to
+# DEVELOPER.md (the authoritative ruleset). Keep the split: config here, policy in
+# those tracked Markdown files.
+.claude/
 .claude*/
+.codex/
+.codex*/
+
 _temp*/
 NB*
 *.bdo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# AGENTS.md
+
+This project keeps a single brief for AI coding agents in **[`CLAUDE.md`](CLAUDE.md)**.
+
+`AGENTS.md` exists only so tools that look for this filename land in the same
+place — it is a pointer, not a second copy, to avoid the two drifting apart.
+Read [`CLAUDE.md`](CLAUDE.md), and the docs it links ([`DEVELOPER.md`](DEVELOPER.md),
+[`llms.txt`](llms.txt)), before editing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ For *what the project is* and where things live, read [`llms.txt`](llms.txt) fir
 
 | Document | What it is the source of truth for |
 |---|---|
-| [`DEVELOPER.md`](DEVELOPER.md) | Coding style, struct layout, C11 rules, module/dependency layering, presets — **the** style authority |
+| [`DEVELOPER.md`](DEVELOPER.md) | Coding style, struct layout, C11 rules, module/dependency layering, presets — **the** style authority. Organised as numbered rules (§1–§15); cite them (e.g. "violates §1"), don't paraphrase |
 | [`llms.txt`](llms.txt) | Project overview, source-tree map, unit conventions, SH12A/DICOM notes |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Build prerequisites, formatting, how to submit a patch |
 | [`docs/dev/`](docs/dev/) | Architecture, testing, scoring, coordinates, RNG deep-dives |
@@ -55,21 +55,24 @@ Format C/H before committing — clang-format (18+) and clang-tidy are enforced 
 
 Python helpers under `tools/` are formatted with `ruff` (see `.pre-commit-config.yaml`).
 
-## Hard rules (agents break these most — see DEVELOPER.md for the full set)
+## Hard rules (agents break these most)
 
-- **C11**, but declare all variables at the **top of the block** (K&R); no declarations inside `for`/`if`.
-- **No `typedef struct`** — write `struct foo` explicitly everywhere.
-- **No `//` comments** in production code — block `/* */` only; `//` is reserved for temporary/WIP notes.
-- `double const *p`, **not** `const double *p`.
-- **No non-portable APIs** — Windows is a target. Avoid POSIX-only APIs (`strcasecmp`/`<strings.h>`, `mkdtemp`, `getpid`, `<unistd.h>`, `<sys/stat.h>`) and also `<threads.h>` (C11 threads; not implemented in MSVC). See the banned-API table in DEVELOPER.md.
-- **No heap allocation on the hot path** — nothing under `osh_scoring_score_step()` / `osh_transport_step()` may `malloc`/`calloc`/`realloc`/`free`. Pre-allocate at setup; scratch/counters are caller-owned (per-worker).
-- **Return conventions don't mix:** predicates return `int` (1 = yes); operations return `enum osh_status` (`OSH_OK = 0` = success). Do not confuse the two.
-- Follow DEVELOPER.md naming rules: public functions use the `osh_` prefix; file-local helpers are `static` and unprefixed; `static inline` helpers use a leading `_`.
-- Case-insensitive keywords: lowercase once at parse time with `osh_lower_inplace()`, then `strcmp` — never `strcasecmp`.
+These are the repo-specific traps, each tagged with the DEVELOPER.md section that
+owns it. The § is the authority — read it before relying on the one-liner here.
+
+- **C11**, but declare all variables at the **top of the block** (K&R); no declarations inside `for`/`if`. — §1
+- **No `typedef struct`** — write `struct foo` explicitly everywhere. — §2.1
+- **No `//` comments** in production code — block `/* */` only; `//` is reserved for temporary/WIP notes. — §4.1
+- `double const *p`, **not** `const double *p`. — §2.2
+- **No non-portable APIs** — Windows is a target. Avoid POSIX-only APIs (`strcasecmp`/`<strings.h>`, `mkdtemp`, `getpid`, `<unistd.h>`, `<sys/stat.h>`) and also `<threads.h>` (C11 threads; not implemented in MSVC). See the banned-API table, §11.1.
+- **No heap allocation on the hot path** — nothing under `osh_scoring_score_step()` / `osh_transport_step()` may `malloc`/`calloc`/`realloc`/`free`. Pre-allocate at setup; scratch/counters are caller-owned (per-worker). — §10
+- **Return conventions don't mix:** predicates return `int` (1 = yes); operations return `enum osh_status` (`OSH_OK = 0` = success). Do not confuse the two. — §5
+- Naming: public functions use the `osh_` prefix; file-local helpers are `static` and unprefixed; `static inline` helpers use a leading `_`. — §6.1
+- Case-insensitive keywords: lowercase once at parse time with `osh_lower_inplace()`, then `strcmp` — never `strcasecmp`. — §11.2
 
 ## Where things go
 
-- Module layout: `src/<module>/` (API + domain types), optional `src/<module>/parse/` (input parsing) and `src/<module>/runtime/` (simulation-ready state). Add these layers only when the module actually has those phases. `runtime/` must not depend on `transport/`. Details in DEVELOPER.md → *Layout*.
+- Module layout: `src/<module>/` (API + domain types), optional `src/<module>/parse/` (input parsing) and `src/<module>/runtime/` (simulation-ready state). Add these layers only when the module actually has those phases. `runtime/` must not depend on `transport/`. Details in DEVELOPER.md §9.
 - Internal headers sit next to their `.c`; `include/openshieldhit/` is public headers only.
 - **Adding a unit test:** drop `tests/unit/test_<thing>.c` — it is auto-discovered by glob and registered as `unit::<file>`. Tests can read fixtures from `tests/fixtures/` via the `OSH_TEST_FIXTURES_DIR` macro (see `tests/unit/CMakeLists.txt` / `tests/unit/README.md`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,17 +61,17 @@ Python helpers under `tools/` are formatted with `ruff` (see `.pre-commit-config
 - **No `typedef struct`** — write `struct foo` explicitly everywhere.
 - **No `//` comments** in production code — block `/* */` only; `//` is reserved for temporary/WIP notes.
 - `double const *p`, **not** `const double *p`.
-- **No POSIX-only APIs** — Windows is a target. No `strcasecmp`/`<strings.h>`, `mkdtemp`, `getpid`, `<unistd.h>`, `<sys/stat.h>`, `<threads.h>`. See the banned-API table in DEVELOPER.md.
+- **No non-portable APIs** — Windows is a target. Avoid POSIX-only APIs (`strcasecmp`/`<strings.h>`, `mkdtemp`, `getpid`, `<unistd.h>`, `<sys/stat.h>`) and also `<threads.h>` (C11 threads; not implemented in MSVC). See the banned-API table in DEVELOPER.md.
 - **No heap allocation on the hot path** — nothing under `osh_scoring_score_step()` / `osh_transport_step()` may `malloc`/`calloc`/`realloc`/`free`. Pre-allocate at setup; scratch/counters are caller-owned (per-worker).
 - **Return conventions don't mix:** predicates return `int` (1 = yes); operations return `enum osh_status` (`OSH_OK = 0` = success). Do not confuse the two.
-- Public API is `osh_`-prefixed; internal helpers are `static` with no prefix. Doxygen `/** @brief … */` on non-trivial functions.
+- Follow DEVELOPER.md naming rules: public functions use the `osh_` prefix; file-local helpers are `static` and unprefixed; `static inline` helpers use a leading `_`.
 - Case-insensitive keywords: lowercase once at parse time with `osh_lower_inplace()`, then `strcmp` — never `strcasecmp`.
 
 ## Where things go
 
 - Module layout: `src/<module>/` (API + domain types), optional `src/<module>/parse/` (input parsing) and `src/<module>/runtime/` (simulation-ready state). Add these layers only when the module actually has those phases. `runtime/` must not depend on `transport/`. Details in DEVELOPER.md → *Layout*.
 - Internal headers sit next to their `.c`; `include/openshieldhit/` is public headers only.
-- **Adding a unit test:** drop `tests/unit/test_<thing>.c` — it is auto-discovered by glob. Each `static void test_<name>(void)` becomes its own CTest case `unit::<file>::<name>`. Read inputs from `tests/fixtures/` via the `OSH_TEST_FIXTURES_DIR` macro; no manual CMake registration needed. See `tests/unit/README.md`.
+- **Adding a unit test:** drop `tests/unit/test_<thing>.c` — it is auto-discovered by glob and registered as `unit::<file>`. Tests can read fixtures from `tests/fixtures/` via the `OSH_TEST_FIXTURES_DIR` macro (see `tests/unit/CMakeLists.txt` / `tests/unit/README.md`).
 
 ## Provenance — important
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+Operating brief for AI coding agents (Claude Code and others) working **inside**
+this repository. It is intentionally short: it points at the authoritative docs
+and captures the handful of repo-specific rules and commands that trip agents up.
+It is **not** a second copy of those docs — when this file and a linked document
+disagree, the linked document wins.
+
+For *what the project is* and where things live, read [`llms.txt`](llms.txt) first.
+
+## Read before editing
+
+| Document | What it is the source of truth for |
+|---|---|
+| [`DEVELOPER.md`](DEVELOPER.md) | Coding style, struct layout, C11 rules, module/dependency layering, presets — **the** style authority |
+| [`llms.txt`](llms.txt) | Project overview, source-tree map, unit conventions, SH12A/DICOM notes |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Build prerequisites, formatting, how to submit a patch |
+| [`docs/dev/`](docs/dev/) | Architecture, testing, scoring, coordinates, RNG deep-dives |
+| [`docs/user/`](docs/user/) | Input-file (`beam.dat` / `geo.dat` / `mat.dat` / `detect.dat`) and CLI reference |
+| `src/<module>/README.md` | What a given module owns and its `parse/` vs `runtime/` split |
+
+## Build, test, format
+
+Day-to-day work uses the **debug** preset (unoptimised, sanitiser-friendly).
+One command per block:
+
+```bash
+cmake --preset debug
+```
+```bash
+cmake --build --preset debug --parallel
+```
+```bash
+ctest --test-dir build_debug --output-on-failure
+```
+
+> **There are no CTest presets.** `ctest --preset debug` fails — CMakePresets.json
+> defines only configure/build presets. Always point CTest at the binary dir:
+> `ctest --test-dir build_debug` (add `-C Debug` on Windows / multi-config).
+
+Optimised build for benchmarking (binaries land in `build/bin/`, debug in `build_debug/bin/`):
+
+```bash
+cmake --preset release
+```
+```bash
+cmake --build --preset release --parallel
+```
+
+Format C/H before committing — clang-format (18+) and clang-tidy are enforced in CI:
+
+```bash
+./tools/clang-format-all.sh
+```
+
+Python helpers under `tools/` are formatted with `ruff` (see `.pre-commit-config.yaml`).
+
+## Hard rules (agents break these most — see DEVELOPER.md for the full set)
+
+- **C11**, but declare all variables at the **top of the block** (K&R); no declarations inside `for`/`if`.
+- **No `typedef struct`** — write `struct foo` explicitly everywhere.
+- **No `//` comments** in production code — block `/* */` only; `//` is reserved for temporary/WIP notes.
+- `double const *p`, **not** `const double *p`.
+- **No POSIX-only APIs** — Windows is a target. No `strcasecmp`/`<strings.h>`, `mkdtemp`, `getpid`, `<unistd.h>`, `<sys/stat.h>`, `<threads.h>`. See the banned-API table in DEVELOPER.md.
+- **No heap allocation on the hot path** — nothing under `osh_scoring_score_step()` / `osh_transport_step()` may `malloc`/`calloc`/`realloc`/`free`. Pre-allocate at setup; scratch/counters are caller-owned (per-worker).
+- **Return conventions don't mix:** predicates return `int` (1 = yes); operations return `enum osh_status` (`OSH_OK = 0` = success). Do not confuse the two.
+- Public API is `osh_`-prefixed; internal helpers are `static` with no prefix. Doxygen `/** @brief … */` on non-trivial functions.
+- Case-insensitive keywords: lowercase once at parse time with `osh_lower_inplace()`, then `strcmp` — never `strcasecmp`.
+
+## Where things go
+
+- Module layout: `src/<module>/` (API + domain types), optional `src/<module>/parse/` (input parsing) and `src/<module>/runtime/` (simulation-ready state). Add these layers only when the module actually has those phases. `runtime/` must not depend on `transport/`. Details in DEVELOPER.md → *Layout*.
+- Internal headers sit next to their `.c`; `include/openshieldhit/` is public headers only.
+- **Adding a unit test:** drop `tests/unit/test_<thing>.c` — it is auto-discovered by glob. Each `static void test_<name>(void)` becomes its own CTest case `unit::<file>::<name>`. Read inputs from `tests/fixtures/` via the `OSH_TEST_FIXTURES_DIR` macro; no manual CMake registration needed. See `tests/unit/README.md`.
+
+## Provenance — important
+
+OpenShieldHIT shares **zero source code** with SHIELD-HIT or SHIELD-HIT12A (SH12A).
+Do not call it a "port", "reimplementation", or "derivative" of them — those imply
+code derivation and are incorrect. The shared ground is the input-file format,
+application domain, and conceptual inspiration only. See the SH12A note in `llms.txt`.
+
+## Submitting work
+
+- One logical change per commit; PR description explains **why**, not just what (see CONTRIBUTING.md).
+- Match the existing commit/PR title style: a module prefix helps, e.g. `scoring: …`, `transport: …`, `docs: …`.
+- CI (Ubuntu/macOS/Windows) must be green: build, `ctest`, clang-format, clang-tidy.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,53 +1,210 @@
 # Developer Notes for OpenShieldHIT
 
-This document collects internal development guidelines and decisions for OSH.
-Not intended for end-users.
+This document is the authoritative source for internal coding rules and design
+rationale in OpenShieldHIT. It is intentionally more than a checklist: many
+contributors use it to learn the project style, so each rule should explain the
+reason behind the choice when the reason is not obvious.
 
-## Style
+When reviewing code, prefer referring to the numbered rules below, for example
+"violates §1" or "see §11". Tool-specific guidance files should point here
+instead of repeating these rules.
 
-- Use `struct foo` explicitly; **do not use `typedef struct`** to hide the fact that it is a struct.
-- In general, discourage `typedef` for project-defined types. Prefer the explicit type kind in declarations (`struct foo`, `enum bar`) because it makes ownership, layout, and API boundaries easier to read when scanning code.
-- For structs:
-  - Largest / most-aligned fields first
-  - Keep fields that are commonly read together near each other
-  - Keep “rarely touched” caches separate
+## How to Read This Document
 
-- Compilation follows the **C11 standard**, but with some **C90-inspired** stylistic ideas:
-  - `//` single-line comments are permitted **only for temporary code**, such as quick notes or `TODO`s. They must not remain in production code. This helps spotting temporary and WIP code.
-  - Use `stdint.h` types (e.g., `uint32_t`) only when needed.
-  - Prefer `char` for boolean flag fields in structs rather than `<stdbool.h>` — it is explicit about storage size and keeps struct layout predictable. Use `int` for function return codes.
-  - Use `<stdatomic.h>` for atomic operations on shared tallies/counters (e.g., `_Atomic`, `atomic_fetch_add`). Prefer lock-free atomics over mutexes for hot paths.
-  - Use `_Alignas(64)` on per-thread data structures to avoid false sharing across cache lines.
-  - Avoid `<threads.h>` for portability (MSVC does not implement it); use pthreads or OpenMP for the thread pool instead.
+Each numbered section is a rule group. A group may contain:
 
-- Use `const` on pointers when the function does not modify the referenced data. This clarifies ownership and protects against accidental changes.
-- Prefer `double const *p` rather than `const double *p`.
+- **Rule:** the required project convention.
+- **Reason:** the design motivation, written in prose when that helps learning.
+- **Exceptions:** allowed cases where the rule would otherwise be too blunt.
+- **Examples:** small examples of preferred and avoided forms.
 
-- Do **not** declare variables inside `for`, `if`, or other control blocks.
-  Declare them at the beginning of the block (old K&R style).
+The rules are grouped by topic rather than by severity. A later section is not
+less important than an earlier one.
 
-### Initialization and Lifetime
+## §1 C Dialect, Declarations, and Initialization
 
-- Prefer **declare early, define late**:
-  - Variables should be declared at the beginning of the block, but assigned or initialized only at the point where their value first becomes logically known.
-  - Avoid assigning placeholder values such as `0` or `NULL` merely to silence warnings; this can mask logic errors where a variable is used before being properly set.
-  - Loop counters and temporary variables should typically be assigned immediately before the loop or computation that uses them, not at function entry.
-  - The goal is that uninitialized use is detectable during review, testing, or with compiler warnings, rather than silently producing incorrect results.
+### §1.1 C Dialect and Declaration Placement
 
-- Do **not** initialize variables or structs at declaration unless required for correctness or safety.
-  Avoiding unnecessary initialization helps the compiler or developer detect logic errors where values are used before being properly assigned.
+**Rule:** OpenShieldHIT is C11, but uses a K&R-inspired declaration style. Declare
+variables at the beginning of the block. Do not declare variables inside `for`,
+`if`, `while`, or other control statements.
 
-- Acceptable reasons to initialize at declaration include:
-  - A variable must have a defined value before first conditional use.
-  - An API requires initialization (for example, pointers passed to functions that may free or overwrite them).
-  - Defensive initialization clearly improves robustness without hiding logic errors.
+### §1.2 Declare Early, Define Late
 
-### Documentation
+Prefer **declare early, define late**:
 
-Use Doxygen-style `/** ... */` block comments on all non-trivial functions,
-placed immediately before the function signature (not inside the body).
+- Put declarations at the top of the block.
+- Assign a value only when the value is logically known.
+- Avoid placeholder initializers such as `0` or `NULL` merely to silence warnings.
+- Assign loop counters and temporary variables close to the loop or computation
+  that uses them.
 
-Follow this structure:
+**Reason:** The project chooses this style because it keeps local state visible
+when scanning the start of a block. That makes review easier and keeps the code
+visually consistent with the plain-C style used throughout the codebase. This is
+not a claim that modern C cannot support mixed declarations; it is a deliberate
+project convention.
+
+Avoiding unnecessary initialization also helps reviewers and compilers catch
+logic errors. A variable that is accidentally used before it is assigned should
+look suspicious, not silently contain a placeholder value.
+
+### §1.3 Initialization Exceptions
+
+**Exceptions:** Some objects must be initialized at declaration for correctness
+or clarity:
+
+- `const` locals must receive their value when declared.
+- An API may require a pointer or handle to start as `NULL` because cleanup code
+  may free it or because an output function may overwrite it.
+- Defensive initialization is acceptable when it clearly improves robustness and
+  does not hide control-flow mistakes.
+
+Use exceptions because they express correctness, not as a way to reintroduce
+mixed declaration style.
+
+**Examples:**
+
+**Preferred:**
+
+```c
+size_t i;
+double sum;
+
+sum = 0.0;
+for (i = 0u; i < n; ++i) {
+    sum += values[i];
+}
+```
+
+**Allowed exception:**
+
+```c
+double const scale = 1.0 / norm;
+```
+
+**Avoid:**
+
+```c
+double sum = 0.0;
+for (size_t i = 0u; i < n; ++i) {
+    sum += values[i];
+}
+```
+
+## §2 Type Spelling, `const`, and Boolean Storage
+
+### §2.1 Struct and Enum Spelling
+
+**Rule:** Use `struct foo` and `enum bar` explicitly for project-defined types.
+Do not hide structs behind `typedef struct`.
+
+In general, avoid `typedef` for project-defined types. Prefer spelling out the
+kind of type in declarations.
+
+**Reason:** This is a readability choice. The code should show when a value is a
+struct instead of hiding that fact behind an alias. Seeing
+`struct osh_beam_workspace` or `enum osh_status` at a call site tells the reader
+something useful about ownership, layout, and API boundaries. It also keeps
+project-defined types from looking like built-in scalar types.
+
+### §2.2 Pointer `const` Spelling
+
+**Rule:** Use `const` on pointers when the function does not modify the
+referenced data. Prefer:
+
+```c
+double const *p;
+```
+
+over:
+
+```c
+const double *p;
+```
+
+**Reason:** Both spellings are valid C, but the project standardizes on
+right-binding `const` because it scales more predictably to complex pointer
+declarations.
+
+### §2.3 Boolean Storage and Exact-Width Integers
+
+**Rule:** Prefer `char` for boolean flag fields inside structs rather than
+`<stdbool.h>`. Use `int` for predicate return values.
+
+**Reason:** `char` makes storage size explicit in structs and keeps layout
+predictable. Predicate functions use `int` because that is the idiomatic C return
+type for yes/no checks and interacts cleanly with `if (predicate(...))`.
+
+Use `stdint.h` types such as `uint32_t` only when the exact width matters.
+
+## §3 Struct Layout and Data Locality
+
+### §3.1 Field Ordering
+
+**Rule:** Lay out structs deliberately:
+
+- Put largest or most-aligned fields first.
+- Keep fields that are commonly read together near each other.
+- Keep rarely touched caches, diagnostics, or optional state separate from hot
+  fields when that improves locality.
+
+**Reason:** Struct layout is part of performance and readability. A reader should
+be able to see which fields are central to the object's identity and which are
+supporting caches or diagnostics. Good layout also avoids accidental padding and
+helps future parallel code keep hot state compact.
+
+### §3.2 Cache-Line Alignment
+
+Use `_Alignas(64)` on per-thread or per-worker data structures when false sharing
+across cache lines is a real concern.
+
+## §4 Comments and Doxygen Documentation
+
+### §4.1 Production Comments
+
+**Rule:** Production code uses block comments, not `//` comments. Single-line
+`//` comments are reserved for temporary notes or work-in-progress markers and
+must not remain in production code.
+
+**Reason:** This makes temporary code visually distinct during review. If `//`
+appears in a diff, it should attract attention.
+
+### §4.2 Inline Declaration Comments
+
+**Rule:** Encourage short inline comments on variable declarations when the name
+or type alone does not make the role obvious.
+
+Use this especially for local state in larger functions, scratch buffers, cached
+values, ownership-sensitive pointers, and variables whose unit or lifetime is not
+immediately clear.
+
+**Reason:** Declaration comments make `.c` files much easier to scan. A reader
+can understand the local working set of a function at the declaration block
+before reading the control flow. This supports the same goal as §1: the beginning
+of a block should give a useful overview of the state the code will manipulate.
+
+**Preferred:**
+
+```c
+double *dist_batch;              /* Caller-owned boundary-distance scratch. */
+size_t primaries_completed;      /* Histories finished after pool compaction. */
+struct osh_diag_sink const *diag; /* Borrowed; NULL means silent. */
+```
+
+**Avoid:**
+
+```c
+size_t i; /* i */
+double sum; /* double sum */
+```
+
+### §4.3 Function Documentation
+
+**Rule:** Use Doxygen-style `/** ... */` block comments on non-trivial functions.
+Place the comment immediately before the function signature.
+
+Use this structure:
 
 ```c
 /**
@@ -67,98 +224,156 @@ Follow this structure:
  */
 ```
 
-Rules:
-- `@brief` is a single line — the summary a reader sees in an overview.
-- `@details` holds everything that needs more than one sentence.
-- Use `@param[in]`, `@param[out]`, `@param[in,out]` as appropriate.
-- Omit `@param` and `@returns` only for trivial flag-setter functions
-  where the signature is completely self-explanatory.
-- Inline `/* */` comments inside the function body are for
-  non-obvious *implementation* details (unit conversions, index tricks),
-  not for repeating what the Doxygen block already says.
+**Details:**
 
-### Design Decisions
+- `@brief` is a single line: the summary a reader sees in an overview.
+- `@details` holds explanations that need more than one sentence.
+- Use `@param[in]`, `@param[out]`, and `@param[in,out]` accurately.
+- Omit `@param` and `@returns` only for trivial flag-setter functions where the
+  signature is completely self-explanatory.
+- Inline `/* */` comments inside a function body are for non-obvious
+  implementation details, such as unit conversions or indexing choices. They
+  should not repeat what the Doxygen block already says.
 
-#### No Allocations on the Simulation Hot Path
+**Reason:** OpenShieldHIT is also a pedagogical codebase. Documentation should
+help readers understand not only what a function does, but why the implementation
+chooses a particular convention, algorithm, unit, or ownership model.
 
-`malloc`, `calloc`, `realloc`, and `free` must not be called during simulation,
-i.e. inside `osh_scoring_score_step()`, `osh_transport_step()`, or anything they
-call. Per-step `calloc`/`free` of scratch buffers was found to dominate CPU time
-(zeroing via `memset` accounted for ~60 % of all instructions in a CT transport
-run). All scratch buffers must be pre-allocated at compile/setup time and stored
-where the hot-path code can reuse them. Buffers that traversal *mutates* per step
-are caller-owned so they can be made per-worker without churn: the voxel-crossing
-scratch lives in a `struct osh_scoring_scratch` passed into
-`osh_scoring_score_step()`, with the serial driver's long-lived copy pre-sized at
-compile time in `osh_scoring_runtime.master_scratch` (exposed via
-`osh_scoring_runtime_master_scratch()`) and a parallel worker owning its own.
+## §5 Return Value Conventions
 
-The same caller-owned discipline applies to mutable counters on the hot path.
-The transport profile (`struct osh_transport_profile`) is per-worker: a worker
-accumulates phase timers and event counters into its own profile carried on
-`osh_worker_context.profile` (and threaded into `osh_transport_ion_step()`), never
-a shared one, so concurrent workers do not race. The serial worker points its
-profile straight at the run's master, so its values are unchanged; a parallel
-driver gives each worker a private profile and folds them in afterwards with
-`osh_transport_profile_merge()` (counters and per-phase `*_s` sum as aggregate
-work; `total_s` combines by maximum, since concurrent workers overlap in
-wall-clock time).
+### §5.1 Predicates
 
-#### API Stability
+**Rule:** Predicate functions return `int`:
 
-The public API is still early and **not yet frozen**.
-
-During this stage, prefer the cleaner interface over preserving temporary
-compatibility glue. Small or medium API changes are acceptable when they
-improve ownership, readability, naming, or module boundaries. Once the core
-architecture settles, API changes should become much more deliberate.
-
-This project is also intended as a pedagogical reference. Where practical,
-non-obvious design choices should be briefly explained in a comment near the
-decision — struct layout, ownership model, unit conventions, algorithm
-selection, and similar. The goal is that a reader can understand not just
-*what* the code does but *why*, without having to dig through git history.
-
-### General Coding Conventions
-#### Return Value Conventions
-
-Two distinct return value conventions are used, and they must not be mixed:
-
-**Predicate functions** return `int` with the meaning "yes/no":
-- `1` = true / condition holds
-- `0` = false / condition does not hold
+- `1` means true or condition holds.
+- `0` means false or condition does not hold.
 - Use `if (foo(...))` at call sites.
-- Typically named as questions: `_in_body()`, `_in_zone()`, `osh_gemca2_check_surface_side()`.
+- Predicate names should read like checks or questions where practical, for
+  example `_in_body()`, `_in_zone()`, or `osh_gemca2_check_surface_side()`.
 
-**Operation functions** return `enum osh_status` (defined in `common/osh_rc.h`):
-- `OSH_OK = 0` = success
-- Any other value = specific failure reason (see `osh_rc.h`)
+### §5.2 Operations
+
+**Rule:** Operation functions return `enum osh_status`:
+
+- `OSH_OK = 0` means success.
+- Any other value is a specific failure reason.
 - Use `if (foo(...) != OSH_OK)` at call sites.
-- Note that `OSH_OK = 0` means success, which is the **opposite** of predicate convention — do not confuse the two.
 
-Functions that return actual computed values (zone IDs, distances, counts) use their natural type (`size_t`, `double`, etc.) and document their sentinel/error value in the Doxygen `@returns` field.
+**Reason:** These two conventions intentionally differ. Predicate truth uses
+non-zero as true, while operation success uses zero through `OSH_OK`. Mixing them
+is a common C bug, so call sites should make the convention obvious.
 
-If a function is trivially infallible (e.g. a pure memcpy wrapper), prefer `void` over a dummy `return 1`.
+Functions that return computed values, such as zone IDs, distances, or counts,
+use their natural type (`size_t`, `double`, and so on) and document any sentinel
+or error value in the Doxygen `@returns` field.
 
----
+### §5.3 Infallible Functions
 
-- Public functions have `osh` prefix : `osh_foobar()`
-- Private/internal functions use `static` and no `_osh` prefix : `foobar()`
-- Private/inline functions use `static inline` and `_` prefix: `_foobar()`. This naming may be subject to change later when we settle on a better convention.
-- Prefer a top-down file layout:
-  - In public headers, place forward declarations and the public API near the top so opening the file gives an immediate module overview.
-  - In `.c` files, place exported/top-level functions before lower-level helpers. Use `static` prototypes, handler typedefs, and dispatch-table declarations near the top when needed to support this layout.
-  - Order public data structures from high-level concepts to supporting detail where the type dependencies allow it.
-- Do not add helper functions merely to shorten one call site. First look for an
-  existing function in the module that owns the concept. Add a new helper only
-  when it has a clear owner, captures reusable non-obvious logic, or prevents a
-  real consistency bug across call sites.
-- Prefer `enum` instead of `#define` numbered lists.
-- Avoid magic numbers in implementation code:
-  - Use named constants (`enum`, `static const`, or `#define` where appropriate) for option IDs, buffer sizes, exit codes, default filenames, and similar values.
-  - Small arithmetic literals directly tied to local logic (e.g. `+1` for NUL terminator sizing) are acceptable when obvious and local.
+If a function is trivially infallible, such as a pure copy helper, prefer `void`
+over a dummy success return.
 
-- Public headers must use include guards of the form:
+## §6 Naming and File Organization
+
+### §6.1 Function Naming
+
+**Rule:** Public functions use the `osh_` prefix:
+
+```c
+osh_foobar()
+```
+
+Private file-local functions are `static` and do not use an `_osh` prefix:
+
+```c
+foobar()
+```
+
+Private `static inline` helpers use a leading underscore for now:
+
+```c
+_foobar()
+```
+
+This `static inline` convention may change later if the project settles on a
+better scheme.
+
+**Reason:** The prefix marks API surface. File-local helpers should stay local
+and readable rather than pretending to be public API.
+
+### §6.2 File Layout
+
+**Rule:** Prefer top-down file layout:
+
+- In public headers, place forward declarations and public API near the top so
+  opening the file gives an immediate module overview.
+- In `.c` files, place exported or top-level functions before lower-level
+  helpers. Use `static` prototypes, handler typedefs, and dispatch-table
+  declarations near the top when needed.
+- Order public data structures from high-level concepts to supporting detail
+  where type dependencies allow it.
+
+**Reason:** Top-down layout lets a reader understand the module's public shape
+before diving into local mechanics.
+
+## §7 Helpers, Constants, and Magic Numbers
+
+### §7.1 Helper Functions
+
+**Rule:** Do not add helper functions merely to shorten one call site. First look
+for an existing function in the module that owns the concept, and scan the shared
+utility modules before writing local arithmetic or geometry helpers. Examples:
+
+- Use `src/common/osh_vect.h` for vector operations, affine transforms, dot/cross
+  products, normalization, and rotations.
+- Use `src/physics/osh_kinematics.h` for generic relativistic kinematics and
+  direction-rotation utilities.
+- Look in the owning module before adding a file-local helper; for example,
+  parsing helpers belong near parsing code, scoring helpers near scoring code,
+  and transport helpers near transport code.
+
+Add a new helper only when it has a clear owner, captures reusable non-obvious
+logic, or prevents a real consistency bug across call sites.
+
+**Exception:** Hot-path helpers may be kept local, `static`, or `static inline`
+when inlining is important for performance or when keeping the helper next to
+the hot loop makes ownership clearer. This exception is for measured or
+well-motivated hot paths, not for avoiding a search for existing utilities.
+
+**Reason:** Helpers are abstraction, not decoration. A helper that does not own a
+concept can make the call graph harder to understand. Reusing the existing
+utility functions also keeps numerics and edge-case behavior consistent across
+modules.
+
+### §7.2 Numbered Lists and Constants
+
+**Rule:** Prefer `enum` instead of `#define` for numbered lists.
+
+**Rule:** Avoid magic numbers in implementation code. Use named constants
+(`enum`, `static const`, or `#define` where appropriate) for option IDs, buffer
+sizes, exit codes, default filenames, and similar values.
+
+Before introducing a new mathematical or physical constant, check
+`include/openshieldhit/const.h` (and the internal compatibility include
+`src/common/osh_const.h`). Use project constants such as `OSH_M_PI` and
+`OSH_M_PI_180`; do not rely on non-standard platform macros such as `M_PI` from
+`math.h`.
+
+Particle identities and properties must also have one source of truth. Do not
+redefine proton, neutron, electron, ion, or PDG constants locally. Use
+`src/particle/osh_particle_const.h` for particle masses, `src/particle/osh_particle_pdg.h`
+for PDG codes, and the accessors in `src/particle/osh_particle.h` for derived
+particle properties such as nuclear or atomic mass. For example, use
+`OSH_PART_MASS_PROTON` or `osh_particle_nuclear_mass_mev_from_za()` rather than a
+local `938.272...` literal.
+
+**Exceptions:** Small arithmetic literals directly tied to local logic, such as
+`+1` for NUL terminator sizing, are acceptable when obvious and local.
+
+## §8 Public Headers and C++ Consumers
+
+### §8.1 Include Guards
+
+**Rule:** Public headers use include guards of the form:
 
 ```c
 #ifndef OSH_FOO_H
@@ -167,27 +382,39 @@ If a function is trivially infallible (e.g. a pure memcpy wrapper), prefer `void
 #endif /* OSH_FOO_H */
 ```
 
-- The idea is to provide a public API as well, allowing these header files to be linked against C++, so encapsulate headers in:
+### §8.2 C++ Linkage
+
+**Rule:** Public headers must be consumable from C++. Wrap public declarations in:
 
 ```c
 #ifdef __cplusplus
 extern "C" {
 #endif
 ```
-and the matching closing brace:
+
+and close with:
+
 ```c
 #ifdef __cplusplus
 }
 #endif
 ```
 
+**Reason:** OpenShieldHIT provides a C API that should be usable from C++ code
+without name-mangling surprises. Internal headers under `src/` should still keep
+clean include boundaries, but `include/openshieldhit/` is the public contract.
 
-## Layout
+## §9 Module Layout and Dependency Direction
 
-- All internal headers are located alongside `.c` files in `src/*`.
-- `include/` is reserved for public headers only, can be added later.
-- No use of `include/internal/` or similar.
-- Prefer a consistent per-module layout where it fits the module's lifecycle:
+### §9.1 Header Locations
+
+**Rule:** Internal headers live alongside `.c` files under `src/`. Public headers
+live under `include/openshieldhit/`. Do not create `include/internal/` or similar
+parallel internal include trees.
+
+### §9.2 Module Directory Shape
+
+**Rule:** Prefer this per-module layout when it fits the module lifecycle:
 
 ```text
 src/<module>/
@@ -196,25 +423,80 @@ src/<module>/runtime/
 src/<module>/README.md
 ```
 
-- Intended meaning of these layers:
-  - `src/<module>/` holds the module's main API, shared domain types, and setup-facing entry points.
-  - `src/<module>/parse/` holds raw input parsing and parse-only helpers.
-  - `src/<module>/runtime/` holds the compiled simulation-ready representation of parsed/setup data.
-  - `src/<module>/README.md` should briefly describe what the module owns, what `parse/` means there, and what `runtime/` means there.
+Meaning:
 
-- Dependency direction rules:
-  - `parse/` may depend on `common/` and its own module headers, but should avoid transport/runtime-specific coupling.
-  - `runtime/` may depend on `common/` and other modules' public headers when needed for simulation-time integration.
-  - `transport/` should depend on module `runtime/` layers rather than owning other modules' preparation code.
-  - `runtime/` layers must not depend on `transport/`.
-  - One module's `runtime/` layer should not reach into another module's `runtime/` internals unless that relationship is explicitly intended and documented.
+- `src/<module>/` holds the module's main API, shared domain types, and
+  setup-facing entry points.
+- `src/<module>/parse/` holds raw input parsing and parse-only helpers.
+- `src/<module>/runtime/` holds the compiled simulation-ready representation of
+  parsed or setup data.
+- `src/<module>/README.md` should briefly describe what the module owns, what
+  `parse/` means there, and what `runtime/` means there.
 
-- Do not create `parse/` or `runtime/` mechanically for every module. Use the structure when the module actually has those phases.
+**Exceptions:** Do not create `parse/` or `runtime/` mechanically for every
+module. Use those layers only when the module actually has those phases.
 
-## Portability — banned POSIX-only APIs
+### §9.3 Dependency Direction
 
-Windows is a target platform. The following POSIX-only APIs must **not** appear
-in any source or test file:
+**Dependency direction rules:**
+
+- `parse/` may depend on `common/` and its own module headers, but should avoid
+  transport/runtime-specific coupling.
+- `runtime/` may depend on `common/` and other modules' public headers when
+  needed for simulation-time integration.
+- `transport/` should depend on module `runtime/` layers rather than owning other
+  modules' preparation code.
+- `runtime/` layers must not depend on `transport/`.
+- One module's `runtime/` layer should not reach into another module's runtime
+  internals unless that relationship is explicitly intended and documented.
+
+**Reason:** The project separates cold input/setup state from hot
+simulation-ready state. The directory structure should make that lifecycle clear
+instead of hiding parsing, compilation, and transport responsibilities in one
+place.
+
+## §10 No Allocations on the Simulation Hot Path
+
+### §10.1 Allocation Rule
+
+**Rule:** `malloc`, `calloc`, `realloc`, and `free` must not be called during
+simulation hot paths, meaning inside `osh_scoring_score_step()`,
+`osh_transport_step()`, or anything they call.
+
+All scratch buffers must be pre-allocated at compile/setup time and stored where
+hot-path code can reuse them.
+
+**Reason:** Per-step allocation is expensive enough to dominate runtime. Earlier
+scratch-buffer allocation showed zeroing via `memset` accounting for roughly
+60 percent of all instructions in a CT transport run. Hot code should spend time
+on transport and scoring, not allocator and zero-fill overhead.
+
+### §10.2 Caller-Owned Scratch and Counters
+
+Buffers that traversal mutates per step are caller-owned so they can become
+per-worker without churn. The voxel-crossing scratch lives in
+`struct osh_scoring_scratch`, is passed into `osh_scoring_score_step()`, and the
+serial driver owns a long-lived copy pre-sized at compile time in
+`osh_scoring_runtime.master_scratch` (available through
+`osh_scoring_runtime_master_scratch()`). A parallel worker owns its own scratch.
+
+The same caller-owned discipline applies to mutable counters on the hot path. The
+transport profile (`struct osh_transport_profile`) is per-worker: a worker
+accumulates phase timers and event counters into its own profile carried on
+`osh_worker_context.profile` and threaded into `osh_transport_ion_step()`. Workers
+must not race on a shared profile. The serial worker points its profile straight
+at the run master, so serial values stay unchanged. A parallel driver gives each
+worker a private profile and folds them afterwards with
+`osh_transport_profile_merge()`. Counters and per-phase `*_s` values sum as
+aggregate work; `total_s` combines by maximum because concurrent workers overlap
+in wall-clock time.
+
+## §11 Portability and Banned APIs
+
+### §11.1 Banned APIs
+
+**Rule:** Windows is a target platform. POSIX-only APIs and APIs missing from
+MSVC must not appear in source or test files.
 
 | Banned | Reason | Replacement |
 |---|---|---|
@@ -223,44 +505,103 @@ in any source or test file:
 | `getpid()` | POSIX process ID | Not needed; use fixed filenames in tests |
 | `<unistd.h>` | POSIX umbrella header | Use C standard library equivalents (`<stdio.h>`, `<stdlib.h>`, `<string.h>`) |
 | `<sys/stat.h>`, `<sys/types.h>` | POSIX filesystem headers | Avoid; write to the current directory instead |
-| `<threads.h>` | C11 threads (not implemented in MSVC) | Use pthreads or OpenMP on non-Windows; guard with `#if !defined(_WIN32)` if needed |
+| `<threads.h>` | C11 threads, not implemented in MSVC | Use pthreads or OpenMP on non-Windows; guard with `#if !defined(_WIN32)` if needed |
 
-**Pattern for case-insensitive keyword matching:**
-Lowercase the string once at parse/storage time using `osh_lower_inplace()` (from
-`common/osh_readline.h`), then compare with lowercase string literals using plain
-`strcmp`. Do not use `strcasecmp` at comparison time.
+**Reason:** Portability should be visible during implementation and review, not
+discovered later in Windows CI.
 
-**Pattern for test output files:**
-Write generated files to `.` (the CTest working directory) with descriptive
-fixed names. Clean them up with `remove()` at the end of the test.
-Do not use `/tmp`, `mkdtemp`, or `getpid`-based naming.
+### §11.2 Case-Insensitive Keyword Matching
 
-## Porting Notes
+**Pattern for case-insensitive keyword matching:** Lowercase the string once at
+parse/storage time using `osh_lower_inplace()` from `common/osh_readline.h`, then
+compare with lowercase string literals using plain `strcmp`. Do not use
+`strcasecmp` at comparison time.
 
-- This is a full reimplementation. No direct code copied from SHIELD-HIT12A.
+### §11.3 Test Output Files
 
-## Build
+**Pattern for test output files:** Write generated files to `.` (the CTest
+working directory) with descriptive fixed names. Clean them up with `remove()` at
+the end of the test. Do not use `/tmp`, `mkdtemp`, or `getpid`-based names.
 
-- Uses CMake with a modular subdirectory layout.
-- Unit tests are built using `CTest`.
-- Named presets are defined in `CMakePresets.json`.
+### §11.4 Atomics and Threads
 
-### Presets
+**Rule:** Use `<stdatomic.h>` for atomic operations on shared tallies and counters
+when atomics are needed, for example `_Atomic` and `atomic_fetch_add`. Prefer
+lock-free atomics over mutexes for hot paths.
+
+**Rule:** Avoid `<threads.h>` for portability. Use pthreads or OpenMP for thread
+pools where appropriate, with platform guards where needed.
+
+## §12 API Stability and Pedagogical Comments
+
+### §12.1 API Stability
+
+**Rule:** The public API is still early and not yet frozen. During this stage,
+prefer the cleaner interface over preserving temporary compatibility glue. Small
+or medium API changes are acceptable when they improve ownership, readability,
+naming, or module boundaries.
+
+Once the core architecture settles, API changes should become much more
+deliberate.
+
+**Reason:** A young public API should not preserve mistakes too early. It is
+better to converge on clear ownership and boundaries before the interface becomes
+hard to change.
+
+### §12.2 Pedagogical Comments
+
+**Rule:** Explain non-obvious design choices near the decision when practical:
+struct layout, ownership model, unit conventions, algorithm selection, dependency
+direction, and similar.
+
+**Reason:** OpenShieldHIT is intended as a pedagogical reference. A reader should
+be able to understand not only what the code does, but why, without digging
+through git history.
+
+## §13 Source-Code Provenance
+
+**Rule:** OpenShieldHIT shares no source code with SHIELD-HIT or SHIELD-HIT12A.
+Do not describe it as a source-code port or derivative of those projects.
+
+**Reason:** The connection is the application domain, compatible input concepts,
+and scientific/algorithmic inspiration. Source-code provenance matters legally
+and scientifically, so wording should not imply copied or derived code.
+
+## §14 Build, Test, and Presets
+
+### §14.1 Presets
+
+**Rule:** The project uses CMake with a modular subdirectory layout. Named
+configure and build presets are defined in `CMakePresets.json`.
 
 | Preset | Binary dir | Flags | Use for |
 |---|---|---|---|
-| `debug` | `build_debug/` | `-O0 -g` | Day-to-day development, sanitisers |
+| `debug` | `build_debug/` | `-O0 -g` | Day-to-day development, sanitizers |
 | `release` | `build/` | `-O3` | Fastest baseline benchmarking |
-| `relwithdebinfo` | `build-rel/` | `-O3 -g` | Optimised benchmarking with symbols |
+| `relwithdebinfo` | `build-rel/` | `-O3 -g` | Optimized benchmarking with symbols |
 | `prof` | `build_prof/` | `-O3 -g -fno-omit-frame-pointer` | `perf record` / flamegraphs |
 
-Configure (first time, or after `CMakeLists` changes):
+### §14.2 Common Commands
+
+Configure, build, and test the debug build:
+
+```bash
+cmake --preset debug
+```
+
+```bash
+cmake --build --preset debug --parallel
+```
+
+```bash
+ctest --test-dir build_debug --output-on-failure
+```
+
+Configure and build the release build:
 
 ```bash
 cmake --preset release
 ```
-
-Build everything:
 
 ```bash
 cmake --build --preset release --parallel
@@ -272,26 +613,29 @@ Build one target:
 cmake --build --preset release --parallel --target gemca_raycast_bench
 ```
 
-Run tests:
+### §14.3 CTest
 
-```bash
-ctest --preset debug
-```
+**Reason:** There are no CTest presets in `CMakePresets.json`; `ctest --preset
+debug` is not valid for this repository. Point CTest at the binary directory with
+`ctest --test-dir build_debug`. On Windows or other multi-config generators, add
+`-C Debug` if needed.
 
-### AVX2 / SIMD acceleration
+## §15 AVX2 and SIMD Acceleration
 
-AVX2+FMA is detected automatically at configure time for every preset via
-`check_c_compiler_flag`.  When the compiler supports `-mavx2 -mfma`,
+**Rule:** Do not add a separate preset just for AVX2. AVX2+FMA support is
+detected automatically at configure time for every preset via
+`check_c_compiler_flag`.
+
+When the compiler supports `-mavx2 -mfma`,
 `src/gemca/runtime/osh_gemca_runtime_avx2.c` is compiled with those flags and
-linked in.  A runtime dispatch (`__builtin_cpu_supports("avx2")`) ensures the
-binary still runs on CPUs without AVX2.
+linked in. Runtime dispatch through `__builtin_cpu_supports("avx2")` keeps the
+binary usable on CPUs without AVX2.
 
-The configure output will tell you whether it was detected:
+The configure output says which path was selected:
 
-```
+```text
 -- gemca_runtime: AVX2+FMA zone batch enabled
 -- gemca_runtime: AVX2+FMA not available, using scalar fallback
 ```
 
-You do **not** need a separate preset for AVX2.  The `release` preset is the
-one to use for SIMD benchmarking.
+Use the `release` preset for SIMD benchmarking.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -647,6 +647,22 @@ Build one target:
 cmake --build --preset release --parallel --target gemca_raycast_bench
 ```
 
+### §14.3 Formatting and Static Analysis
+
+**Rule:** Respect the repository's local formatting and static-analysis
+configuration. Use the checked-in clang-format and clang-tidy settings; do not
+apply a personal formatter style or editor defaults that disagree with the repo.
+
+Run formatting before submitting C or header changes:
+
+```bash
+./tools/clang-format-all.sh
+```
+
+**Reason:** Formatting and static-analysis settings are part of the project
+contract. Keeping them local and version-controlled avoids style drift between
+contributors, editors, operating systems, and LLM-generated patches.
+
 ## §15 Hot-Path Data Layout, SIMD, and Offload Readiness
 
 ### §15.1 SoA-Ready Hot Paths

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -491,6 +491,40 @@ worker a private profile and folds them afterwards with
 aggregate work; `total_s` combines by maximum because concurrent workers overlap
 in wall-clock time.
 
+### §10.3 Expensive Math on Hot Paths
+
+**Rule:** Avoid repeated calls to expensive transcendental functions such as
+`sin()`, `cos()`, `tan()`, `acos()`, `asin()`, `atan2()`, `log()`, `exp()`, and
+`pow()` on hot paths when the value can be precomputed, tabulated, cached, or
+rewritten with simpler arithmetic.
+
+**Reason:** These functions are often much more expensive than additions,
+multiplications, fused multiply-adds, or table lookups. In per-step transport,
+geometry, scoring, or inner physics loops, even a single avoidable
+transcendental call can become visible in profiles.
+
+**Exceptions:** Use the mathematically correct function when the physics or
+geometry requires it. The rule is to avoid unnecessary repeated evaluation, not
+to replace clear and correct physics with fragile approximations. Good patterns
+include computing `sin`/`cos` once at parse/setup time for fixed angles, carrying
+both `cos_phi` and `sin_phi` from a sampling helper, using squared lengths when
+only comparisons are needed, and documenting any approximation used in hot code.
+
+**Example:** Avoid generic `pow()` for simple fixed exponents in hot code.
+
+```c
+y = x * sqrt(x); /* preferred for x^(3/2) */
+```
+
+instead of:
+
+```c
+y = pow(x, 1.5);
+```
+
+The `pow()` form is general and may cost substantially more CPU cycles than the
+specialized expression.
+
 ## §11 Portability and Banned APIs
 
 ### §11.1 Banned APIs

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -647,18 +647,40 @@ Build one target:
 cmake --build --preset release --parallel --target gemca_raycast_bench
 ```
 
-### §14.3 CTest
+## §15 Hot-Path Data Layout, SIMD, and Offload Readiness
 
-**Reason:** There are no CTest presets in `CMakePresets.json`; `ctest --preset
-debug` is not valid for this repository. Point CTest at the binary directory with
-`ctest --test-dir build_debug`. On Windows or other multi-config generators, add
-`-C Debug` if needed.
+### §15.1 SoA-Ready Hot Paths
 
-## §15 AVX2 and SIMD Acceleration
+**Rule:** Design simulation hot paths so they remain friendly to
+structure-of-arrays (SoA) storage, vectorization, SIMD kernels, and future
+offload backends where applicable.
 
-**Rule:** Do not add a separate preset just for AVX2. AVX2+FMA support is
-detected automatically at configure time for every preset via
-`check_c_compiler_flag`.
+Prefer APIs and data flow that operate on contiguous arrays or explicit batches
+of the same field, rather than interleaving unrelated per-history state in a
+single large object. Keep cold metadata separate from per-step mutable state.
+When adding hot-path state, ask whether a future worker, SIMD lane, or GPU kernel
+could consume it without unpacking an array-of-structs layout first.
+
+**Reason:** The current serial code should not block future performance work.
+OpenShieldHIT already uses pool-style transport state and batched geometry/scoring
+operations; new hot code should preserve that direction. SoA-friendly design
+makes cache behavior easier to reason about, enables explicit SIMD kernels, and
+keeps a path open for thread, accelerator, or GPU offload work if a module later
+justifies it.
+
+**Examples:**
+
+- Prefer separate arrays such as `x[]`, `y[]`, `z[]`, `ux[]`, `uy[]`, `uz[]`,
+  `e[]` for live particle state over an array of large per-particle structs.
+- Pass caller-owned scratch arrays into hot kernels instead of allocating or
+  hiding scratch inside the callee.
+- Keep immutable species/material metadata shared and separate from per-history
+  mutable state.
+
+### §15.2 Current AVX2 Dispatch
+
+**Rule:** Do not add a separate preset just for AVX2. AVX2+FMA support is detected
+automatically at configure time for every preset via `check_c_compiler_flag`.
 
 When the compiler supports `-mavx2 -mfma`,
 `src/gemca/runtime/osh_gemca_runtime_avx2.c` is compiled with those flags and

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@ OpenShieldHIT transports ions (protons, heavier ions) through 3D geometry using 
 ## Key documents
 
 - [README.md](README.md) — overview, build, install, application usage, public C API, repository layout
-- [DEVELOPER.md](DEVELOPER.md) — coding style, naming conventions, struct layout rules, C11 portability constraints (no POSIX-only APIs), module dependency rules, CMake presets
+- [DEVELOPER.md](DEVELOPER.md) — authoritative numbered coding ruleset (§1–§15): coding style, naming conventions, struct layout rules, C11 portability constraints (no POSIX-only APIs), module dependency rules, CMake presets
 - [TODO.md](TODO.md) — known open work items; treat as directional, not authoritative (items may be stale)
 - [docs/user/beam.dat.md](docs/user/beam.dat.md) — complete keyword reference for the beam input file
 - [docs/user/detect.dat.md](docs/user/detect.dat.md) — scored quantities (Dose in MeV/g, DoseGy in Gy, Fluence, DLET, TLET, …) and output formats
@@ -19,10 +19,11 @@ OpenShieldHIT transports ions (protons, heavier ions) through 3D geometry using 
 ```bash
 cmake --preset release && cmake --build --preset release --parallel   # optimised
 cmake --preset debug   && cmake --build --preset debug --parallel     # debug + sanitisers
-ctest --preset debug                                        # run tests
+ctest --test-dir build_debug --output-on-failure                      # run tests
 ```
 
-Binaries: `build_rel/bin/openshieldhit` (release) or `build/bin/openshieldhit` (debug).
+There are no CTest presets — point `ctest` at the binary dir (`--test-dir build_debug`), not `--preset`.
+Binaries: `build/bin/openshieldhit` (release) or `build_debug/bin/openshieldhit` (debug). Full preset table and commands: DEVELOPER.md §14.
 
 ## Running a simulation
 
@@ -60,16 +61,20 @@ tests/cases/             end-to-end integration cases (each is a self-contained 
 tests/fixtures/          small shared input files reused across unit tests
 ```
 
-## Key conventions (from DEVELOPER.md)
+## Coding conventions
 
-- **C11**, but no `//` single-line comments in production code (reserved for TODO/WIP)
-- No `typedef struct` — use `struct foo` explicitly everywhere
-- No POSIX-only APIs (`strcasecmp`, `mkdtemp`, `<unistd.h>`) — Windows is a target
-- Case-insensitive keyword matching: lowercase at parse time with `osh_lower_inplace()`, then `strcmp`
-- All public functions prefixed `osh_`; internal helpers are `static` with no prefix
-- Return values: predicate functions return `int` (1/0); operation functions return `enum osh_status` (OSH_OK = 0 = success)
-- No heap allocations on the simulation hot path (inside `osh_scoring_score_step` or `osh_transport_step`)
-- Doxygen `/** @brief / @param / @returns */` blocks on all non-trivial functions
+Coding rules are **not** duplicated here — [`DEVELOPER.md`](DEVELOPER.md) is the
+authoritative, numbered ruleset (§1–§15). Cite a section (e.g. "violates §1")
+rather than paraphrasing. This map points at the sections agents need most:
+
+- C dialect, K&R top-of-block declarations, initialization — §1
+- Type / `const` / boolean spelling (`struct foo`, `double const *p`) — §2
+- Comments and Doxygen (block `/* */` only in production) — §4
+- Return conventions (predicate `int` vs `enum osh_status`, `OSH_OK = 0`) — §5
+- Naming and file layout (`osh_` prefix; `static` helpers) — §6
+- Module layout and dependency direction — §9
+- No allocations on the simulation hot path — §10
+- Portability, banned APIs, case-insensitive keyword matching — §11
 
 ## Unit conventions
 


### PR DESCRIPTION
Closes #205.

## Why

Issue #205 asks for a `CLAUDE.md` (and "any agentic configs as well"). The
discussion on the issue already set the direction:

- **@nbassler** was wary this could "get very messy" and would rather lean on the
  existing `llms.txt`.
- **@grzanka** laid out the distinction: `llms.txt` tells *any* AI *what the
  project is and where to look*; a `CLAUDE.md` tells an agent *how to behave while
  modifying the code* — and, crucially, since we've already invested in
  `DEVELOPER.md`, it "would probably just point Claude at that file rather than
  repeating it."

This PR follows that steer literally. It's the same "one source of truth, thin
signpost, don't duplicate" reasoning @grzanka argued for the `INSTALL.md`
question on #164 — applied to agent config.

## What

- **`CLAUDE.md`** — a lean, one-screen operating brief for coding agents. It is a
  *signpost*, not a second copy: a table routes to `DEVELOPER.md` (style
  authority), `llms.txt` (project map), `CONTRIBUTING.md`, `docs/`, and per-module
  READMEs. It then captures only the high-value, repo-specific things an agent
  gets wrong:
  - verified build / test / format commands, one command per copy-block (the
    convention from #164);
  - the handful of hard rules agents break most (K&R block-top declarations, no
    `typedef struct`, no `//` in production, `double const *p`, banned POSIX-only
    APIs, no hot-path allocation, predicate-`int` vs `enum osh_status`), each
    pointing back to `DEVELOPER.md` for the full set;
  - module layout and how the auto-discovered `tests/unit/test_*.c` harness works;
  - the SH12A zero-shared-code provenance note.
- **`AGENTS.md`** and **`.github/copilot-instructions.md`** — thin pointers to
  `CLAUDE.md` so other tools (and GitHub Copilot, which is actively used on this
  repo for reviews and `@copilot` tasks) land on the same page. They are
  redirects, not copies, so nothing can drift. Copilot's file additionally inlines
  the few C rules it most needs at generation time.

Addresses the "messy" concern by keeping exactly **one** place with real content;
the other two files are 2–15 line redirects.

## Accuracy

Commands were checked against `CMakePresets.json` and the CI workflow, not copied
from prose. One correction worth flagging: there are **no CTest presets**, so
`ctest --preset debug` errors with *"No such test preset"* — `CLAUDE.md` documents
the working form `ctest --test-dir build_debug` instead. (Copilot flagged this same
issue on #164; `llms.txt` still carries the outdated `ctest --preset debug` and a
stale `build_rel/` release path — happy to fix those in a small follow-up if
wanted, kept out of scope here.)

## Notes

Docs-only; no code paths touched, so CI is build/format/tidy + the existing test
suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sX2yXJShQJn8HV3iergoQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013sX2yXJShQJn8HV3iergoQ)_