### PR TITLE
build: give tagless builds a semver-shaped default version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,6 @@ if(NOT GIT_VERSION)
     set(GIT_VERSION "0.0.1-unknown")
 endif()
 
-message(STATUS "OpenShieldHIT version: ${GIT_VERSION}")
-
 # Parse semver components from tag (e.g. v1.2.3 or v1.2.3-5-gabcdef)
 string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)" OSH_SEMVER_MATCH "${GIT_VERSION}")
 if(OSH_SEMVER_MATCH)
@@ -37,11 +35,19 @@ if(OSH_SEMVER_MATCH)
     set(OSH_VERSION_MINOR "${CMAKE_MATCH_2}")
     set(OSH_VERSION_PATCH "${CMAKE_MATCH_3}")
 else()
+    # Tagless checkout (shallow clone, fresh fork, CI mirror without tags):
+    # `git describe --always` fell back to a bare commit hash with no X.Y.Z to
+    # parse. Synthesise a semver-shaped default so OSH_VERSION always contains a
+    # major.minor.patch that agrees with the component accessors, keeping the
+    # commit as build metadata for provenance (e.g. "0.0.0+6aae2da").
     set(OSH_VERSION_MAJOR 0)
     set(OSH_VERSION_MINOR 0)
     set(OSH_VERSION_PATCH 0)
+    set(GIT_VERSION "0.0.0+${GIT_VERSION}")
 endif()
 set(OSH_PROJECT_VERSION "${OSH_VERSION_MAJOR}.${OSH_VERSION_MINOR}.${OSH_VERSION_PATCH}")
+
+message(STATUS "OpenShieldHIT version: ${GIT_VERSION}")
 
 configure_file(
     ${PROJECT_SOURCE_DIR}/src/common/osh_version.h.in


### PR DESCRIPTION
## Why

On any checkout that can't reach a `v*.*.*` tag — shallow clones, fresh forks, CI mirrors without tags, most container dev environments — `unit::test_osh_main::version_components_in_string` fails and turns the whole suite red (#236).

The root cause is a disagreement inside the version derivation itself. `git describe --tags --always ...` falls back to a **bare commit hash** (e.g. `6aae2da`) when no matching tag is reachable. That hash became `OSH_VERSION` verbatim, but the semver regex found no `X.Y.Z` in it and defaulted the components to `0.0.0`. So the string (`"6aae2da"`) and its components (`0.0.0`) disagreed, and the test's invariant — *the version string contains `major.minor.patch`* — no longer held. The main repo's CI only passes because it has full history + tags.

## What

This takes the issue's **option 2** ("provide a real default tag for tagless builds"), fixing the derivation rather than relaxing the test:

- When the semver regex finds no `X.Y.Z`, wrap the bare-hash fallback into a semver-shaped string `0.0.0+<hash>` (e.g. `0.0.0+6aae2da`).
- `OSH_VERSION` now always contains the `major.minor.patch` that the component accessors report, so the invariant holds **by construction** — no test change needed.
- The commit hash is retained as semver build metadata, so tagless builds stay identifiable (this preserves the reason `--always` was there in the first place).
- The `message(STATUS ...)` line moves after parsing so it reports the actual embedded version.

Tagged builds are unaffected (the `if` branch is unchanged), and the git-absent path still yields `0.0.1-unknown` as before.

## Testing

On this tagless checkout, `git describe --always` yields `6aae2da`; the embedded version is now `0.0.0+6aae2da`.

```
$ ctest --test-dir build_debug
100% tests passed, 0 tests failed out of 125
```

`version_components_in_string` — previously the sole failure — now passes, satisfying the issue's acceptance criterion (green `ctest` on a `--depth 1` clone with no tags).

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QATBkRMBs1YUs7wSgbPeuG)_