### PR TITLE
docs: make TODO issue references clickable and reconcile with issues/codebase

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,18 +3,18 @@
 - [ ] Revisit remaining path/file metadata in public cold workspaces
   (`wdir`, `fname`, and similar fields should disappear as app-owned path
   handling is cleaned up)
-- [ ] Add result merge API for embarrassingly parallel runs
+- [ ] Add result merge API for embarrassingly parallel runs ([#230])
 - [x] Add chunked / partial run control (run in batches, inspect partial
-  results, save explicitly) — batch-aware checkpoint scheduler (#195/#207) plus
-  periodic/on-demand family-exact dumps (#193). The per-worker *merge* step is
-  still open (tracked in #161).
+  results, save explicitly) — batch-aware checkpoint scheduler ([#195]/[#207]) plus
+  periodic/on-demand family-exact dumps ([#193]). The per-worker *merge* step is
+  still open (tracked in [#161]).
 - [ ] Finish naming consistency: remaining stale "prepare" wording in
   messages/comments
 
 ## Beam
 
-- [ ] Add ridge-modulator / ripple-filter support
-- [ ] Add MCPL phase-space import
+- [ ] Add ridge-modulator / ripple-filter support ([#42])
+- [ ] Add MCPL phase-space import ([#41])
 - [ ] Add EXTSPEC support
 - [ ] Add parlev support
 
@@ -39,25 +39,24 @@
 
 ## Transport
 
-- [x] Vavilov + Landau energy straggling (STRAGG 2) — branch
+- [x] Vavilov + Landau energy straggling (STRAGG 2, [#190]) — branch
       `190-physics-add-vavilov-and-landau-straggling`.  DONE: clean-room fit to
       the exact Vavilov (1957) distribution + universal Landau; pole-free
       polynomial+Chebyshev inverse-CDF evaluators; κ-dispatch (Gaussian ≥10 /
       Vavilov / Landau <0.01) wired into ion step.  Validated vs SH12A: distal
       80–20% fluence falloff width 0.4522 vs 0.4533 cm (0.2%); DLET at matched
       fluence within ~2%.  STRAGG 0/1 byte-identical.  No GEANT3/Thomsen numbers.
-      Remaining nicety: render the `plot_straggling.py` strag2 overlay.
-- [ ] Profile STRAGG 2 Vavilov overhead on the straggling benchmark; current
+- [ ] Profile STRAGG 2 Vavilov overhead on the straggling benchmark ([#211]); current
       20k-history timing is still ~2x faster than SH12A, but OSH's relative
       STRAGG 2 cost over STRAGG 0 is larger.  Check
       `osh_physics_strag_vavilov_lambda()` for cheap wins before broader
       transport refactors.
 - [ ] Urban energy-loss fluctuation (STRAGG 3, reserved) — needs δ-ray cut +
       restricted stopping power; tied to future delta-electron transport
-- [ ] Nuclear fragmentation — secondary particle transport (SMM, Bondorf et al.)
+- [ ] Nuclear fragmentation — secondary particle transport (SMM, Bondorf et al.) ([#176])
 - [ ] Batch ion-step phases around runtime lookup hot spots
 
-## Neutron Transport (issue #154, merged via branch 154-neutron-transport-minimal-model)
+## Neutron Transport ([#154], merged via branch 154-neutron-transport-minimal-model)
 
 Fast-neutron transport is implemented as a condensed model.  Neutrons produced
 by abrasion and Fermi break-up are banked in the neutron pool and drained by
@@ -87,7 +86,7 @@ by abrasion and Fermi break-up are banked in the neutron pool and drained by
 - [ ] Charged secondaries from neutron reactions (n,p)/(n,α) fed back into the
       ion transport family (currently deposited locally)
 - [ ] Local neutron energy deposits scored (point-deposit scoring path)
-- [ ] Thermal-neutron physics below 1 eV (separate issue #178)
+- [ ] Thermal-neutron physics below 1 eV (separate issue [#178])
 - [ ] Validation: compare neutron fluence to FLUKA or TOPAS reference for
       130 MeV protons on water
 
@@ -130,7 +129,7 @@ Open:
 - [ ] Revisit data-module structure (`material/`, `particle/`, embedded tables)
 - [ ] Rename `struct ray` to `struct ray_v` throughout
 
-## DICOM Study Recalculator (future app)
+## DICOM Study Recalculator (future app, RTPLAN support [#92])
 
 A dedicated `apps/osh_dicom_study` (name TBD) will handle full-plan DICOM
 recalculation without the file-parse overhead of `osh_sim`:
@@ -158,3 +157,18 @@ Positioning in `osh_sim` (manual / current design):
   through data-only APIs.
 - Cold workspaces are the stable user-facing model; runtime structs are derived
   compile products used by simulation and transport.
+
+<!-- Issue / PR references (reference-style links; render as clickable #nnn on GitHub). -->
+[#41]: https://github.com/openshieldhit/openshieldhit/issues/41
+[#42]: https://github.com/openshieldhit/openshieldhit/issues/42
+[#92]: https://github.com/openshieldhit/openshieldhit/issues/92
+[#154]: https://github.com/openshieldhit/openshieldhit/issues/154
+[#161]: https://github.com/openshieldhit/openshieldhit/issues/161
+[#176]: https://github.com/openshieldhit/openshieldhit/issues/176
+[#178]: https://github.com/openshieldhit/openshieldhit/issues/178
+[#190]: https://github.com/openshieldhit/openshieldhit/issues/190
+[#193]: https://github.com/openshieldhit/openshieldhit/issues/193
+[#195]: https://github.com/openshieldhit/openshieldhit/issues/195
+[#207]: https://github.com/openshieldhit/openshieldhit/pull/207
+[#211]: https://github.com/openshieldhit/openshieldhit/issues/211
+[#230]: https://github.com/openshieldhit/openshieldhit/issues/230


### PR DESCRIPTION
## Why

Browsing [`TODO.md`](https://github.com/openshieldhit/openshieldhit/blob/main/TODO.md) on the web, the `#nnn` references were dead text: GitHub only autolinks bare `#nnn` inside issues/PRs/commits, **not** in committed Markdown files. The list had also drifted from the issue tracker and the codebase in a couple of spots.

## What changed (TODO.md only)

- **Clickable references.** Every issue/PR reference is now a reference-style Markdown link, so it renders as a clickable `#nnn` in the blob view while the prose stays compact. The link definitions are collected in one block at the end of the file.
- **Cross-linked open items to their tracking issues** where a clear 1:1 match exists: result-merge API (#230), ridge/ripple-filter (#42), MCPL import (#41), STRAGG 2 profiling (#211), SMM fragmentation (#176), DICOM RTPLAN (#92). Existing bare refs (#195/#207, #193, #161, #154, #178) and the done Vavilov item (#190) were made clickable too.
- **Removed a stale done-claim.** The Vavilov item listed "render the `plot_straggling.py` strag2 overlay" as a remaining nicety — but `strag2` is already wired into `tools/plot_straggling.py` (`CASES`/`MODEL`), so that line is dropped.

## Consistency audit

Spot-checked the remaining unchecked items against the source to confirm they are genuinely still open and not stale: EXTSPEC/parlev (parsers explicitly return "not yet implemented"), alanine (placeholder enum only, no runtime path), zone scoring (no `GEO_ZONE` deposit path in `score_step`/`score_point`), the AVX2 `eval_distance` path (still a `@todo`; the existing avx2 fn is the *zone* batch), material number/electron densities and dedx SIMD helpers (absent), and `struct ray` (legacy form still present). All left as-is. Neutron isotope expansion and the batch checkpoint scheduler are present, so those done-markers are correct.

## Verification

Rendered the file through CommonMark; all 13 references resolve to `<a href>` anchors pointing at the correct `/issues/` (or `/pull/207`) URLs, including the one inside the `## Neutron Transport` heading. No orphan or dangling reference labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134u3Z8RKjefgtk5S3FKQ99

---
_Generated by [Claude Code](https://claude.ai/code/session_0134u3Z8RKjefgtk5S3FKQ99)_