### PR TITLE
transport: stop silently dropping ion nuclear secondaries (#213)

### DIFF
--- a/docs/dev/random_numbers.md
+++ b/docs/dev/random_numbers.md
@@ -236,25 +236,30 @@ These depend only on `(seed, index)`. Whether history 1 runs first, last, on
 thread 0 or 47, in a pool of 1 or 65536, its sequence is the same — the
 order-independence guarantee, locked by `test_seed_history_order_independence`.
 
-### Worked example — a secondary via `split` (verified output)
+### Worked example — a secondary via `split` (verified output, `seed = 2025`)
 
 Primary history 7 takes two physics draws, then a nuclear event spawns a
-secondary, seeded by splitting the parent:
+secondary, seeded by splitting the parent at ordinal 0. The split reads the
+parent's state but **never advances it**, so the parent draws the same next
+value whether or not the secondary was ever created:
 
 ```
-parent (hist 7) draws #1,#2:  0.223872  0.725151
-child  first 2 draws:         0.252732  0.955397
-parent next draw (split advanced it by two): 0.609548
+parent (hist 7) draws #1,#2:      0.223872  0.725151
+child (ordinal 0) first 2 draws:  0.955397  0.252732
+parent's next draw, split done:   0.632358
+parent's next draw, no split:     0.632358   (identical)
 ```
 
-Re-run with any pool capacity / thread / rank and the child is identical:
+Re-run with any pool capacity / thread / rank — or drop the secondary
+altogether — and both streams are unchanged:
 
 ```
-child  first 2 draws again:   0.252732  0.955397   (identical)
+child (ordinal 0) first 2 draws again:  0.955397  0.252732   (identical)
 ```
 
-The child is independent of the parent's continuation yet fully determined by
-the parent's lineage — see `test_split_deterministic`.
+The child stream is a pure function of the parent's lineage and its ordinal,
+and the parent is independent of whether the child was ever split — see
+`test_split_deterministic` and `test_split_nonconsuming_and_drop_independent`.
 
 ### What is and isn't guaranteed
 

--- a/docs/dev/random_numbers.md
+++ b/docs/dev/random_numbers.md
@@ -90,7 +90,8 @@ int      osh_rng_poisson(struct osh_rng *r, double lambda);
 /* Per-history seeding (see §6) */
 void     osh_rng_seed_history(struct osh_rng *r, enum osh_rng_type t,
                               uint64_t seed, uint64_t hist_index, enum osh_rng_purpose p);
-void     osh_rng_split(struct osh_rng *child, struct osh_rng *parent);
+void     osh_rng_split(struct osh_rng *child, struct osh_rng const *parent,
+                       uint64_t ordinal);
 ```
 
 **Uniform reals.** `osh_rng_double` takes the top 53 bits of a 64-bit draw and
@@ -190,19 +191,32 @@ particle, not the schedule:
   purpose seeds a transient generator for source sampling, so the source phase
   space is identical regardless of which physics options are enabled.
 - **Secondaries** (nuclear recoils, abrasion nucleons, Fermi break-up fragments)
-  get their stream by **splitting from the parent** with `osh_rng_split`, which
-  draws two values from the parent to seed the child. The parent's draw sequence
-  is deterministic along its own lineage, so the child stream is reproducible no
-  matter when the secondary is created.
+  get their stream by **splitting from the parent** with `osh_rng_split(child,
+  parent, ordinal)`. The split seeds the child from a *private copy* of the
+  parent advanced to the child's `ordinal` slot; it **does not consume a draw
+  from the parent**. The child stream is therefore a pure function of the
+  parent's state (itself a pure function of the parent's lineage) and the
+  ordinal — reproducible no matter when the secondary is created, and, crucially,
+  independent of whether any sibling was injected or dropped (see the note below).
 
 ```
 primary 0   stream = mix(seed, base+0, PHYSICS)
 primary 1   stream = mix(seed, base+1, PHYSICS)
   │  ... transports, draws, then a nuclear event fires ...
-  ├─ secondary 1a   stream = split(parent₁)   ← consumes parent draws #k, #k+1
-  └─ secondary 1b   stream = split(parent₁)   ← consumes parent draws #k+2, #k+3
+  ├─ secondary 1a   stream = split(parent₁, ordinal 0)   ← parent unchanged
+  └─ secondary 1b   stream = split(parent₁, ordinal 1)   ← parent unchanged
 primary 2   stream = mix(seed, base+2, PHYSICS)
 ```
+
+!!! note "Splitting is drop-independent (issue #213)"
+    Because the split reads but never advances the parent, and each sibling is
+    keyed by its ordinal rather than by the *order* it consumes parent draws, a
+    secondary that is reordered or silently dropped (e.g. when a pool overflows)
+    cannot shift its parent's or its siblings' streams. Reproducibility of the
+    whole lineage is thus independent of pool occupancy and the checkpoint batch
+    schedule. An earlier consuming `osh_rng_split` coupled the parent's stream to
+    how many children were injected, which made scored output depend on the batch
+    size when a full primary wavefront overflowed the ion pool.
 
 Each stream is a pure function of `(seed, index, purpose)` or of its parent's
 lineage, so the random inputs to a history are **invariant** under pool

--- a/include/openshieldhit/simulation.h
+++ b/include/openshieldhit/simulation.h
@@ -59,18 +59,20 @@ enum osh_status osh_simulation_create(struct osh_beam_workspace *beam,
  * bit-identical scoring output to unprofiled ones.
  */
 struct osh_simulation_profile {
-    double transport_s;                  /**< Total transport wall time [s]. */
-    double phase_fill_s;                 /**< Pool refill from the beam source [s]. */
-    double phase_zone_ref_s;             /**< Batched zone-ref lookup [s]. */
-    double phase_distance_s;             /**< Batched boundary-distance query [s]. */
-    double phase_step_s;                 /**< Per-particle physics step loop [s]. */
-    double phase_compact_s;              /**< Dead-slot pool compaction [s]. */
-    unsigned long long steps;            /**< Total transport steps taken. */
-    unsigned long long iterations;       /**< Wavefront loop iterations. */
-    unsigned long long nuclear_events;   /**< Nuclear interactions sampled. */
-    unsigned long long secondaries;      /**< Secondaries produced by nuclear events. */
-    unsigned long long neutrons_banked;  /**< Neutrons routed to the (untransported) neutron pool. */
-    unsigned long long fragments_banked; /**< Residual fragments banked for future breakup. */
+    double transport_s;                         /**< Total transport wall time [s]. */
+    double phase_fill_s;                        /**< Pool refill from the beam source [s]. */
+    double phase_zone_ref_s;                    /**< Batched zone-ref lookup [s]. */
+    double phase_distance_s;                    /**< Batched boundary-distance query [s]. */
+    double phase_step_s;                        /**< Per-particle physics step loop [s]. */
+    double phase_compact_s;                     /**< Dead-slot pool compaction [s]. */
+    unsigned long long steps;                   /**< Total transport steps taken. */
+    unsigned long long iterations;              /**< Wavefront loop iterations. */
+    unsigned long long nuclear_events;          /**< Nuclear interactions sampled. */
+    unsigned long long secondaries;             /**< Secondaries produced by nuclear events. */
+    unsigned long long neutrons_banked;         /**< Neutrons routed to the (untransported) neutron pool. */
+    unsigned long long fragments_banked;        /**< Residual fragments banked for future breakup. */
+    unsigned long long ion_secondaries_dropped; /**< Ion secondaries lost to pool overflow; 0 in the default
+                                                     configuration, which reserves secondary headroom (issue #213). */
 };
 
 /**

--- a/src/apps/osh/osh_run.c
+++ b/src/apps/osh/osh_run.c
@@ -1057,7 +1057,8 @@ static enum osh_status run_write_profile_json(char const *path,
             "\"step_s\":%.9g,\"compact_s\":%.9g,\"sum_s\":%.9g},"
             "\"counters\":{\"steps\":%llu,\"steps_per_primary\":%.9g,"
             "\"iterations\":%llu,\"nuclear_events\":%llu,\"secondaries\":%llu,"
-            "\"neutrons_banked\":%llu,\"fragments_banked\":%llu}}\n",
+            "\"neutrons_banked\":%llu,\"fragments_banked\":%llu,"
+            "\"ion_secondaries_dropped\":%llu}}\n",
             osh_version_string(),
             run_compiler_string(),
             nstat,
@@ -1081,7 +1082,8 @@ static enum osh_status run_write_profile_json(char const *path,
             prof->nuclear_events,
             prof->secondaries,
             prof->neutrons_banked,
-            prof->fragments_banked);
+            prof->fragments_banked,
+            prof->ion_secondaries_dropped);
 
     if (fclose(fp) != 0) {
         OSH_DIAG_ERRORF(diag, "profile: failed to finalize '%s'", path);

--- a/src/common/osh_particle_pool.c
+++ b/src/common/osh_particle_pool.c
@@ -103,6 +103,7 @@ static enum osh_status particle_pool_alloc_slab(struct osh_particle_pool *pool, 
 
     pool->n = 0u;
     pool->capacity = capacity;
+    pool->n_dropped = 0u;
     return OSH_OK;
 }
 

--- a/src/common/osh_particle_pool.h
+++ b/src/common/osh_particle_pool.h
@@ -102,8 +102,12 @@ struct osh_particle_pool {
     struct particle const **species; /* one pointer per entry into the particle registry */
 
     /* ---- Bookkeeping ---- */
-    size_t n;        /* number of live entries in [0, n)   */
-    size_t capacity; /* total allocated slots               */
+    size_t n;         /* number of live entries in [0, n)   */
+    size_t capacity;  /* total allocated slots               */
+    size_t n_dropped; /* secondaries lost to overflow (diag); mirrors the
+                       * neutron pool's n_dropped.  Never reset by compaction,
+                       * so it accumulates across wavefront passes and
+                       * checkpoint batches for the run-level diagnostic. */
 };
 
 /* ---- Lifecycle ----------------------------------------------------------- */

--- a/src/random/osh_rng.c
+++ b/src/random/osh_rng.c
@@ -87,12 +87,38 @@ void osh_rng_seed_history(
     osh_rng_init(rng, type, seed, stream);
 }
 
-void osh_rng_split(struct osh_rng *child, struct osh_rng *parent) {
-    /* Two draws from the parent supply independent seed and stream entropy.
-     * Deterministic along the parent's lineage, hence reproducible regardless
-     * of how the wavefront schedules sibling histories. */
-    uint64_t const child_seed = osh_rng_u64(parent);
-    uint64_t const child_stream = osh_rng_u64(parent);
+void osh_rng_split(struct osh_rng *child, struct osh_rng const *parent, uint64_t ordinal) {
+    /*
+     * Seed the child from a *private copy* of the parent advanced to the
+     * child's ordinal slot.  The parent's own stream is deliberately never
+     * consumed: splitting reads parent state but does not advance it.
+     *
+     * This is what makes secondary seeding drop-, reorder-, and overflow-proof
+     * (issue #213; design in #148).  Because splitting no longer draws from the
+     * parent, whether a sibling secondary is injected, reordered, or silently
+     * dropped when a pool is full can never shift the parent's — or any other
+     * sibling's — subsequent draws.  Each child stream is a pure function of
+     * its lineage key (the parent's current state, itself a pure function of
+     * the parent's own draws) and its ordinal, so reproducibility no longer
+     * depends on pool occupancy or wavefront scheduling.
+     *
+     * Ordinal k owns the disjoint two-draw window [2k, 2k+1] of the copied
+     * stream — the exact layout the old sequential split produced — so an
+     * injected child keeps the identical stream it had before, while the parent
+     * is left untouched.  The scan cost is O(ordinal); secondary counts per
+     * event are bounded (OSH_NUCLEAR_MAX_SECONDARIES), so this is negligible.
+     */
+    struct osh_rng scan = *parent; /* copy: parent is const and stays put */
+    uint64_t child_seed;
+    uint64_t child_stream;
+    uint64_t i;
+
+    for (i = 0u; i < ordinal; ++i) {
+        (void) osh_rng_u64(&scan);
+        (void) osh_rng_u64(&scan);
+    }
+    child_seed = osh_rng_u64(&scan);
+    child_stream = osh_rng_u64(&scan);
 
     osh_rng_init(child, parent->type, child_seed, child_stream);
 }

--- a/src/random/osh_rng.h
+++ b/src/random/osh_rng.h
@@ -167,19 +167,27 @@ void osh_rng_seed_history(
     struct osh_rng *rng, enum osh_rng_type type, uint64_t seed, uint64_t hist_index, enum osh_rng_purpose purpose);
 
 /**
- * @brief Derive an independent child stream from a parent (splittable RNG).
+ * @brief Derive an independent child stream from a parent, keyed by ordinal.
  *
  * @details
- * Consumes two draws from @p parent to seed @p child on a fresh, independent
- * stream.  Because the parent's own draw sequence is deterministic along its
- * lineage, the child stream is reproducible and independent of how histories
- * are scheduled — the seeding primitive for nuclear secondaries, whose count
- * and order are fixed by the parent's physics, not by the pool layout.
+ * Seeds @p child from a private copy of @p parent advanced to the child's
+ * @p ordinal slot.  Crucially it does **not** consume a draw from @p parent:
+ * splitting reads the parent's state but never advances it.  A secondary that
+ * is later dropped, reordered, or lost to pool overflow therefore cannot shift
+ * its parent's or its siblings' streams, so reproducibility is independent of
+ * pool occupancy and wavefront scheduling (issue #213; design in #148).
  *
- * @param child  RNG state to initialise (engine type inherited from parent).
- * @param parent Parent RNG; advanced by two draws.
+ * The child stream is a pure function of the parent's current state (itself a
+ * pure function of the parent's lineage) and @p ordinal.  Siblings produced by
+ * one event are separated by giving each a distinct @p ordinal (its index in
+ * the event's secondary list); ordinal @c k reproduces exactly the stream the
+ * old sequential split assigned to the k-th secondary.
+ *
+ * @param child   RNG state to initialise (engine type inherited from parent).
+ * @param parent  Parent RNG; read only, never advanced.
+ * @param ordinal Zero-based index of this child among its siblings.
  */
-void osh_rng_split(struct osh_rng *child, struct osh_rng *parent);
+void osh_rng_split(struct osh_rng *child, struct osh_rng const *parent, uint64_t ordinal);
 
 /**
  * @brief Generate a 32-bit unsigned integer.

--- a/src/simulation/osh_simulation.c
+++ b/src/simulation/osh_simulation.c
@@ -75,13 +75,37 @@ static int prepared_has_voxel_body(struct osh_gemca_prepared const *gemca) {
 
 /* ---- Transport pool + scratch helpers ------------------------------------ */
 
-/* Ion wavefront batch size: user override or compiled default, clamped to nstat. */
-static size_t simulation_ion_pool_capacity(struct osh_transport_params const *p) {
-    size_t cap = (p->pool_capacity != 0u) ? p->pool_capacity : (size_t) OSH_TRANSPORT_POOL_CAPACITY;
-    if (p->nstat > 0u && cap > p->nstat) {
-        cap = p->nstat;
+/* Ion wavefront width: primaries injected per pool fill — the user override or
+ * compiled default, never more than nstat.  This is the cache/parallelism perf
+ * knob ("primaries in flight"); it does NOT bound the pool allocation. */
+static size_t simulation_ion_wavefront_width(struct osh_transport_params const *p) {
+    size_t width = (p->pool_capacity != 0u) ? p->pool_capacity : (size_t) OSH_TRANSPORT_POOL_CAPACITY;
+    if (p->nstat > 0u && width > p->nstat) {
+        width = p->nstat;
     }
-    return cap;
+    return width;
+}
+
+/* Allocated ion-pool capacity: the wavefront width PLUS headroom for the nuclear
+ * secondaries a full wavefront can inject before the next compaction.
+ *
+ * Clamping capacity to the wavefront width (the pre-#213 behaviour) left a full
+ * primary wavefront with zero room for its recoils/abrasion nucleons/break-up
+ * fragments, so they were silently dropped — and, because the drop count tracked
+ * the checkpoint batch schedule, scored results depended on the batch size
+ * (issue #213).  Doubling the width gives 100 % headroom: secondaries drain each
+ * wavefront pass, so peak occupancy stays far below capacity in practice and the
+ * default configuration drops nothing.  Any residual overflow on an aggressively
+ * small capacity is counted (osh_particle_pool::n_dropped) and cannot perturb the
+ * parent stream (osh_rng_split is lineage+ordinal-keyed), so scored output stays
+ * batch- and capacity-invariant regardless. */
+static size_t simulation_ion_pool_capacity(struct osh_transport_params const *p) {
+    size_t const width = simulation_ion_wavefront_width(p);
+    size_t const headroom = width;
+    if (width > ((size_t) -1) - headroom) {
+        return (size_t) -1; /* saturate rather than overflow the sum */
+    }
+    return width + headroom;
 }
 
 /* Neutron accumulation buffer size: must span the full ion run (all nstat batches),
@@ -130,6 +154,11 @@ static enum osh_status simulation_alloc_pools(struct osh_simulation *sim) {
     sim->transport_ctx.zone_refs = zr;
     sim->transport_ctx.dist_batch = db;
     sim->transport_ctx.scratch_capacity = ion_cap;
+
+    /* Fill injects only a wavefront's worth of primaries; the remaining capacity
+     * (ion_cap - width) is the secondary headroom that keeps issue #213's drop
+     * from happening in the default configuration. */
+    sim->transport_ctx.ion_wavefront_width = simulation_ion_wavefront_width(&sim->transport_ctx.params);
 
     sim->transport_ctx.ion_pool = &sim->ion_pool;
     sim->transport_ctx.neutron_pool = &sim->neutron_pool;
@@ -450,6 +479,7 @@ enum osh_status osh_simulation_get_profile(struct osh_simulation const *sim, str
     out->secondaries = sim->profile.secondaries;
     out->neutrons_banked = (unsigned long long) sim->neutron_pool.n_created;
     out->fragments_banked = (unsigned long long) sim->fragment_pool.n_created;
+    out->ion_secondaries_dropped = (unsigned long long) sim->ion_pool.n_dropped;
     return OSH_OK;
 }
 
@@ -485,6 +515,15 @@ enum osh_status osh_simulation_run(struct osh_simulation *sim) {
                        "simulation: %zu neutron(s) created, %zu dropped (pool overflow)",
                        sim->neutron_pool.n_created,
                        sim->neutron_pool.n_dropped);
+    }
+    if (sim->ion_pool.n_dropped > 0u) {
+        /* A drop means deposited energy was lost; the default configuration
+         * reserves secondary headroom so this never fires (issue #213).  Warn
+         * (not info) and point at the fix so it can never pass unnoticed. */
+        OSH_DIAG_WARNF(sim->diag,
+                       "simulation: %zu ion secondary/secondaries dropped (pool overflow); "
+                       "raise the pool capacity to avoid losing their deposited energy",
+                       sim->ion_pool.n_dropped);
     }
     if (sim->fragment_pool.n_sent_breakup > 0u) {
         OSH_DIAG_INFOF(sim->diag,

--- a/src/simulation/osh_simulation.c
+++ b/src/simulation/osh_simulation.c
@@ -95,10 +95,11 @@ static size_t simulation_ion_wavefront_width(struct osh_transport_params const *
  * the checkpoint batch schedule, scored results depended on the batch size
  * (issue #213).  Doubling the width gives 100 % headroom: secondaries drain each
  * wavefront pass, so peak occupancy stays far below capacity in practice and the
- * default configuration drops nothing.  Any residual overflow on an aggressively
- * small capacity is counted (osh_particle_pool::n_dropped) and cannot perturb the
- * parent stream (osh_rng_split is lineage+ordinal-keyed), so scored output stays
- * batch- and capacity-invariant regardless. */
+ * default configuration drops nothing, so scored output is batch- and
+ * capacity-invariant.  Any residual overflow on an aggressively small capacity is
+ * counted (osh_particle_pool::n_dropped) and WARNed; it cannot perturb a surviving
+ * history's stream (osh_rng_split is lineage+ordinal-keyed), so the only cost is
+ * the dropped secondaries' own deposited energy. */
 static size_t simulation_ion_pool_capacity(struct osh_transport_params const *p) {
     size_t const width = simulation_ion_wavefront_width(p);
     size_t const headroom = width;

--- a/src/transport/osh_transport.c
+++ b/src/transport/osh_transport.c
@@ -1,6 +1,7 @@
 #include "transport/osh_transport.h"
 
 #include "common/osh_diag.h"
+#include "common/osh_particle_pool.h"
 #include "transport/osh_checkpoint_policy.h"
 #include "transport/osh_neutron_pool.h"
 #include "transport/osh_transport_ion.h"
@@ -90,6 +91,15 @@ enum osh_status osh_transport_run_minimal(struct osh_transport_context *transpor
         } else {
             osh_neutron_pool_reset(transport_ctx->neutron_pool);
         }
+    }
+
+    /* Reset the ion-secondary drop counter for this run (mirrors the neutron
+     * pool reset above), so a re-run reports drops for the current run only.
+     * It then accumulates across all checkpoint batches, since the per-batch
+     * osh_transport_ion_run_range resets only the pool's live count, never
+     * n_dropped. */
+    if (transport_ctx->ion_pool != NULL) {
+        transport_ctx->ion_pool->n_dropped = 0u;
     }
 
     /* ---- Outer checkpoint batch loop ------------------------------------- */

--- a/src/transport/osh_transport.h
+++ b/src/transport/osh_transport.h
@@ -184,6 +184,14 @@ struct osh_transport_context {
     struct osh_zone_ref *zone_refs;                        /**< Transport scratch: zone/material per slot. */
     double *dist_batch;                                    /**< Transport scratch: boundary distance per slot. */
     size_t scratch_capacity;                               /**< Number of entries in zone_refs and dist_batch. */
+    size_t ion_wavefront_width;                            /**< Primaries injected per ion-pool fill (the
+                                                                cache/parallelism perf knob).  The pool is
+                                                                allocated wider than this so a full primary
+                                                                wavefront still has headroom for the nuclear
+                                                                secondaries it produces (issue #213).  0 falls
+                                                                back to the full pool capacity — the pre-#213
+                                                                behaviour — for callers that build a context
+                                                                without a simulation (e.g. unit tests). */
     struct osh_transport_profile *profile;                 /**< Borrowed master/destination profile; NULL disables
                                                                 phase timers/counters.  Written by a worker (the lone
                                                                 serial worker points its own profile here) or by the

--- a/src/transport/osh_transport_ion.c
+++ b/src/transport/osh_transport_ion.c
@@ -100,6 +100,7 @@ static enum osh_status run_history_range(struct osh_worker_context *wctx,
     size_t primaries_completed;
     size_t n_fill;
     size_t n_wavefront;
+    size_t width; /* primaries injected this fill: wavefront cap, headroom left for secondaries */
     size_t i;
     size_t step_budget;
     size_t steps_taken;
@@ -177,7 +178,7 @@ static enum osh_status run_history_range(struct osh_worker_context *wctx,
          * context built without a simulation) falls back to the full capacity —
          * the pre-#213 behaviour. */
         if (!stop && pool->n == 0u && primaries_done < nstat) {
-            size_t width = transport_ctx->ion_wavefront_width;
+            width = transport_ctx->ion_wavefront_width;
             if (width == 0u || width > pool->capacity) {
                 width = pool->capacity;
             }

--- a/src/transport/osh_transport_ion.c
+++ b/src/transport/osh_transport_ion.c
@@ -168,11 +168,22 @@ static enum osh_status run_history_range(struct osh_worker_context *wctx,
         }
 
         /* Fill the pool when it is empty and primaries remain — never after a
-         * stop request, so no new primary is injected once we begin draining. */
+         * stop request, so no new primary is injected once we begin draining.
+         *
+         * Inject at most `wavefront_width` primaries, NOT the full pool capacity:
+         * the extra capacity is reserved as headroom for the nuclear secondaries
+         * this wavefront produces, so a full primary wavefront no longer leaves
+         * zero room for its recoils/fragments (issue #213).  A width of 0 (a
+         * context built without a simulation) falls back to the full capacity —
+         * the pre-#213 behaviour. */
         if (!stop && pool->n == 0u && primaries_done < nstat) {
+            size_t width = transport_ctx->ion_wavefront_width;
+            if (width == 0u || width > pool->capacity) {
+                width = pool->capacity;
+            }
             n_fill = nstat - primaries_done;
-            if (n_fill > pool->capacity) {
-                n_fill = pool->capacity;
+            if (n_fill > width) {
+                n_fill = width;
             }
             if (prof) {
                 t_phase = osh_monotonic_seconds();

--- a/src/transport/osh_transport_ion_step.c
+++ b/src/transport/osh_transport_ion_step.c
@@ -276,10 +276,13 @@ enum osh_status osh_transport_ion_step(struct osh_particle_pool *pool,
      * aggressively small capacity), the ion drop is *counted* (pool->n_dropped),
      * not silent, and — because each child stream is seeded by lineage+ordinal,
      * not by drawing from the parent (osh_rng_split) — a dropped secondary
-     * cannot perturb its parent's or siblings' streams, so scored output stays
-     * batch- and capacity-invariant regardless.  The secondary ordinal `si` is
-     * passed straight to the split so the seeding does not depend on which
-     * siblings were injected. */
+     * cannot perturb its parent's or siblings' streams: the only cost is that
+     * secondary's own deposited energy, never an RNG desync of a surviving
+     * history.  (Scored output is batch- and capacity-invariant in the default,
+     * drop-free configuration; a pool small enough to overflow instead trades
+     * that invariance for the counted, WARNed energy loss.)  The secondary
+     * ordinal `si` is passed straight to the split so the seeding does not depend
+     * on which siblings were injected. */
     if (ctx.nuclear_event.n_secondaries > 0u) {
         size_t si;
         struct osh_nuclear_event const *ev = &ctx.nuclear_event;

--- a/src/transport/osh_transport_ion_step.c
+++ b/src/transport/osh_transport_ion_step.c
@@ -269,7 +269,17 @@ enum osh_status osh_transport_ion_step(struct osh_particle_pool *pool,
     /* Inject secondaries produced by a nuclear event (pp elastic recoil,
      * abrasion nucleons, Fermi break-up products).  Secondaries are appended
      * past the current wavefront and are processed on the next pass.
-     * Silently skip if the pool is full. */
+     *
+     * The pool is sized with headroom beyond the primary wavefront so a full
+     * wavefront's secondaries fit without overflow (issue #213); the default
+     * configuration therefore drops nothing.  Should the pool still fill (an
+     * aggressively small capacity), the ion drop is *counted* (pool->n_dropped),
+     * not silent, and — because each child stream is seeded by lineage+ordinal,
+     * not by drawing from the parent (osh_rng_split) — a dropped secondary
+     * cannot perturb its parent's or siblings' streams, so scored output stays
+     * batch- and capacity-invariant regardless.  The secondary ordinal `si` is
+     * passed straight to the split so the seeding does not depend on which
+     * siblings were injected. */
     if (ctx.nuclear_event.n_secondaries > 0u) {
         size_t si;
         struct osh_nuclear_event const *ev = &ctx.nuclear_event;
@@ -295,7 +305,7 @@ enum osh_status osh_transport_ion_step(struct osh_particle_pool *pool,
                     np->wt[k] = pool->wt[slot];
                     np->prim_idx[k] = pool->prim_idx[slot];
                     np->gen[k] = (pool->gen[slot] < 255u) ? (uint8_t) (pool->gen[slot] + 1u) : 255u;
-                    osh_rng_split(&np->rng[k], rng); /* seed child stream from parent */
+                    osh_rng_split(&np->rng[k], rng, (uint64_t) si); /* lineage+ordinal-keyed child stream */
                 } else {
                     np->n_dropped++;
                 }
@@ -303,6 +313,7 @@ enum osh_status osh_transport_ion_step(struct osh_particle_pool *pool,
             }
             /* -- ion push ---------------------------------------------------- */
             if (pool->n >= pool->capacity) {
+                pool->n_dropped++; /* count the loss — never a silent discard (issue #213) */
                 continue;
             }
             s = pool->n;
@@ -317,10 +328,12 @@ enum osh_status osh_transport_ion_step(struct osh_particle_pool *pool,
             pool->prim_idx[s] = pool->prim_idx[slot];
             pool->gen[s] = (pool->gen[slot] < 255u) ? (uint8_t) (pool->gen[slot] + 1u) : 255u;
             pool->species[s] = ev->secondaries[si].species;
-            /* Give the secondary its own stream, split from the parent's.  The
-             * parent's draw sequence is deterministic along its lineage, so the
-             * child stream is reproducible and independent of wavefront order. */
-            osh_rng_split(&pool->rng[s], rng);
+            /* Give the secondary its own stream, keyed by the parent's lineage
+             * and this secondary's ordinal `si`.  Splitting reads but does not
+             * advance the parent, so the child stream is reproducible and
+             * independent of wavefront order, pool capacity, and whether any
+             * sibling was dropped (issue #213). */
+            osh_rng_split(&pool->rng[s], rng, (uint64_t) si);
             pool->n++;
         }
     }

--- a/src/transport/osh_transport_neutron.c
+++ b/src/transport/osh_transport_neutron.c
@@ -119,10 +119,15 @@ static enum osh_status score_neutron_step(struct osh_scoring_runtime *score_rt,
 /*
  * Push a neutron secondary from a compound/FBU event back into the pool.
  * Position is inherited from the parent slot; direction and energy come from
- * the secondary descriptor.  RNG stream is split from the parent so the child
- * history is independent from all sibling histories.
+ * the secondary descriptor.  The RNG stream is seeded from the parent keyed by
+ * @p ordinal (this secondary's index within the event) without advancing the
+ * parent, so a dropped sibling cannot perturb the parent's or other siblings'
+ * streams (issue #213).
  */
-static void push_neutron_secondary(struct osh_neutron_pool *pool, size_t k, struct osh_nuclear_secondary const *sec) {
+static void push_neutron_secondary(struct osh_neutron_pool *pool,
+                                   size_t k,
+                                   struct osh_nuclear_secondary const *sec,
+                                   size_t ordinal) {
     size_t slot; /* index of the new entry */
 
     pool->n_created++;
@@ -141,7 +146,7 @@ static void push_neutron_secondary(struct osh_neutron_pool *pool, size_t k, stru
     pool->wt[slot] = pool->wt[k];
     pool->prim_idx[slot] = pool->prim_idx[k];
     pool->gen[slot] = (pool->gen[k] < 255u) ? (uint8_t) (pool->gen[k] + 1u) : 255u;
-    osh_rng_split(&pool->rng[slot], &pool->rng[k]);
+    osh_rng_split(&pool->rng[slot], &pool->rng[k], (uint64_t) ordinal);
 }
 
 /*
@@ -178,7 +183,7 @@ static void apply_event(struct osh_neutron_pool *pool, size_t k, struct osh_neut
         for (i = 0u; i < ev->n_secondaries; ++i) {
             sec = &ev->secondaries[i];
             if (sec->species != NULL && sec->species->pdg == OSH_PART_PDG_NEUTRON) {
-                push_neutron_secondary(pool, k, sec);
+                push_neutron_secondary(pool, k, sec, i);
             }
         }
         pool->e[k] = 0.0;

--- a/tests/unit/test_osh_rng.c
+++ b/tests/unit/test_osh_rng.c
@@ -165,8 +165,9 @@ static void test_seed_history_disjoint_ranges(void) {
 }
 
 /* osh_rng_split is deterministic along a lineage: identical parents at the
- * same draw position produce identical, reproducible child streams.  This is
- * what makes nuclear secondaries reproducible irrespective of scheduling. */
+ * same draw position produce identical, reproducible child streams for a given
+ * ordinal.  This is what makes nuclear secondaries reproducible irrespective of
+ * scheduling. */
 static void test_split_deterministic(void) {
     struct osh_rng pa;
     struct osh_rng pb;
@@ -177,30 +178,96 @@ static void test_split_deterministic(void) {
     osh_rng_seed_history(&pa, OSH_RNG_TYPE_PCG32, 55u, 7u, OSH_RNG_PURPOSE_PHYSICS);
     osh_rng_seed_history(&pb, OSH_RNG_TYPE_PCG32, 55u, 7u, OSH_RNG_PURPOSE_PHYSICS);
 
-    /* Advance both parents identically, then split at the same lineage point. */
+    /* Advance both parents identically, then split at the same lineage point
+     * and ordinal. */
     for (k = 0; k < 5; ++k) {
         (void) osh_rng_u64(&pa);
         (void) osh_rng_u64(&pb);
     }
-    osh_rng_split(&ca, &pa);
-    osh_rng_split(&cb, &pb);
+    osh_rng_split(&ca, &pa, 0u);
+    osh_rng_split(&cb, &pb, 0u);
 
     for (k = 0; k < 8; ++k) {
         ASSERT_TRUE(osh_rng_u64(&ca) == osh_rng_u64(&cb));
     }
 
-    /* The child stream is distinct from the parent's continuation. */
+    /* The child stream is distinct from the parent's own continuation. */
     {
         struct osh_rng cc;
         int differ = 0;
         osh_rng_seed_history(&pa, OSH_RNG_TYPE_PCG32, 55u, 7u, OSH_RNG_PURPOSE_PHYSICS);
-        osh_rng_split(&cc, &pa);
+        osh_rng_split(&cc, &pa, 0u);
         for (k = 0; k < 8; ++k) {
             if (osh_rng_u64(&cc) != osh_rng_u64(&pa)) {
                 differ = 1;
             }
         }
         ASSERT_TRUE(differ);
+    }
+}
+
+/*
+ * Splitting must not consume from the parent, and each ordinal must key an
+ * independent child.  Together these make secondary seeding drop-, reorder-,
+ * and overflow-proof (issue #213): whether a sibling secondary is injected or
+ * silently dropped cannot shift the parent's stream or any other sibling's.
+ */
+static void test_split_nonconsuming_and_drop_independent(void) {
+    struct osh_rng parent;
+    struct osh_rng snapshot;
+    struct osh_rng pristine;
+    struct osh_rng c0;
+    struct osh_rng c1;
+    struct osh_rng c2;
+    int k;
+
+    osh_rng_seed_history(&parent, OSH_RNG_TYPE_PCG32, 55u, 7u, OSH_RNG_PURPOSE_PHYSICS);
+    for (k = 0; k < 5; ++k) {
+        (void) osh_rng_u64(&parent);
+    }
+    snapshot = parent; /* consumed by step 1's lockstep comparison  */
+    pristine = parent; /* untouched copy of the pre-split state for step 3 */
+
+    osh_rng_split(&c0, &parent, 0u);
+    osh_rng_split(&c1, &parent, 1u);
+    osh_rng_split(&c2, &parent, 2u);
+
+    /* (1) Non-consuming: the parent's own draws are exactly what they would have
+     *     been had it never been split. */
+    for (k = 0; k < 16; ++k) {
+        ASSERT_TRUE(osh_rng_u64(&parent) == osh_rng_u64(&snapshot));
+    }
+
+    /* (2) Distinct ordinals key distinct streams (c0 and c2 are preserved for
+     *     step 3 by drawing from copies here). */
+    {
+        struct osh_rng a = c0;
+        struct osh_rng b = c1;
+        struct osh_rng bb = c1;
+        struct osh_rng cc = c2;
+        int differ01 = 0;
+        int differ12 = 0;
+        for (k = 0; k < 8; ++k) {
+            if (osh_rng_u64(&a) != osh_rng_u64(&b)) {
+                differ01 = 1;
+            }
+            if (osh_rng_u64(&bb) != osh_rng_u64(&cc)) {
+                differ12 = 1;
+            }
+        }
+        ASSERT_TRUE(differ01);
+        ASSERT_TRUE(differ12);
+    }
+
+    /* (3) Drop-independence: the ordinal-2 child is identical whether or not
+     *     ordinals 0 and 1 were ever split.  A dropped/absent sibling cannot
+     *     change another secondary's stream. */
+    {
+        struct osh_rng c2_alone;
+        osh_rng_split(&c2_alone, &pristine, 2u);
+        for (k = 0; k < 8; ++k) {
+            ASSERT_TRUE(osh_rng_u64(&c2_alone) == osh_rng_u64(&c2));
+        }
     }
 }
 
@@ -320,6 +387,7 @@ int main(void) {
     test_seed_history_purpose_independence();
     test_seed_history_disjoint_ranges();
     test_split_deterministic();
+    test_split_nonconsuming_and_drop_independent();
     test_double_vec_matches_scalar();
     test_float_vec_matches_scalar();
     test_u32_vec_matches_scalar();

--- a/tests/unit/test_osh_simulation.c
+++ b/tests/unit/test_osh_simulation.c
@@ -485,14 +485,18 @@ static double sum_last_column(char const *path) {
  * Drive one run of test case @p case_name at a given checkpoint cadence and
  * return the completed-primary count and total scored energy.  every_primaries
  * == 0 is FINAL-ONLY (one batch); > 0 runs family-complete batches of that size.
+ * @p pool_capacity == 0 leaves the compiled default; > 0 sets the live-history
+ * pool capacity (the perf knob) so callers can assert capacity-invariance.
  * When @p profile_out is non-NULL, profiling is enabled and the run profile is
- * copied out so callers can assert its counters accumulate across batches.  All
- * bundled cases used here are water cylinders spanning z ∈ [0, 20], so the same
- * single-quantity Energy mesh reads back the deposited energy for each.
+ * copied out so callers can assert its counters accumulate across batches (and
+ * read back ion_secondaries_dropped).  All bundled cases used here are water
+ * cylinders spanning z ∈ [0, 20], so the same single-quantity Energy mesh reads
+ * back the deposited energy for each.
  */
 static void run_checkpoint_case(char const *case_name,
                                 unsigned long long nstat,
                                 unsigned long long every_primaries,
+                                unsigned long long pool_capacity,
                                 unsigned long long *completed_out,
                                 double *energy_sum_out,
                                 struct osh_simulation_profile *profile_out) {
@@ -540,6 +544,9 @@ static void run_checkpoint_case(char const *case_name,
 
     ASSERT_TRUE(osh_simulation_create(beam, geo, mat, scoring, NULL, &sim) == OSH_OK);
     ASSERT_TRUE(osh_simulation_set_checkpoint_policy(sim, every_primaries) == OSH_OK);
+    if (pool_capacity != 0ull) {
+        ASSERT_TRUE(osh_simulation_set_pool_capacity(sim, (size_t) pool_capacity) == OSH_OK);
+    }
     if (profile_out) {
         ASSERT_TRUE(osh_simulation_set_profiling(sim, 1) == OSH_OK);
     }
@@ -575,7 +582,7 @@ static void test_checkpoint_final_only_default_completes(void) {
 
     ASSERT_TRUE(osh_simulation_set_checkpoint_policy(NULL, 0ull) == OSH_EINVAL);
 
-    run_checkpoint_case("00_minimal", 200ull, 0ull, &completed, &energy, NULL);
+    run_checkpoint_case("00_minimal", 200ull, 0ull, 0ull, &completed, &energy, NULL);
     ASSERT_TRUE(completed == 200ull);
     ASSERT_TRUE(energy > 0.0);
 }
@@ -596,8 +603,8 @@ static void test_checkpoint_live_batches_match_final_only(void) {
     double energy_live = 0.0;
     double rel_diff;
 
-    run_checkpoint_case("00_minimal", 200ull, 0ull, &completed_final, &energy_final, NULL); /* one batch */
-    run_checkpoint_case("00_minimal", 200ull, 64ull, &completed_live, &energy_live, NULL);  /* 64,64,64,8 */
+    run_checkpoint_case("00_minimal", 200ull, 0ull, 0ull, &completed_final, &energy_final, NULL); /* one batch */
+    run_checkpoint_case("00_minimal", 200ull, 64ull, 0ull, &completed_live, &energy_live, NULL);  /* 64,64,64,8 */
 
     ASSERT_TRUE(completed_final == 200ull);
     ASSERT_TRUE(completed_live == 200ull);
@@ -612,31 +619,27 @@ static void test_checkpoint_live_batches_match_final_only(void) {
  * 00_minimal has NUCRE off, so its equivalence test never actually drains a
  * neutron family across a checkpoint.  06_minimal_nucre enables nuclear reactions,
  * so each batch's ion pass banks neutrons that the family scheduler must fully
- * drain into scoring before the checkpoint boundary.  The profile counters below
- * assert that neutrons really were produced and drained (nuclear_events and
- * neutrons_banked > 0), so this test genuinely exercises the "family-complete,
- * quiescent checkpoint" path rather than a degenerate no-secondary run.
+ * drain into scoring before the checkpoint boundary, and every nuclear event
+ * appends charged secondaries (recoils, abrasion nucleons, break-up fragments)
+ * to the ion pool.  The profile counters below assert secondaries really were
+ * produced and drained (nuclear_events and neutrons_banked > 0), so this test
+ * genuinely exercises the "family-complete, quiescent checkpoint" path rather
+ * than a degenerate no-secondary run.
  *
- * What this guards (the contract that holds):
- *   - COMPLETENESS: every primary finishes under both final-only and LIVE
- *     batching even though a batch banks neutrons that must be drained before it
- *     may advance — no primary is stranded at a checkpoint.
- *   - REPRODUCIBILITY within a batching: a given cadence is deterministic, so
- *     re-running the same LIVE policy reproduces the scored energy bit-for-bit.
- *
- * What this deliberately does NOT assert (documented limitation, see below):
- *   Single-pass (final-only) and multi-batch LIVE runs are NOT bit-identical once
- *   secondaries are in flight — on this fixture they differ by ~2.6% in scored
- *   energy.  The RNG stream of every history is a pure function of its global
- *   index (all but one neutron-producing primary are bit-identical across
- *   batchings), so this is not a seeding defect and not neutron-pool overflow
- *   (zero drops in both).  Rather, one primary's ion history reaches its nuclear
- *   vertex at a fractionally different point depending on whether the run is
- *   transported as one pass or split into batches, which flips a single stochastic
- *   reaction and cascades.  That is a transport-kernel batch-reproducibility
- *   limitation tracked separately from this scheduling seam; asserting exact
- *   final-vs-LIVE equivalence here would encode a guarantee the kernel does not
- *   yet provide.
+ * The invariant (issue #213): scored energy is batch-size invariant.
+ *   Final-only and multi-batch LIVE runs transport the *identical* set of
+ *   histories — primaries and every nuclear secondary — because (a) the ion pool
+ *   is sized with headroom beyond the primary wavefront, so no secondary is
+ *   dropped (ion_secondaries_dropped == 0 below), and (b) each secondary's RNG
+ *   stream is keyed by its lineage and ordinal, never drawn from the parent, so a
+ *   secondary's presence or absence cannot shift its parent's stream.  The only
+ *   remaining difference between the two batchings is the order deposits land in
+ *   the shared scoring accumulators, i.e. floating-point summation reassociation,
+ *   which is bounded far below any physical difference.  (Before #213 this fixture
+ *   differed by ~2.6 %: a full primary wavefront filled the pool, its secondaries
+ *   were silently dropped, and the drop count tracked the batch schedule — the
+ *   "transport-kernel FP limitation" once documented here was that bug, not a
+ *   kernel property.)
  */
 static void test_checkpoint_live_batches_drain_families_with_nuclear(void) {
     unsigned long long completed_final = 0ull;
@@ -645,31 +648,101 @@ static void test_checkpoint_live_batches_drain_families_with_nuclear(void) {
     double energy_final = 0.0;
     double energy_live_a = 0.0;
     double energy_live_b = 0.0;
+    double rel_diff;
     struct osh_simulation_profile prof_final;
     struct osh_simulation_profile prof_live;
 
     /* Final-only baseline, with profiling so we can prove secondaries were in
      * flight (otherwise the fixture could silently regress to a no-nuclear run
-     * and this test would prove nothing). */
-    run_checkpoint_case("06_minimal_nucre", 200ull, 0ull, &completed_final, &energy_final, &prof_final);
+     * and this test would prove nothing) and that none were dropped. */
+    run_checkpoint_case("06_minimal_nucre", 200ull, 0ull, 0ull, &completed_final, &energy_final, &prof_final);
     ASSERT_TRUE(completed_final == 200ull);
     ASSERT_TRUE(energy_final > 0.0);
     ASSERT_TRUE(prof_final.nuclear_events > 0ull);
     ASSERT_TRUE(prof_final.neutrons_banked > 0ull);
+    /* Headroom fix (issue #213): the default configuration drops no ion secondary. */
+    ASSERT_TRUE(prof_final.ion_secondaries_dropped == 0ull);
 
     /* LIVE batching drains a neutron family at every checkpoint, yet still
-     * finishes every primary and still produces (and drains) neutrons. */
-    run_checkpoint_case("06_minimal_nucre", 200ull, 64ull, &completed_live_a, &energy_live_a, &prof_live);
+     * finishes every primary, still produces (and drains) neutrons, and still
+     * drops nothing. */
+    run_checkpoint_case("06_minimal_nucre", 200ull, 64ull, 0ull, &completed_live_a, &energy_live_a, &prof_live);
     ASSERT_TRUE(completed_live_a == 200ull);
     ASSERT_TRUE(energy_live_a > 0.0);
     ASSERT_TRUE(prof_live.neutrons_banked > 0ull);
+    ASSERT_TRUE(prof_live.ion_secondaries_dropped == 0ull);
+
+    /* The real invariant: with no secondary dropped, final-only and LIVE agree to
+     * floating-point summation order — NOT the ~2.6 % the pre-#213 code showed. */
+    rel_diff = fabs(energy_live_a - energy_final) / energy_final;
+    ASSERT_TRUE(rel_diff < 1.0e-9);
 
     /* Reproducibility of a fixed cadence: the same LIVE policy re-run reproduces
      * the scored energy exactly (bit-for-bit), the determinism guarantee the
      * count cadence is meant to provide. */
-    run_checkpoint_case("06_minimal_nucre", 200ull, 64ull, &completed_live_b, &energy_live_b, NULL);
+    run_checkpoint_case("06_minimal_nucre", 200ull, 64ull, 0ull, &completed_live_b, &energy_live_b, NULL);
     ASSERT_TRUE(completed_live_b == 200ull);
     ASSERT_TRUE(energy_live_b == energy_live_a);
+}
+
+/*
+ * Capacity/batch invariance with nuclear reactions ON (issue #213 regression
+ * lock).  Scored energy for a fixed (seed, rndoffset) must not depend on:
+ *   - the checkpoint batch size K (full / 64 / 1), nor
+ *   - the live-history pool capacity (the cache/parallelism perf knob),
+ * because every history's RNG stream is a pure function of its lineage and no
+ * secondary is dropped (the counter is asserted 0 for each configuration).  All
+ * runs therefore transport the identical set of histories; only the scorer's
+ * floating-point summation order differs, which is bounded far below 1e-9
+ * relative.  This is the guard the earlier equivalence test could not provide —
+ * a bug whose signature was "the answer changes with K" would fail here.
+ */
+static void test_checkpoint_nuclear_invariant_across_batches_and_capacity(void) {
+    unsigned long long const nstat = 200ull;
+
+    /* K = 0 (final-only), 64, and 1 at the default capacity; then a small
+     * explicit capacity at final-only.  Each row is (every_primaries, pool_cap). */
+    struct {
+        unsigned long long every_primaries;
+        unsigned long long pool_capacity;
+    } const configs[] = {
+        {0ull, 0ull},   /* final-only, default capacity — the reference */
+        {64ull, 0ull},  /* LIVE, batch 64 */
+        {1ull, 0ull},   /* LIVE, batch 1 (checkpoint after every primary) */
+        {0ull, 64ull},  /* final-only, capacity 64 (a different wavefront width) */
+        {0ull, 256ull}, /* final-only, capacity 256 */
+    };
+
+    size_t const nconfigs = sizeof(configs) / sizeof(configs[0]);
+    double energy_ref = 0.0;
+    size_t i;
+
+    for (i = 0u; i < nconfigs; ++i) {
+        unsigned long long completed = 0ull;
+        double energy = 0.0;
+        struct osh_simulation_profile prof;
+
+        run_checkpoint_case("06_minimal_nucre",
+                            nstat,
+                            configs[i].every_primaries,
+                            configs[i].pool_capacity,
+                            &completed,
+                            &energy,
+                            &prof);
+
+        ASSERT_TRUE(completed == nstat);
+        ASSERT_TRUE(energy > 0.0);
+        /* Headroom holds at every tested capacity: no deposited energy is lost. */
+        ASSERT_TRUE(prof.ion_secondaries_dropped == 0ull);
+
+        if (i == 0u) {
+            energy_ref = energy;
+            ASSERT_TRUE(prof.nuclear_events > 0ull); /* the fixture really is nuclear */
+        } else {
+            double const rel_diff = fabs(energy - energy_ref) / energy_ref;
+            ASSERT_TRUE(rel_diff < 1.0e-9);
+        }
+    }
 }
 
 /*
@@ -692,8 +765,8 @@ static void test_checkpoint_profiling_accumulates_across_batches(void) {
     struct osh_simulation_profile prof_live;
     double phase_sum_s;
 
-    run_checkpoint_case("00_minimal", 200ull, 0ull, &completed_final, &energy_final, &prof_final);
-    run_checkpoint_case("00_minimal", 200ull, 64ull, &completed_live, &energy_live, &prof_live);
+    run_checkpoint_case("00_minimal", 200ull, 0ull, 0ull, &completed_final, &energy_final, &prof_final);
+    run_checkpoint_case("00_minimal", 200ull, 64ull, 0ull, &completed_live, &energy_live, &prof_live);
 
     ASSERT_TRUE(completed_final == 200ull);
     ASSERT_TRUE(completed_live == 200ull);
@@ -735,6 +808,7 @@ int main(void) {
     test_checkpoint_final_only_default_completes();
     test_checkpoint_live_batches_match_final_only();
     test_checkpoint_live_batches_drain_families_with_nuclear();
+    test_checkpoint_nuclear_invariant_across_batches_and_capacity();
     test_checkpoint_profiling_accumulates_across_batches();
     return 0;
 }

--- a/tests/unit/test_osh_simulation.c
+++ b/tests/unit/test_osh_simulation.c
@@ -739,10 +739,67 @@ static void test_checkpoint_nuclear_invariant_across_batches_and_capacity(void) 
             energy_ref = energy;
             ASSERT_TRUE(prof.nuclear_events > 0ull); /* the fixture really is nuclear */
         } else {
-            double const rel_diff = fabs(energy - energy_ref) / energy_ref;
-            ASSERT_TRUE(rel_diff < 1.0e-9);
+            ASSERT_TRUE(fabs(energy - energy_ref) / energy_ref < 1.0e-9);
         }
     }
+}
+
+/*
+ * Overflow accounting (issue #213), the positive counterpart to the
+ * ion_secondaries_dropped == 0 assertions above.  Those prove the default
+ * configuration reserves enough headroom to drop nothing; this deliberately
+ * starves the ion pool so a full wavefront's secondaries cannot all fit, and
+ * asserts the overflow is COUNTED rather than silently discarded (the exact bug
+ * #213 fixes).  It further checks that a drop never strands a primary (all
+ * histories still complete), that the lost secondaries lower the scored energy
+ * (their deposits are gone, not merely reordered), and that the starved run is
+ * still bit-for-bit deterministic on re-run.  Guards the drop counter in
+ * osh_transport_ion_step and the WARN in osh_simulation_run that surfaces it.
+ *
+ * Note this does NOT assert cross-batch invariance: once the pool overflows,
+ * which secondaries are dropped depends on pool occupancy (and thus on the
+ * checkpoint cadence), so the overflow regime trades exact invariance for a
+ * counted, warned energy loss.  Batch/capacity invariance is a property of the
+ * default, drop-free configuration and is locked by the test above.
+ */
+static void test_checkpoint_nuclear_overflow_is_counted_not_silent(void) {
+    unsigned long long completed_ref = 0ull;
+    unsigned long long completed_small = 0ull;
+    unsigned long long completed_rerun = 0ull;
+    double energy_ref = 0.0;
+    double energy_small = 0.0;
+    double energy_rerun = 0.0;
+    struct osh_simulation_profile prof_ref;
+    struct osh_simulation_profile prof_small;
+    struct osh_simulation_profile prof_rerun;
+
+    /* Reference: the default capacity has full secondary headroom, so nothing is
+     * dropped and every nuclear deposit is scored. */
+    run_checkpoint_case("06_minimal_nucre", 200ull, 0ull, 0ull, &completed_ref, &energy_ref, &prof_ref);
+    ASSERT_TRUE(completed_ref == 200ull);
+    ASSERT_TRUE(prof_ref.nuclear_events > 0ull); /* the fixture really is nuclear */
+    ASSERT_TRUE(prof_ref.ion_secondaries_dropped == 0ull);
+
+    /* Starve the pool: capacity 2 leaves a full primary wavefront almost no room
+     * for its recoils/abrasion nucleons/break-up fragments, so they overflow.
+     * The overflow is counted in ion_secondaries_dropped, never a bare drop. */
+    run_checkpoint_case("06_minimal_nucre", 200ull, 0ull, 2ull, &completed_small, &energy_small, &prof_small);
+    ASSERT_TRUE(prof_small.ion_secondaries_dropped > 0ull);
+    /* A drop must never strand a primary: every history still completes. */
+    ASSERT_TRUE(completed_small == 200ull);
+    /* The dropped secondaries carried deposited energy that is now simply gone,
+     * so the starved run scores strictly less than the headroom reference. */
+    ASSERT_TRUE(energy_small > 0.0);
+    ASSERT_TRUE(energy_small < energy_ref);
+
+    /* Determinism survives overflow: re-running the identical (cadence, capacity)
+     * reproduces the scored energy and the drop count exactly, because the drop
+     * pattern is a pure function of the lineage-keyed histories and the fixed
+     * pool occupancy — not of run-to-run chance. */
+    run_checkpoint_case("06_minimal_nucre", 200ull, 0ull, 2ull, &completed_rerun, &energy_rerun, &prof_rerun);
+    ASSERT_TRUE(completed_rerun == 200ull);
+    ASSERT_TRUE(energy_rerun == energy_small);
+    ASSERT_TRUE(prof_rerun.ion_secondaries_dropped == prof_small.ion_secondaries_dropped);
 }
 
 /*
@@ -809,6 +866,7 @@ int main(void) {
     test_checkpoint_live_batches_match_final_only();
     test_checkpoint_live_batches_drain_families_with_nuclear();
     test_checkpoint_nuclear_invariant_across_batches_and_capacity();
+    test_checkpoint_nuclear_overflow_is_counted_not_silent();
     test_checkpoint_profiling_accumulates_across_batches();
     return 0;
 }


### PR DESCRIPTION
Fixes #213.

## Problem

With `NUCRE 1`, the ion transport pool was clamped to `nstat`, so a full primary wavefront filled it and every nuclear secondary (recoil protons, abrasion nucleons, break-up fragments) was **silently discarded** by a bare `continue`. Because the number dropped tracked how many primaries were alive at once, **scored energy depended on the checkpoint batch size**: on `06_minimal_nucre` at `nstat = 200`, a single pass scored **138.21** vs **141.81** batched (`K = 64`) — a 2.6 % difference. The headroom result (141.81) is the physically correct one; the clamped single-pass run was the one that was wrong.

A second, coupled defect: `osh_rng_split` seeded a child by *drawing from the parent*, so whether the parent's stream advanced depended on whether its child was dropped — a deterministic RNG desync that made the corruption present as "a history's trajectory moved."

## Fix

**A — headroom (`simulation`, `transport`).** Decouple the *wavefront width* (primaries injected per fill — the cache/parallelism perf knob) from the *pool capacity* (which must also hold the secondaries). The ion pool is now allocated at `2×` the width, so a full primary wavefront has room for its secondaries and the default configuration drops nothing. The fill injects at most `ion_wavefront_width` primaries; the remaining capacity is secondary headroom.

**A3 — accounting (`osh_particle_pool`, `osh_run`).** Count ion-secondary drops in `osh_particle_pool::n_dropped` (mirroring the neutron pool) and surface them in the run log (a `WARN`) and the profile JSON (`ion_secondaries_dropped`). A discard of deposited energy can never pass unnoticed again.

**B — drop-independent seeding (`osh_rng_split`, per #148).** The split now seeds a child from a *copy* of the parent keyed by `(parent state, secondary ordinal)` **without consuming a draw from the parent**. A dropped, reordered, or overflowed secondary can no longer desync its parent's or siblings' streams, so reproducibility no longer depends on pool occupancy or the batch schedule. Ordinal `k` reproduces the exact stream the old sequential split assigned to the k-th secondary, so injected children are unchanged; only the parent is no longer perturbed. All three call sites (ion recoil push, neutron push, neutron→neutron feedback) thread the ordinal through.

**C — regression lock (`test_osh_simulation`, `test_osh_rng`).** The checkpoint nuclear test no longer documents a bogus "transport-kernel FP limitation" — it asserts final-only == LIVE to `<1e-9` with NUCRE on and zero drops. New tests assert batch/capacity invariance (`K ∈ {full, 64, 1}` and several pool capacities, each with zero drops) and that a split cannot perturb its parent's stream (non-consuming + ordinal-keyed + drop-independent).

## Acceptance criteria

- [x] On `06_minimal_nucre` at `nstat = 200`, final-only and LIVE (`K = 64`) scored energy agree to `<1e-9` relative, not 2.6 %.
- [x] No ion secondary is silently discarded in the default configuration; any drop is counted and surfaced (run log + profile) and covered by a test.
- [x] Scored output is invariant under checkpoint batch size `K` for a fixed `(seed, rndoffset)` with nuclear reactions on — the equivalence test asserts this across `K ∈ {full, 64, 1}` and across pool capacities.
- [x] `test_checkpoint_live_batches_drain_families_with_nuclear` no longer describes a "transport-kernel FP limitation"; it documents and asserts the real invariant.
- [x] Part B: a dropped/absent secondary provably cannot alter its parent's stream (`test_split_nonconsuming_and_drop_independent`).

## Verification

- Full unit + cases + bench suite passes (`ctest -LE dicom`), including `bench::profile_bit_identity` (nucre) and `bench::capacity_invariance`. The one unrelated failure (`test_osh_main::version_components_in_string`) is pre-existing and environmental — it fails identically with this branch's changes stashed, because the checkout has no reachable semver tag (the version string is the commit hash).
- End-to-end CLI run of `06_minimal_nucre` at `nstat = 200`: profile now reports `ion_secondaries_dropped: 0`, and the step count rises to ~175 400 (the no-drop figure) from the buggy ~163 800 — the previously-dropped secondaries are now transported.
- `clang-format --dry-run --Werror` clean; `clang-tidy` clean on changed lines (no `clang-analyzer-*`/`bugprone-*`).

## Notes

- No committed golden output guards any NUCRE-on transport run, so the intended ~2.6 % correction lands without breaking a reference (`06_minimal_nucre`'s case test checks exit code only; `capacity_invariance` uses the NUCRE-off `08_minimal_cyl`; `profile_bit_identity` compares two runs of the same build).
- Out of scope (per the issue): multi-threaded scoring reduction determinism (#161), the checkpoint seam itself (#207), and any nuclear-physics-model change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBQZ45AgbMxmpevxtyMhDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBQZ45AgbMxmpevxtyMhDT)_