### PR TITLE
run-control: address #217 review nits (SIGUSR1 comment, ternaries, OOM wording)

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -129,9 +129,11 @@ complete one (`osh_checkpoint_completeness_label()`).  The graceful wall-time st
 (issue #192) routes its early stop through the family scheduler, so its partial
 save is always family-exact for the primaries that finished.
 
-Scheduled dumps also reserve their snapshot buffer against the memory budget up
-front (`osh_scoring_mem_estimate::shadow_bytes`), so a periodic dump can never run
-the process out of memory mid-run.  Still growing into the stable
+Scheduled dumps also budget their snapshot buffer against the memory budget up
+front (`osh_scoring_mem_estimate::shadow_bytes`), so a periodic dump's cost is
+accounted before the run rather than discovered mid-run; the buffer still
+allocates lazily at the first dump and fails soft under memory pressure.  Still
+growing into the stable
 `osh_checkpoint_policy` shape in their own follow-ups: variance-batch folding
 (#169) and per-worker accumulator merges (#161).
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -132,7 +132,7 @@ save is always family-exact for the primaries that finished.
 Scheduled dumps also budget their snapshot buffer against the memory budget up
 front (`osh_scoring_mem_estimate::shadow_bytes`), so a periodic dump's cost is
 accounted before the run rather than discovered mid-run; the buffer still
-allocates lazily at the first dump and fails soft under memory pressure.  Still
+allocates lazily at the first dump and is fail-soft under memory pressure.  Still
 growing into the stable
 `osh_checkpoint_policy` shape in their own follow-ups: variance-batch folding
 (#169) and per-worker accumulator merges (#161).

--- a/docs/user/command-line.md
+++ b/docs/user/command-line.md
@@ -155,7 +155,7 @@ every platform.
 **Memory.** When a dump cadence is set, the small extra buffer a snapshot needs
 is budgeted up front and shown in the `Scoring memory:` line, so its cost is
 accounted before the run starts rather than discovered partway through. The
-buffer is still allocated lazily at the first dump and fails soft if that
+buffer is still allocated lazily at the first dump and is fail-soft if that
 allocation cannot be satisfied. Runs without a dump cadence pay nothing for this.
 
 ## Notes

--- a/docs/user/command-line.md
+++ b/docs/user/command-line.md
@@ -153,9 +153,10 @@ on Windows, so on-demand dumps are a no-op there; the scheduled cadences work on
 every platform.
 
 **Memory.** When a dump cadence is set, the small extra buffer a snapshot needs
-is reserved up front and shown in the `Scoring memory:` line, so a scheduled dump
-can never run the process out of memory partway through. Runs without a dump
-cadence pay nothing for this.
+is budgeted up front and shown in the `Scoring memory:` line, so its cost is
+accounted before the run starts rather than discovered partway through. The
+buffer is still allocated lazily at the first dump and fails soft if that
+allocation cannot be satisfied. Runs without a dump cadence pay nothing for this.
 
 ## Notes
 

--- a/src/apps/osh/osh_run.c
+++ b/src/apps/osh/osh_run.c
@@ -300,8 +300,9 @@ enum osh_status osh_run(struct osh_run_options const *opt, FILE *out, FILE *err)
     /* Detect host resources, report the scoring memory footprint, and refuse
      * the run up front if it would exceed the memory budget — before
      * osh_simulation_create() allocates any scoring buffers.  When a periodic dump
-     * is scheduled, the snapshot shadow is reserved here too so a scheduled dump
-     * can never OOM mid-run (issue #193 budget-reservation rule). */
+     * is scheduled, the snapshot shadow is budgeted here too so a scheduled dump
+     * is accounted up front, not discovered mid-run (issue #193 budget-reservation
+     * rule); the shadow still allocates lazily at the first dump and fails soft. */
     rc = run_check_memory(scoring, opt->mem_budget, scheduled_dump, out, err);
     if (rc != OSH_OK) {
         goto cleanup;
@@ -360,16 +361,25 @@ enum osh_status osh_run(struct osh_run_options const *opt, FILE *out, FILE *err)
         }
         if (out) {
             if (eff_dump_every_primaries > 0ull) {
+                char const *src;
+                if (opt->has_dump_every_primaries) {
+                    src = " (--dump-every-primaries)";
+                } else {
+                    src = " (beam.dat NSTAT step)";
+                }
                 fprintf(out,
                         "Periodic dumps   : every %llu primaries%s (exact partial result)\n",
                         eff_dump_every_primaries,
-                        opt->has_dump_every_primaries ? " (--dump-every-primaries)" : " (beam.dat NSTAT step)");
+                        src);
             }
             if (eff_dump_every_s > 0.0) {
-                fprintf(out,
-                        "Periodic dumps   : every %g s%s (exact partial result)\n",
-                        eff_dump_every_s,
-                        opt->has_dump_every ? " (--dump-every)" : " (beam.dat DUMPEVERY)");
+                char const *src;
+                if (opt->has_dump_every) {
+                    src = " (--dump-every)";
+                } else {
+                    src = " (beam.dat DUMPEVERY)";
+                }
+                fprintf(out, "Periodic dumps   : every %g s%s (exact partial result)\n", eff_dump_every_s, src);
             }
         }
     }
@@ -480,9 +490,10 @@ cleanup:
  * @param[in] mem_budget_override Budget string (e.g. "8GB", "80%") or NULL.
  * @param[in] reserve_shadow      Non-zero when a periodic dump is scheduled: add
  *                                the snapshot shadow (est.shadow_bytes) to the
- *                                footprint so a scheduled dump can never OOM
- *                                mid-run (issue #193).  On-demand-only dumps do
- *                                not reserve — they allocate lazily and fail-soft.
+ *                                footprint so a scheduled dump is budgeted up
+ *                                front (issue #193), not discovered mid-run.  The
+ *                                shadow still allocates lazily and fails soft;
+ *                                on-demand-only dumps do not reserve at all.
  * @param[in] out                 Human-readable report stream, or NULL.
  * @param[in] err                 Error stream for the refusal message, or NULL.
  *
@@ -535,11 +546,15 @@ static enum osh_status run_check_memory(struct osh_scoring_workspace const *scor
 
     /* Footprint gated against the budget: the accumulators, plus the snapshot
      * shadow when a periodic dump is scheduled (it will be allocated on the first
-     * dump, so reserving it up front means a scheduled dump never OOMs mid-run).
+     * dump, so it is budgeted up front rather than discovered mid-run).
      * Saturate rather than wrap on the (practically impossible) overflow. */
     footprint = est.accum_bytes;
     if (reserve_shadow && est.shadow_bytes > 0u) {
-        footprint = (footprint <= UINT64_MAX - est.shadow_bytes) ? (footprint + est.shadow_bytes) : UINT64_MAX;
+        if (footprint <= UINT64_MAX - est.shadow_bytes) {
+            footprint = footprint + est.shadow_bytes;
+        } else {
+            footprint = UINT64_MAX;
+        }
     }
 
     osh_sysinfo_format_bytes(info.ram_total_bytes, b_total, sizeof(b_total));

--- a/src/apps/osh/osh_run.c
+++ b/src/apps/osh/osh_run.c
@@ -302,7 +302,7 @@ enum osh_status osh_run(struct osh_run_options const *opt, FILE *out, FILE *err)
      * osh_simulation_create() allocates any scoring buffers.  When a periodic dump
      * is scheduled, the snapshot shadow is budgeted here too so a scheduled dump
      * is accounted up front, not discovered mid-run (issue #193 budget-reservation
-     * rule); the shadow still allocates lazily at the first dump and fails soft. */
+     * rule); the shadow still allocates lazily at the first dump and is fail-soft. */
     rc = run_check_memory(scoring, opt->mem_budget, scheduled_dump, out, err);
     if (rc != OSH_OK) {
         goto cleanup;
@@ -492,7 +492,7 @@ cleanup:
  *                                the snapshot shadow (est.shadow_bytes) to the
  *                                footprint so a scheduled dump is budgeted up
  *                                front (issue #193), not discovered mid-run.  The
- *                                shadow still allocates lazily and fails soft;
+ *                                shadow still allocates lazily and is fail-soft;
  *                                on-demand-only dumps do not reserve at all.
  * @param[in] out                 Human-readable report stream, or NULL.
  * @param[in] err                 Error stream for the refusal message, or NULL.

--- a/src/apps/osh/osh_signals.c
+++ b/src/apps/osh/osh_signals.c
@@ -79,7 +79,9 @@ static sig_atomic_t volatile g_stop = 0;
 /* On-demand dump flag, raised by SIGUSR1 and consumed (read-and-cleared) by the
  * run loop.  Same concurrency model as g_stop: the handler runs in the
  * interrupted thread, so volatile sig_atomic_t is the right, async-signal-safe
- * type.  Edge-triggered, unlike g_stop, so one signal yields exactly one dump. */
+ * type.  Best-effort edge trigger, unlike the level-held g_stop: one or more
+ * SIGUSR1s pending before a checkpoint coalesce into a single dump (standard
+ * POSIX signals coalesce, so N rapid signals need not yield N dumps). */
 static sig_atomic_t volatile g_dump = 0;
 
 static void on_sigint(int sig) {
@@ -127,9 +129,11 @@ void osh_signals_install_dump(void) {
 
 int osh_signals_should_dump(void *user) {
     (void) user; /* the flag is a process singleton; no per-call context needed */
-    /* Edge-triggered: read and clear so each SIGUSR1 fires exactly one dump.  The
-     * clear races only with the handler *setting* it; a signal landing between the
-     * read and the clear is simply serviced by the next poll, never lost for good. */
+    /* Best-effort edge trigger: read and clear so pending SIGUSR1 requests produce
+     * one dump at this poll.  This is not a lossless one-dump-per-signal guarantee:
+     * signals coalesce, and a SIGUSR1 landing between the read and the clear is
+     * dropped rather than deferred.  That is acceptable for a dump-and-continue
+     * hint — the user simply re-signals, and a scheduled cadence bounds latency. */
     if (g_dump) {
         g_dump = 0;
         return 1;

--- a/src/transport/osh_run_control.h
+++ b/src/transport/osh_run_control.h
@@ -148,10 +148,13 @@ int run_ctl_should_dump(struct osh_run_control *ctl, double elapsed, size_t comp
  * @details
  * True when a time or count cadence is set — i.e. dumps will fire on a schedule
  * regardless of any external signal.  This is the discriminator for the shadow
- * memory budget-reservation rule (issue #193): a scheduled dump reserves its
- * shadow up front (it *will* happen, so it must never OOM mid-run), whereas an
- * on-demand-only dump (@ref should_dump set but no cadence) allocates lazily and
- * is fail-soft.  An on-demand callback alone does **not** count as scheduled.
+ * memory budget-reservation rule (issue #193): a scheduled dump budgets its
+ * shadow up front (it *will* happen, so its cost is accounted before the run
+ * rather than discovered mid-run), whereas an on-demand-only dump (@ref
+ * should_dump set but no cadence) allocates lazily and is fail-soft.  The shadow
+ * itself still allocates lazily at the first dump, so the reservation lowers risk
+ * rather than being an absolute guarantee.  An on-demand callback alone does
+ * **not** count as scheduled.
  *
  * @param[in] ctl  Run-control block, or NULL.
  * @returns 1 when @c dump_every_s > 0 or @c dump_every_primaries > 0, else 0.

--- a/tests/unit/test_osh_run_dump.c
+++ b/tests/unit/test_osh_run_dump.c
@@ -1,11 +1,11 @@
 /*
  * App-layer coverage for the periodic-dump wiring in osh_run() (issue #193):
- * the time-cadence report, the shadow memory-budget reservation, and the
- * over-budget refusal.  Drives osh_run() end to end against the bundled
- * 12_partial_dump water inputs (geo/beam/mat/Water.txt), overriding only the
- * detect file with a DoseGy scorer so the snapshot shadow has a non-zero size
- * (DoseGy postprocess writes data, unlike Energy/Fluence), which is what makes
- * the reservation branch fire.
+ * the time-cadence report, the beam.dat-sourced cadence report labels, the
+ * shadow memory-budget reservation, and the over-budget refusal.  Drives
+ * osh_run() end to end against the bundled 12_partial_dump water inputs
+ * (geo/beam/mat/Water.txt), overriding only the detect file with a DoseGy scorer
+ * so the snapshot shadow has a non-zero size (DoseGy postprocess writes data,
+ * unlike Energy/Fluence), which is what makes the reservation branch fire.
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -84,6 +84,55 @@ static void test_time_cadence_run_reports_and_reserves(void) {
     remove(detect_path);
 }
 
+/* A valid beam.dat whose cadence comes from the cards themselves — a positive
+ * NSTAT save step and a DUMPEVERY duration — with no CLI override.  Driving
+ * osh_run() with this exercises the beam.dat-sourced report labels ("beam.dat
+ * NSTAT step" / "beam.dat DUMPEVERY"), the else arms of the CLI-over-card
+ * precedence, which the CLI-flag tests above never reach. */
+static char const *const BEAM_WITH_CARDS = "RNDSEED   89736501\n"
+                                           "PRIMARY   1 1\n"
+                                           "TMAX0     150.0 0.0\n"
+                                           "BEAMSIGMA 0.0 0.0\n"
+                                           "BEAMPOS   0.0 0.0 -5.00\n"
+                                           "NSTAT     200 40\n" /* save step 40 -> nsave = 40 */
+                                           "DUMPEVERY 0.05\n"   /* wall-time cadence from the card */
+                                           "DELTAE    0.005\n"
+                                           "DEMIN     0.025\n"
+                                           "STRAGG    1\n"
+                                           "MSCAT     2\n"
+                                           "NUCRE     0\n";
+
+/*
+ * Cadence sourced from beam.dat rather than the CLI: with no --dump-every[-primaries]
+ * flag but a beam.dat carrying a positive NSTAT step and a DUMPEVERY duration, both
+ * "Periodic dumps" report lines take their else arm and print the "beam.dat ..."
+ * source label.  A non-NULL out stream is required so the reporting branches run.
+ */
+static void test_beam_dat_cadence_reports(void) {
+    char detect_path[256];
+    char beam_path[256];
+    char out_dir[256];
+    struct osh_run_options opt;
+    FILE *out;
+    FILE *err;
+
+    write_temp_file(detect_path, sizeof(detect_path), DOSEGY_DETECT);
+    write_temp_file(beam_path, sizeof(beam_path), BEAM_WITH_CARDS);
+    snprintf(out_dir, sizeof(out_dir), "osh_rundump_out_%d", tmp_counter++);
+
+    init_opts(&opt, detect_path, out_dir);
+    opt.beam_path = beam_path; /* override beam.dat; no has_dump_every* -> cadence comes from the cards */
+
+    out = tmpfile();
+    err = tmpfile();
+    ASSERT_TRUE(out != NULL && err != NULL);
+    ASSERT_TRUE(osh_run(&opt, out, err) == OSH_OK);
+    fclose(out);
+    fclose(err);
+    remove(beam_path);
+    remove(detect_path);
+}
+
 /*
  * The budget-reservation refusal: with a scheduled dump the snapshot shadow is
  * added to the footprint, and a tiny --mem-budget must refuse the run up front
@@ -113,6 +162,7 @@ static void test_scheduled_dump_over_budget_is_refused(void) {
 
 int main(void) {
     test_time_cadence_run_reports_and_reserves();
+    test_beam_dat_cadence_reports();
     test_scheduled_dump_over_budget_is_refused();
     return 0;
 }


### PR DESCRIPTION
Closes #228 — the three cleanups collected from the "Quick review from Niels/Codex." approval on #217. All non-functional: comments, docs, and one mechanical ternary rewrite. No behavior change.

## Why

#217 (periodic & on-demand partial-result dumps) merged with an APPROVE plus three small review nits worth tidying in a follow-up. This is that follow-up.

## What

1. **`src/apps/osh/osh_signals.c` — soften the SIGUSR1 read-and-clear comments.**
   The two comments claimed exactly-one-dump-per-signal ("so one signal yields exactly one dump", "never lost for good"). That overstates what the code guarantees:
   - a `SIGUSR1` delivered after `if (g_dump)` reads true but before `g_dump = 0` is cleared and lost, not deferred to the next poll;
   - standard (non-realtime) POSIX signals coalesce, so N rapid signals need not yield N dumps.

   Reworded both to best-effort / edge-trigger semantics. This is fine for a dump-and-continue hint — the user re-signals, and a scheduled cadence bounds latency.

2. **`src/apps/osh/osh_run.c` — replace the ternaries this PR introduced with explicit `if`/`else`,** per DEVELOPER.md **§7.2** (which landed on `main` after #217 branched and asks that *new* non-macro ternaries be treated as review findings). The two touched sites are the periodic-dump report source labels (`--dump-every-primaries`/`NSTAT step`, `--dump-every`/`DUMPEVERY`) and the saturated shadow-footprint calc. Scoped to the newly-added ternaries only — §7.2 explicitly does not want a tree-wide sweep of pre-existing ones.

3. **Soften "can never OOM mid-run" → "budgeted up front"** across `osh_run.c`, `src/transport/osh_run_control.h`, `docs/user/command-line.md`, and `docs/dev/architecture.md`. The shadow is only *reserved against the budget* up front; it still allocates lazily at the first dump and fails soft under external memory pressure, so the absolute claim was inaccurate.

## Testing

- `cmake --build --preset debug` — warning-free.
- Focused suite from the review, all green:
  ```
  ctest --test-dir build_debug -R "unit::(test_osh_run_control|test_osh_signals|test_osh_cli|test_osh_checkpoint_policy|test_osh_run_dump|test_osh_simulation)$|unit::cli::help" --output-on-failure
  ```
  `test_osh_run_dump` (periodic-dump report + shadow-reservation accounting) and `test_osh_signals` (SIGUSR1 edge trigger) cover the changed lines.
- `clang-format --dry-run --Werror` clean on all changed C/H files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017NRqS2qBkDqq3Vd8dwQ7kc)_