### PR TITLE
build: wire ASan+UBSan sanitizer preset and CI job (#237)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,3 +92,39 @@ jobs:
 
     - name: Build project (Release)
       run: cmake --build build --config Release --parallel
+
+  # AddressSanitizer + UndefinedBehaviorSanitizer pass.  Builds the dedicated
+  # `asan` preset (Debug + -fsanitize=address,undefined) and runs the full ctest
+  # suite instrumented, so memory-safety bugs (heap/stack buffer overflow,
+  # use-after-free, use-after-scope) and undefined behaviour fail CI instead of
+  # silently passing the plain -Og debug build.  GCC/Clang only; Windows is
+  # covered by the Debug/Release jobs above.
+  sanitizers:
+    runs-on: ubuntu-latest
+    env:
+      # LeakSanitizer is disabled for now: the codebase still has benign at-exit
+      # "leaks" (memory reachable at process teardown) that would otherwise mask
+      # the memory-safety signal this job exists to provide.  abort_on_error and
+      # halt_on_error turn a sanitizer report into a non-zero exit so ctest fails.
+      ASAN_OPTIONS: detect_leaks=0:abort_on_error=1
+      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0  # Full git history needed for version extraction (git describe)
+        lfs: false
+
+    - name: Set up CMake
+      uses: jwlawson/actions-setup-cmake@v2.2.0
+
+    - name: Configure project (ASan+UBSan)
+      run: cmake --preset asan
+
+    - name: Build project (ASan+UBSan)
+      run: cmake --build --preset asan --parallel
+
+    - name: Run tests (ASan+UBSan)
+      # DICOM fixtures are downloaded on demand by the DICOM_FIXTURES setup
+      # fixture, same as the main test job.
+      run: ctest --test-dir build_asan --output-on-failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,15 +97,37 @@ jobs:
   # `asan` preset (Debug + -fsanitize=address,undefined) and runs the full ctest
   # suite instrumented, so memory-safety bugs (heap/stack buffer overflow,
   # use-after-free, use-after-scope) and undefined behaviour fail CI instead of
-  # silently passing the plain -Og debug build.  GCC/Clang only; Windows is
-  # covered by the Debug/Release jobs above.
+  # silently passing the plain -Og debug build.  Runs across three GCC/Clang
+  # toolchains — Linux GCC, Linux Clang, and macOS Apple Clang — because the two
+  # sanitizer implementations and the two platform ABIs each catch a slightly
+  # different set of bugs (allocator quirks, alignment/UB Apple Clang flags).
+  # Windows/MSVC ASan (ASan-only, no UBSan) is tracked as a follow-up; the
+  # Debug/Release jobs above still cover the MSVC build.
   sanitizers:
-    runs-on: ubuntu-latest
+    name: sanitizers (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-gcc
+            os: ubuntu-latest
+            cc: gcc
+          - name: linux-clang
+            os: ubuntu-latest
+            cc: clang
+          - name: macos-clang
+            os: macos-latest
+            cc: clang
     env:
+      # The `asan` preset pins no toolchain, so pick the compiler per matrix leg.
+      CC: ${{ matrix.cc }}
       # LeakSanitizer is disabled for now: the codebase still has benign at-exit
       # "leaks" (memory reachable at process teardown) that would otherwise mask
       # the memory-safety signal this job exists to provide.  abort_on_error and
       # halt_on_error turn a sanitizer report into a non-zero exit so ctest fails.
+      # LSan is unsupported on macOS anyway, where detect_leaks=0 is a harmless
+      # no-op.
       ASAN_OPTIONS: detect_leaks=0:abort_on_error=1
       UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
     steps:
@@ -117,6 +139,19 @@ jobs:
 
     - name: Set up CMake
       uses: jwlawson/actions-setup-cmake@v2.2.0
+
+    # Ubuntu's `clang` package does not pull in the ASan/UBSan runtime archives
+    # (libclang_rt.*), so the sanitizer link step fails without them. GCC bundles
+    # its runtimes and macOS gets them from the Xcode toolchain, so this is
+    # Linux-Clang only. The package version is derived from the clang in PATH so
+    # it tracks whatever ubuntu-latest ships; apt install is a no-op if already
+    # present.
+    - name: Install Clang sanitizer runtime
+      if: matrix.name == 'linux-clang'
+      run: |
+        sudo apt-get update
+        ver="$(clang --version | sed -nE 's/.*version ([0-9]+).*/\1/p' | head -1)"
+        sudo apt-get install -y "libclang-rt-${ver}-dev"
 
     - name: Configure project (ASan+UBSan)
       run: cmake --preset asan

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,9 @@ For *what the project is* and where things live, read [`llms.txt`](llms.txt) fir
 
 ## Build, test, format
 
-Day-to-day work uses the **debug** preset (unoptimised, sanitiser-friendly).
+Day-to-day work uses the **debug** preset — a plain `-Og` build (no sanitizers).
+For an AddressSanitizer + UBSan run, use the **asan** preset (`build_asan/`),
+which is what the `sanitizers` CI job builds and tests.
 One command per block:
 
 ```bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,16 @@ if(OSH_ENABLE_SANITIZERS)
         add_compile_options(-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer)
         add_link_options(-fsanitize=address,undefined)
     elseif(MSVC)
+        # MSVC ships AddressSanitizer only (no UBSan). Two MSVC-specific
+        # requirements, both flagged in review: ASan is incompatible with the
+        # /RTC run-time checks that CMake's Debug flags enable by default (strip
+        # them, or cl.exe errors out), and with incremental linking (force it
+        # off). The ASan runtime is import-linked automatically by cl.exe, but
+        # its DLL (clang_rt.asan_dynamic-*.dll, shipped with the MSVC toolchain)
+        # must be discoverable on PATH when the instrumented tests run.
+        string(REGEX REPLACE "/RTC[1csu]+" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
         add_compile_options(/fsanitize=address)
+        add_link_options(/INCREMENTAL:NO)
     else()
         message(FATAL_ERROR "OSH_ENABLE_SANITIZERS requires GCC, Clang, or MSVC")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,25 @@ if(OSH_ENABLE_COVERAGE)
     endif()
 endif()
 
+# Opt-in AddressSanitizer + UndefinedBehaviorSanitizer instrumentation. The
+# `debug` preset is a plain -Og build; the sanitizer pass lives behind this
+# switch and is exposed as the dedicated `asan` preset (build_asan/) so CI can
+# run an instrumented ctest without slowing everyday debug builds. GCC/Clang get
+# ASan+UBSan; MSVC only ships AddressSanitizer (no UBSan), so it gets ASan alone.
+# -fno-sanitize-recover=all turns UBSan reports into hard aborts so a violation
+# fails the test run instead of merely printing a warning.
+option(OSH_ENABLE_SANITIZERS "Enable AddressSanitizer + UndefinedBehaviorSanitizer" OFF)
+if(OSH_ENABLE_SANITIZERS)
+    if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+        add_compile_options(-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer)
+        add_link_options(-fsanitize=address,undefined)
+    elseif(MSVC)
+        add_compile_options(/fsanitize=address)
+    else()
+        message(FATAL_ERROR "OSH_ENABLE_SANITIZERS requires GCC, Clang, or MSVC")
+    endif()
+endif()
+
 # ---- Libraries / modules (these create osh_common, osh_random, etc.) ----
 add_subdirectory(src/common)
 add_subdirectory(src/random)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,6 +38,16 @@
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
                 "CMAKE_C_FLAGS": "-fno-omit-frame-pointer"
             }
+        },
+        {
+            "name": "asan",
+            "displayName": "ASan+UBSan",
+            "description": "Debug build instrumented with AddressSanitizer + UndefinedBehaviorSanitizer",
+            "binaryDir": "${sourceDir}/build_asan",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "OSH_ENABLE_SANITIZERS": "ON"
+            }
         }
     ],
     "buildPresets": [
@@ -56,6 +66,10 @@
         {
             "name": "prof",
             "configurePreset": "prof"
+        },
+        {
+            "name": "asan",
+            "configurePreset": "asan"
         }
     ]
 }

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -664,7 +664,9 @@ configure and build presets are defined in `CMakePresets.json`.
 > The `debug` preset does **not** enable sanitizers — it is a plain `-Og` build.
 > Use the `asan` preset (or `-DOSH_ENABLE_SANITIZERS=ON` on any GCC/Clang
 > configure) to build with AddressSanitizer + UndefinedBehaviorSanitizer; CI runs
-> the full test suite under it. Run leak checks separately: the `asan` CI job sets
+> the full test suite under it on three toolchains — Linux GCC, Linux Clang, and
+> macOS Apple Clang — so implementation-specific reports surface on each. Run
+> leak checks separately: the `asan` CI job sets
 > `ASAN_OPTIONS=detect_leaks=0` while the codebase's benign at-exit leaks are
 > worked through, so LeakSanitizer does not fire there by default.
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -655,10 +655,18 @@ configure and build presets are defined in `CMakePresets.json`.
 
 | Preset | Binary dir | Flags | Use for |
 |---|---|---|---|
-| `debug` | `build_debug/` | `-O0 -g` | Day-to-day development, sanitizers |
+| `debug` | `build_debug/` | `-Og -g3 -fno-omit-frame-pointer` | Day-to-day development |
+| `asan` | `build_asan/` | `-Og -g3 -fsanitize=address,undefined` | Instrumented `ctest` (ASan + UBSan) |
 | `release` | `build/` | `-O3` | Fastest baseline benchmarking |
 | `relwithdebinfo` | `build-rel/` | `-O3 -g` | Optimized benchmarking with symbols |
 | `prof` | `build_prof/` | `-O3 -g -fno-omit-frame-pointer` | `perf record` / flamegraphs |
+
+> The `debug` preset does **not** enable sanitizers — it is a plain `-Og` build.
+> Use the `asan` preset (or `-DOSH_ENABLE_SANITIZERS=ON` on any GCC/Clang
+> configure) to build with AddressSanitizer + UndefinedBehaviorSanitizer; CI runs
+> the full test suite under it. Run leak checks separately: the `asan` CI job sets
+> `ASAN_OPTIONS=detect_leaks=0` while the codebase's benign at-exit leaks are
+> worked through, so LeakSanitizer does not fire there by default.
 
 ### §14.2 Common Commands
 
@@ -690,6 +698,22 @@ Build one target:
 
 ```bash
 cmake --build --preset release --parallel --target gemca_raycast_bench
+```
+
+Configure, build, and run the test suite under AddressSanitizer + UBSan (matches
+the `sanitizers` CI job; LeakSanitizer is disabled while benign at-exit leaks are
+worked through):
+
+```bash
+cmake --preset asan
+```
+
+```bash
+cmake --build --preset asan --parallel
+```
+
+```bash
+ASAN_OPTIONS=detect_leaks=0 ctest --test-dir build_asan --output-on-failure
 ```
 
 ### §14.3 Formatting and Static Analysis

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,8 @@ OpenShieldHIT transports ions (protons, heavier ions) through 3D geometry using 
 
 ```bash
 cmake --preset release && cmake --build --preset release --parallel   # optimised
-cmake --preset debug   && cmake --build --preset debug --parallel     # debug + sanitisers
+cmake --preset debug   && cmake --build --preset debug --parallel     # plain -Og debug
+cmake --preset asan    && cmake --build --preset asan    --parallel   # ASan + UBSan
 ctest --test-dir build_debug --output-on-failure                      # run tests
 ```
 

--- a/tests/unit/test_osh_scoring_parse_geometry.c
+++ b/tests/unit/test_osh_scoring_parse_geometry.c
@@ -213,57 +213,60 @@ static void test_error_missing_args(void) {
     int nw;
     enum osh_status rc;
 
+    /* tokenize() stores pointers *into* the mutable line buffer, so the buffer
+     * must outlive the parse call; keep each call in the same block as its l[]. */
+
     /* name with no argument */
     memset(&geo, 0, sizeof(geo));
     {
         char l[] = "name";
         nw = tokenize(l, words, 8);
+        rc = osh_scoring_parse_geometry_line(&geo, NULL, words, nw, "test", 1, NULL);
+        ASSERT_TRUE(rc == OSH_EPARSE);
     }
-    rc = osh_scoring_parse_geometry_line(&geo, NULL, words, nw, "test", 1, NULL);
-    ASSERT_TRUE(rc == OSH_EPARSE);
 
     /* axis with too few arguments */
     memset(&geo, 0, sizeof(geo));
     {
         char l[] = "x -10.0 10.0";
         nw = tokenize(l, words, 8);
+        rc = osh_scoring_parse_geometry_line(&geo, NULL, words, nw, "test", 1, NULL);
+        ASSERT_TRUE(rc == OSH_EPARSE);
     }
-    rc = osh_scoring_parse_geometry_line(&geo, NULL, words, nw, "test", 1, NULL);
-    ASSERT_TRUE(rc == OSH_EPARSE);
 
     /* rotation with no arguments */
     memset(&geo, 0, sizeof(geo));
     {
         char l[] = "rotation";
         nw = tokenize(l, words, 8);
+        rc = osh_scoring_parse_geometry_line(&geo, NULL, words, nw, "test", 1, NULL);
+        ASSERT_TRUE(rc == OSH_EPARSE);
     }
-    rc = osh_scoring_parse_geometry_line(&geo, NULL, words, nw, "test", 1, NULL);
-    ASSERT_TRUE(rc == OSH_EPARSE);
 
     /* zones with too few arguments */
     memset(&geo, 0, sizeof(geo));
     {
         char l[] = "zones 3";
         nw = tokenize(l, words, 8);
+        rc = osh_scoring_parse_geometry_line(&geo, NULL, words, nw, "test", 1, NULL);
+        ASSERT_TRUE(rc == OSH_EPARSE);
     }
-    rc = osh_scoring_parse_geometry_line(&geo, NULL, words, nw, "test", 1, NULL);
-    ASSERT_TRUE(rc == OSH_EPARSE);
 
     /* inputpath with no argument */
     memset(&geo, 0, sizeof(geo));
     {
         char l[] = "inputpath";
         nw = tokenize(l, words, 8);
+        rc = osh_scoring_parse_geometry_line(&geo, NULL, words, nw, "test", 1, NULL);
+        ASSERT_TRUE(rc == OSH_EPARSE);
     }
-    rc = osh_scoring_parse_geometry_line(&geo, NULL, words, nw, "test", 1, NULL);
-    ASSERT_TRUE(rc == OSH_EPARSE);
 
     /* body with no argument */
     memset(&geo, 0, sizeof(geo));
     {
         char l[] = "body";
         nw = tokenize(l, words, 8);
+        rc = osh_scoring_parse_geometry_line(&geo, NULL, words, nw, "test", 1, NULL);
+        ASSERT_TRUE(rc == OSH_EPARSE);
     }
-    rc = osh_scoring_parse_geometry_line(&geo, NULL, words, nw, "test", 1, NULL);
-    ASSERT_TRUE(rc == OSH_EPARSE);
 }

--- a/tests/unit/test_osh_scoring_step.c
+++ b/tests/unit/test_osh_scoring_step.c
@@ -446,7 +446,10 @@ static void test_score_mesh_dqeff_tqeff(void) {
     unsigned int proj_a[1];
     double proj_mass[1];
     float rho_arr[1];
-    float sp_dummy[1];
+    /* Two-point log energy grid: enough for osh_material_runtime_sp_lookup(),
+     * which interpolates between grid points idx and idx+1 (so nenergy >= 2 and
+     * the table must hold two entries per [material][projectile]). */
+    float sp_dummy[2];
     struct osh_material_runtime mat_rt;
     double mean_energy;
     double gamma_inv;
@@ -458,11 +461,21 @@ static void test_score_mesh_dqeff_tqeff(void) {
     proj_a[0] = 1u;
     proj_mass[0] = proton_mass_mev;
     rho_arr[0] = 1.0f;
-    sp_dummy[0] = 0.0f;
+    /* Flat, non-zero stopping power. Its magnitude does not affect the Qeff
+     * pages exercised here (they carry no dose-to-medium override, so the
+     * looked-up value only feeds sp_tr, which stays unused); it only has to be a
+     * valid in-bounds read. */
+    sp_dummy[0] = 1.0f;
+    sp_dummy[1] = 1.0f;
 
     memset(&mat_rt, 0, sizeof(mat_rt));
     mat_rt.nprojectiles = 1u;
     mat_rt.nmaterials = 1u;
+    mat_rt.nenergy = 2u;
+    mat_rt.emin = OSH_MATERIAL_RUNTIME_EMIN;
+    mat_rt.emax = OSH_MATERIAL_RUNTIME_EMAX;
+    mat_rt.log_emin = log(OSH_MATERIAL_RUNTIME_EMIN);
+    mat_rt.inv_dlog = (double) (mat_rt.nenergy - 1u) / log(OSH_MATERIAL_RUNTIME_EMAX / OSH_MATERIAL_RUNTIME_EMIN);
     mat_rt.projectile_z = proj_z;
     mat_rt.projectile_a = proj_a;
     mat_rt.projectile_mass_mev = proj_mass;


### PR DESCRIPTION
## Why

Closes #237.

The `debug` preset was documented as the sanitizer build (DEVELOPER.md preset table, CLAUDE.md, llms.txt), but `grep -rn fsanitize` returned nothing — no `-fsanitize` flag was set anywhere. Memory-safety and UB bugs therefore passed `ctest`/CI silently on the same code that only broke when a translation unit was compiled *manually* with `-fsanitize=address` (see the companion DICOM CT overflow, #235). The docs also overstated the debug build's guarantees.

## What

- **CMake:** add an opt-in `OSH_ENABLE_SANITIZERS` cache option — `-fsanitize=address,undefined -fno-sanitize-recover=all` on GCC/Clang, `/fsanitize=address` on MSVC (which has no UBSan). Default `OFF`, so everyday debug builds and the Windows target are unaffected.
- **Preset:** add a dedicated `asan` configure/build preset (`build_asan/`, Debug + `OSH_ENABLE_SANITIZERS=ON`) so the flags are opt-in per build rather than slowing the everyday `debug` preset.
- **CI:** add a `sanitizers` job to `test.yml` that builds the `asan` preset and runs the full `ctest` suite instrumented. `-fno-sanitize-recover=all` + `halt_on_error`/`abort_on_error` make any sanitizer report a non-zero exit so the run actually fails.
- **Docs:** correct the `debug` row (it is `-Og -g3`, not `-O0`, and has no sanitizer) in DEVELOPER.md, CLAUDE.md and llms.txt, and document the new `asan` preset.

## Test-code bugs surfaced by the new job (fixed here so it is green)

Running the suite under ASan turned up two genuine stack bugs — exactly the class this job exists to catch:

- `test_osh_scoring_parse_geometry`: `tokenize()` stores pointers *into* an `l[]` buffer, but the buffer went out of scope before the parse call read `words[]` → **stack-use-after-scope**. Fixed by keeping each call in the block that owns its buffer.
- `test_osh_scoring_step`: a 1-element dummy stopping-power table with `nenergy = 0` made `osh_material_runtime_sp_lookup()` read one element past the end → **stack-buffer-overflow**. Fixed with a valid 2-point log-energy grid. (The looked-up value only feeds `sp_tr`, unused by the Qeff pages, so the assertions are unchanged.)

## Notes

- **LeakSanitizer is disabled** in the job (`ASAN_OPTIONS=detect_leaks=0`). The tree still has benign at-exit "leaks" (memory reachable at process teardown, e.g. the gemca zone-compile AST) that would otherwise mask the memory-safety signal. Leak cleanup is a separate, larger effort; the job can flip leak detection on afterwards.
- The **companion DICOM CT overflow (#235)** has no test in the suite yet, so this job is green today; adding that regression test in #235 will make it fail under ASan until the overflow is fixed — the intended behavior per #237's acceptance.

## Validation

Locally, `cmake --preset asan && cmake --build --preset asan` then `ASAN_OPTIONS=detect_leaks=0 ctest --test-dir build_asan` is green (GCC 13.3). The plain `debug` suite is also green. (The one local failure, `version_components_in_string`, is an artifact of a tag-less sandbox checkout — `git describe` returns a bare hash — and fails identically on the unmodified debug build; real CI uses `fetch-depth: 0`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TuSePsxbMj8JeT5udd1PLY

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuSePsxbMj8JeT5udd1PLY)_