### PR TITLE
refactor: rename minimal transport functions to standardize naming

### DIFF
--- a/src/simulation/README.md
+++ b/src/simulation/README.md
@@ -88,7 +88,7 @@ process-global diagnostics ownership.
 
 ## What `osh_simulation_run` does
 
-1. **Transport** — drives `osh_transport_run_minimal` to completion.
+1. **Transport** — drives `osh_transport_run` to completion.
 2. **Postprocess** — calls `osh_scoring_postprocess` to finalise accumulators.
 
 After a successful run, the simulation records both:

--- a/src/simulation/osh_simulation.c
+++ b/src/simulation/osh_simulation.c
@@ -654,7 +654,7 @@ enum osh_status osh_simulation_run(struct osh_simulation *sim) {
     }
     sim->transport_ctx.completed_primaries = (size_t) sim->transport_ctx.params.nstat;
 
-    rc = osh_transport_run_minimal(
+    rc = osh_transport_run(
         &sim->transport_ctx, sim->beam_rt, &sim->geom_rt, &sim->transport_tables, &sim->scoring_runtime);
     if (rc != OSH_OK) {
         OSH_DIAG_ERRORF(sim->diag, "%s", "simulation: transport failed");

--- a/src/transport/README.md
+++ b/src/transport/README.md
@@ -29,13 +29,12 @@ family kernel:
 Current status:
 
 - Ion transport is implemented as the main charged-particle CSDA wavefront.
-- Neutron transport has a minimal pool-drain loop: it transports banked
-  neutrons through geometry/material boundaries, samples free paths from the
-  neutron macroscopic total cross section, and delegates reaction final states
-  to `physics/neutron/`.
+- Neutron transport drains banked neutrons through geometry/material
+  boundaries, samples free paths from the neutron macroscopic total cross
+  section, and delegates reaction final states to `physics/neutron/`.
 - Photon transport remains a stub.
-- The scheduler seam exists now only to define family IDs, fixed-priority
-  selection, and the dispatch ownership point in `osh_transport.c`.
+- The scheduler defines family IDs, fixed-priority selection, pending-work
+  flags, and the dispatch ownership point in `osh_transport.c`.
 - Cross-family feedback is still incomplete: neutron secondaries can be pushed
   back to the neutron pool, but charged secondaries from neutron reactions are
   not yet fed into the ion family and local neutron energy deposits are not yet

--- a/src/transport/osh_transport.c
+++ b/src/transport/osh_transport.c
@@ -59,9 +59,10 @@ static enum osh_status dispatch_transport_family(enum osh_transport_family famil
                                                  size_t hist_hi,
                                                  size_t *ion_completed_out);
 
-/*
- * Orchestrator for the minimal transport run.
+/**
+ * @brief Orchestrate one complete transport run.
  *
+ * @details
  * After the once-per-run family setup (neutron pool, drop counter), the run takes
  * one of two shapes:
  *   • the DEFAULT path (run_master_batched) — the outer checkpoint batch loop that
@@ -79,18 +80,21 @@ static enum osh_status dispatch_transport_family(enum osh_transport_family famil
  * Both share the INNER family scheduler (run_families_over_range): for one range it
  * drains ions then the neutrons/fragments they banked, so the range is
  * *family-exact* before returning.
+ *
+ * @returns OSH_OK on success, OSH_EINVAL for invalid run parameters, or an OSH_E*
+ *          propagated from setup, family transport, scoring, or merging.
  */
-enum osh_status osh_transport_run_minimal(struct osh_transport_context *transport_ctx,
-                                          struct osh_beam_runtime *beam_rt,
-                                          struct osh_gemca_runtime const *geom_rt,
-                                          struct osh_material_runtime const *material_rt,
-                                          struct osh_scoring_runtime *score_rt) {
-    size_t neutron_capacity;
-    size_t nstat;
-    size_t replicas;
-    size_t done;
-    int neutron_enabled; /* cache: neutron pool is present for this run */
-    enum osh_status rc;
+enum osh_status osh_transport_run(struct osh_transport_context *transport_ctx,
+                                  struct osh_beam_runtime *beam_rt,
+                                  struct osh_gemca_runtime const *geom_rt,
+                                  struct osh_material_runtime const *material_rt,
+                                  struct osh_scoring_runtime *score_rt) {
+    size_t neutron_capacity; /* Pool capacity used when the neutron pool must be initialised. */
+    size_t nstat;            /* Requested primary history count for this transport run. */
+    size_t replicas;         /* Score-replica partition count; 0 selects the shared-master path. */
+    size_t done;             /* Primaries fully completed by the chosen run path. */
+    int neutron_enabled;     /* Cached predicate: neutron pool is present for this run. */
+    enum osh_status rc;      /* First failing status from setup or the selected run path. */
 
     if (!transport_ctx) {
         return OSH_EINVAL;
@@ -155,17 +159,26 @@ enum osh_status osh_transport_run_minimal(struct osh_transport_context *transpor
     return OSH_OK;
 }
 
-/*
+/**
+ * @brief Run checkpoint batches into the shared master accumulators.
+ *
+ * @details
  * Default path: the outer checkpoint batch loop over [0, nstat), depositing into
  * the shared master accumulators (target == NULL) and firing the periodic-dump
- * hook at each family-complete boundary.  Factored out of osh_transport_run_minimal
- * so the replica path is a sibling rather than a special case buried in the loop.
+ * hook at each family-complete boundary.  Factored out of osh_transport_run()
+ * so the replica path is a sibling rather than a special case buried in the
+ * loop.
  *
  * The batch size K comes from the checkpoint policy.  FINAL-ONLY (a NULL policy or
  * OSH_PARTIAL_NONE) yields a single batch of K = nstat, so the loop runs exactly
  * once and this is byte-for-byte identical to the un-batched transport.  A LIVE
  * policy yields several family-complete batches at the configured cadence; scored
  * output then matches the final-only result up to floating-point reduction order.
+ *
+ * @param[out] completed_out  Exact number of primary histories completed.
+ * @param[in]  neutron_enabled  Non-zero when the neutron family should be enabled.
+ *
+ * @returns OSH_OK on success, or an OSH_E* from family transport.
  */
 static enum osh_status run_master_batched(struct osh_transport_context *transport_ctx,
                                           struct osh_beam_runtime *beam_rt,
@@ -174,25 +187,25 @@ static enum osh_status run_master_batched(struct osh_transport_context *transpor
                                           struct osh_scoring_runtime *score_rt,
                                           int neutron_enabled,
                                           size_t *completed_out) {
-    struct osh_checkpoint_policy const *policy = transport_ctx->checkpoint_policy;
-    struct osh_run_control *ctl = transport_ctx->run_control; /* clean-stop / dump policy, or NULL */
-    size_t const nstat = transport_ctx->params.nstat;
-    size_t done;          /* primaries whose histories have finished; the true completed count */
-    double measured_rate; /* primaries/s from the last batch; seeds the adaptive time cadence */
-    enum osh_status rc;
+    struct osh_checkpoint_policy const *policy = transport_ctx->checkpoint_policy; /* Borrowed batch cadence. */
+    struct osh_run_control *ctl = transport_ctx->run_control; /* Borrowed clean-stop / dump policy, or NULL. */
+    size_t const nstat = transport_ctx->params.nstat;         /* Requested primary history count. */
+    size_t done;          /* Primaries whose histories have finished; the true completed count. */
+    double measured_rate; /* Primaries/s from the last batch; seeds the adaptive time cadence. */
+    enum osh_status rc;   /* Status from one family-complete batch. */
 
     done = 0u;
     measured_rate = 0.0;
     while (done < nstat) {
-        size_t batch_completed = 0u;
-        size_t const remaining = nstat - done;
+        size_t batch_completed = 0u;           /* Primaries finished by this batch. */
+        size_t const remaining = nstat - done; /* Histories still available to schedule. */
         /* Size the batch from the policy.  The measured rate feeds only the
          * adaptive time cadence; count cadence, explicit batch, and final-only
          * ignore it (final-only returns the whole remainder → one pass, unchanged). */
         size_t const k = osh_checkpoint_next_batch_size(policy, measured_rate, remaining);
-        double t_batch_start = osh_monotonic_seconds();
-        double batch_s;
-        int dump_destination_ready; /* set below: the driver wired a sink + shadow for dumps */
+        double t_batch_start = osh_monotonic_seconds(); /* Batch start time for adaptive cadence. */
+        double batch_s;                                 /* Wall time spent in this family-complete batch. */
+        int dump_destination_ready;                     /* Set below: the driver wired a sink + shadow for dumps. */
 
         /* target == NULL: deposit straight into the shared master views. */
         rc = run_families_over_range(transport_ctx,
@@ -266,7 +279,10 @@ static enum osh_status run_master_batched(struct osh_transport_context *transpor
     return OSH_OK;
 }
 
-/*
+/**
+ * @brief Run score replicas and merge their private accumulators.
+ *
+ * @details
  * Split [0, nstat) into @p nreplicas contiguous integer sub-ranges, transport each
  * one sequentially into its OWN private accumulator set, then merge every set into
  * the shared master before the caller's postprocess + save (issue #230).  This is
@@ -288,6 +304,13 @@ static enum osh_status run_master_batched(struct osh_transport_context *transpor
  * DEVELOPER.md §10: every allocation (private sets + scratch) happens here at setup
  * and every merge at the quiescent boundary after each range fully drains — never on
  * the per-step hot path.
+ *
+ * @param[in]  nreplicas      Number of contiguous history partitions to run.
+ * @param[in]  neutron_enabled  Non-zero when the neutron family should be enabled.
+ * @param[out] completed_out  Exact number of primary histories completed.
+ *
+ * @returns OSH_OK on success, OSH_ENOMEM for allocation/size failures, or an
+ *          OSH_E* from family transport or score merging.
  */
 static enum osh_status run_score_replicas(struct osh_transport_context *transport_ctx,
                                           struct osh_beam_runtime *beam_rt,
@@ -300,16 +323,16 @@ static enum osh_status run_score_replicas(struct osh_transport_context *transpor
     /* Accumulators for all replicas live in one flat block indexed [r*npages + p]:
      * replica r's deposit target is the slice &private_acc[r*npages].  A flat block
      * (vs. an array of per-replica pointers) is one allocation and one free. */
-    struct osh_scoring_accumulator *private_acc;  /* flat nreplicas*npages block, or NULL when npages==0 */
-    struct osh_scoring_scratch *private_scratch;  /* one traversal scratch per replica */
-    struct osh_scoring_accumulator *master;       /* master accumulator view (merge destination) */
-    struct osh_transport_profile *master_profile; /* run master profile, or NULL when profiling off */
-    size_t const nstat = transport_ctx->params.nstat;
-    size_t const npages = score_rt->npages;
-    size_t completed_total;
-    size_t r;
-    size_t p;
-    enum osh_status rc;
+    struct osh_scoring_accumulator *private_acc;      /* flat nreplicas*npages block, or NULL when npages==0 */
+    struct osh_scoring_scratch *private_scratch;      /* one traversal scratch per replica */
+    struct osh_scoring_accumulator *master;           /* master accumulator view (merge destination) */
+    struct osh_transport_profile *master_profile;     /* run master profile, or NULL when profiling off */
+    size_t const nstat = transport_ctx->params.nstat; /* Requested primary history count. */
+    size_t const npages = score_rt->npages;           /* Accumulator pages per replica. */
+    size_t completed_total;                           /* Primaries finished across all launched replicas. */
+    size_t r;                                         /* Replica loop index. */
+    size_t p;                                         /* Scoring page loop index. */
+    enum osh_status rc;                               /* First failing allocation, transport, or merge status. */
 
     *completed_out = 0u;
 
@@ -351,11 +374,11 @@ static enum osh_status run_score_replicas(struct osh_transport_context *transpor
         /* Contiguous integer partition: hi(N-1) == nstat exactly, and consecutive
          * ranges share no history, so the union is [0, nstat) with no gap/overlap
          * for any N <= nstat.  64-bit intermediate avoids nstat*r overflow. */
-        size_t const lo = (size_t) ((unsigned long long) nstat * r / nreplicas);
-        size_t const hi = (size_t) ((unsigned long long) nstat * (r + 1u) / nreplicas);
-        size_t completed = 0u;
-        struct osh_score_target target;
-        struct osh_transport_profile replica_profile;
+        size_t const lo = (size_t) ((unsigned long long) nstat * r / nreplicas);        /* Inclusive history bound. */
+        size_t const hi = (size_t) ((unsigned long long) nstat * (r + 1u) / nreplicas); /* Exclusive history bound. */
+        size_t completed = 0u;                        /* Primaries finished by this replica range. */
+        struct osh_score_target target;               /* Private accumulator/scratch view for this replica. */
+        struct osh_transport_profile replica_profile; /* Temporary profile reduced into the master profile. */
 
         target.acc_set = &private_acc[r * npages];
         target.scratch = &private_scratch[r];
@@ -461,9 +484,9 @@ static enum osh_status run_families_over_range(struct osh_transport_context *tra
                                                size_t hist_hi,
                                                int neutron_enabled,
                                                size_t *batch_completed_out) {
-    struct osh_transport_scheduler scheduler;
-    enum osh_transport_family family;
-    enum osh_status rc;
+    struct osh_transport_scheduler scheduler; /* Per-range queue of enabled families with pending work. */
+    enum osh_transport_family family;         /* Family selected by scheduler_next(). */
+    enum osh_status rc;                       /* Status from scheduler setup or the dispatched family kernel. */
 
     if (batch_completed_out) {
         *batch_completed_out = 0u;
@@ -557,6 +580,8 @@ static enum osh_status dispatch_transport_family(enum osh_transport_family famil
                                                  size_t hist_lo,
                                                  size_t hist_hi,
                                                  size_t *ion_completed_out) {
+    struct osh_diag_sink const *diag; /* Borrowed diagnostics sink; NULL keeps unsupported-family errors silent. */
+
     switch (family) {
     case OSH_TRANSPORT_FAMILY_ION:
         return osh_transport_ion_run_range(
@@ -564,14 +589,13 @@ static enum osh_status dispatch_transport_family(enum osh_transport_family famil
     case OSH_TRANSPORT_FAMILY_NEUTRON:
         return osh_transport_neutron_run(transport_ctx, beam_rt, geom_rt, material_rt, score_rt, target);
     case OSH_TRANSPORT_FAMILY_PHOTON:
-        return osh_transport_photon_run_minimal(transport_ctx, beam_rt, geom_rt, material_rt, score_rt);
+        return osh_transport_photon_run(transport_ctx, beam_rt, geom_rt, material_rt, score_rt);
     case OSH_TRANSPORT_FAMILY_ELECTRON:
     case OSH_TRANSPORT_FAMILY_COUNT:
         break;
     }
 
-    OSH_DIAG_ERRORF(transport_ctx ? transport_ctx->diag : NULL,
-                    "transport: %s transport is not implemented",
-                    osh_transport_family_name(family));
+    diag = transport_ctx ? transport_ctx->diag : NULL;
+    OSH_DIAG_ERRORF(diag, "transport: %s transport is not implemented", osh_transport_family_name(family));
     return OSH_ENOTSUP;
 }

--- a/src/transport/osh_transport.h
+++ b/src/transport/osh_transport.h
@@ -225,43 +225,44 @@ struct osh_transport_context {
 };
 
 /**
- * @brief Run the minimal straight-line CSDA transport loop.
+ * @brief Run the top-level family-scheduled transport driver.
  *
  * @details
- * This is the first end-to-end transport slice for OpenShieldHIT:
- *   - primaries are sampled from beam/
- *   - the top-level driver currently seeds the ion family only
- *   - zones and boundary distances come from gemca/runtime/
- *   - energy loss is computed from material CSDA range tables
- *   - scoring is applied step-by-step through scoring/runtime
+ * The transport driver owns the outer run structure: it partitions the requested
+ * histories into family-complete checkpoint batches, dispatches each enabled
+ * particle family to its kernel, drains all secondaries banked by a batch before
+ * returning to the caller, and optionally routes score-replica ranges through
+ * private accumulators before merging them into the master result.
  *
- * Internally, transport uses a scheduler-owned outer loop with one pool per
- * particle family (ions, neutrons, photons, electrons, ...).  The dispatch
- * seam lives in transport/ rather than inside each family kernel, so that
- * per-family kernels are pure functions of their pool and can be offloaded or
- * parallelised independently in future refactors.
- *
- * Physics included:
- *   - CSDA energy loss (residual-range tables)
- *   - multiple Coulomb scattering (Highland/Molière, random-hinge method)
- *   - Gaussian energy straggling (Bohr variance)
- *   - nuclear interactions (pp elastic, abrasion + Fermi break-up secondaries)
- *
- * Not yet implemented:
- *   - de-excitation of heavy nuclear residues, A > 16 (evaporation/SMM)
+ * Family kernels keep the physics details local to their modules.  The current
+ * ion family includes CSDA energy loss, Highland/Molière multiple Coulomb
+ * scattering, Bohr Gaussian energy straggling, and nuclear interactions
+ * (pp elastic, abrasion + Fermi break-up secondaries).  The neutron family drains
+ * banked fast neutrons through its own pool.  Placeholder families such as photon
+ * and electron report OSH_ENOTSUP until their kernels exist.
  *
  * DELTAE is treated as a maximum fractional energy-loss step criterion in
- * material. Boundary-limited steps are truncated and the exit energy is
+ * material. Boundary-limited ion steps are truncated and the exit energy is
  * recovered from the residual CSDA range.
  *
- * The caller is responsible for calling osh_gemca_compile() before this
- * function and osh_gemca_runtime_free() after it returns.
+ * The caller is responsible for compiling geometry/material/scoring runtimes
+ * before calling this function and freeing those runtimes after it returns.
+ *
+ * @param[in,out] transport_ctx  Per-run transport context, including pools,
+ *                               run controls, diagnostics, and transport params.
+ * @param[in]     beam_rt        Hot beam runtime for primary generation.
+ * @param[in]     geom_rt        Compiled geometry runtime.
+ * @param[in]     material_rt    Hot material runtime tables.
+ * @param[in,out] score_rt       Scoring runtime receiving all deposits.
+ *
+ * @returns OSH_OK on success, OSH_EINVAL for invalid run parameters, or an
+ *          OSH_E* propagated from setup, family transport, scoring, or merging.
  */
-enum osh_status osh_transport_run_minimal(struct osh_transport_context *transport_ctx,
-                                          struct osh_beam_runtime *beam_rt,
-                                          struct osh_gemca_runtime const *geom_rt,
-                                          struct osh_material_runtime const *material_rt,
-                                          struct osh_scoring_runtime *score_rt);
+enum osh_status osh_transport_run(struct osh_transport_context *transport_ctx,
+                                  struct osh_beam_runtime *beam_rt,
+                                  struct osh_gemca_runtime const *geom_rt,
+                                  struct osh_material_runtime const *material_rt,
+                                  struct osh_scoring_runtime *score_rt);
 
 #ifdef __cplusplus
 }

--- a/src/transport/osh_transport_neutron.c
+++ b/src/transport/osh_transport_neutron.c
@@ -28,14 +28,24 @@
 
 static struct particle const k_neutron_species = {OSH_PART_MASS_NEUTRON, OSH_PART_PDG_NEUTRON, 0, 0u, 1u, 0u};
 
-/*
- * Total macroscopic cross section Σ_tot [cm⁻¹] for one material cell.
+/**
+ * @brief Compute the total macroscopic neutron cross section for one material cell.
+ *
+ * @details
  * Σ_tot = Σ_i n_i σ_tot,i,  with n_i [cm⁻³] and σ in cm².
  *
  * Called separately from osh_neutron_reaction_sample() so the free-path
  * length can be sampled before committing to a full reaction.  The two
  * xsec_lookup calls per element are redundant but acceptable for the
- * minimal model; they share the same xsec warning-once state.
+ * current neutron model; they share the same xsec warning-once state.
+ *
+ * @param[in,out] xsec        Cross-section lookup cache and warning state.
+ * @param[in]     handler     Nuclear handler carrying material element lists.
+ * @param[in]     mat_idx     Material index for the current zone/voxel.
+ * @param[in]     rho_g_cm3   Material density [g/cm³].
+ * @param[in]     e_mev       Neutron kinetic energy [MeV].
+ *
+ * @returns Σ_tot [cm⁻¹].
  */
 static double neutron_sigma_tot_cm(struct osh_neutron_xsec *xsec,
                                    struct osh_nuclear_handler const *handler,

--- a/src/transport/osh_transport_neutron.h
+++ b/src/transport/osh_transport_neutron.h
@@ -15,7 +15,7 @@ struct osh_scoring_runtime;
 struct osh_score_target;
 
 /**
- * @brief Minimal fast-neutron transport loop.
+ * @brief Fast-neutron transport loop.
  *
  * @details
  * Drains the neutron pool supplied via transport_ctx->neutron_pool using a

--- a/src/transport/osh_transport_photon.c
+++ b/src/transport/osh_transport_photon.c
@@ -3,11 +3,11 @@
 #include "common/osh_diag.h"
 #include "transport/osh_transport.h"
 
-enum osh_status osh_transport_photon_run_minimal(struct osh_transport_context *transport_ctx,
-                                                 struct osh_beam_runtime *beam_rt,
-                                                 struct osh_gemca_runtime const *geom_rt,
-                                                 struct osh_material_runtime const *material_rt,
-                                                 struct osh_scoring_runtime *score_rt) {
+enum osh_status osh_transport_photon_run(struct osh_transport_context *transport_ctx,
+                                         struct osh_beam_runtime *beam_rt,
+                                         struct osh_gemca_runtime const *geom_rt,
+                                         struct osh_material_runtime const *material_rt,
+                                         struct osh_scoring_runtime *score_rt) {
     (void) beam_rt;
     (void) geom_rt;
     (void) material_rt;

--- a/src/transport/osh_transport_photon.h
+++ b/src/transport/osh_transport_photon.h
@@ -15,13 +15,26 @@ struct osh_scoring_runtime;
 
 /**
  * @brief Photon transport loop (stub — not yet implemented).
- * @return OSH_ENOTSUP always.
+ *
+ * @details
+ * Placeholder family kernel used by the scheduler so unsupported photon work
+ * reports a normal OSH_ENOTSUP status through the same dispatch path as other
+ * particle families.
+ *
+ * @param[in,out] transport_ctx  Per-run transport context; diagnostics are used
+ *                               for the unsupported-family message.
+ * @param[in]     beam_rt        Unused until photon transport is implemented.
+ * @param[in]     geom_rt        Unused until photon transport is implemented.
+ * @param[in]     material_rt    Unused until photon transport is implemented.
+ * @param[in,out] score_rt       Unused until photon transport is implemented.
+ *
+ * @returns OSH_ENOTSUP always.
  */
-enum osh_status osh_transport_photon_run_minimal(struct osh_transport_context *transport_ctx,
-                                                 struct osh_beam_runtime *beam_rt,
-                                                 struct osh_gemca_runtime const *geom_rt,
-                                                 struct osh_material_runtime const *material_rt,
-                                                 struct osh_scoring_runtime *score_rt);
+enum osh_status osh_transport_photon_run(struct osh_transport_context *transport_ctx,
+                                         struct osh_beam_runtime *beam_rt,
+                                         struct osh_gemca_runtime const *geom_rt,
+                                         struct osh_material_runtime const *material_rt,
+                                         struct osh_scoring_runtime *score_rt);
 
 #ifdef __cplusplus
 }

--- a/src/transport/osh_transport_scheduler.h
+++ b/src/transport/osh_transport_scheduler.h
@@ -8,7 +8,7 @@ extern "C" {
 #endif
 
 /*
- * Internal header: scheduler seam for future multi-pool transport orchestration.
+ * Internal header: scheduler seam for multi-pool transport orchestration.
  * Not part of the public API yet.
  */
 
@@ -21,12 +21,12 @@ enum osh_transport_family {
 };
 
 /*
- * Minimal scheduler state for the future outer transport loop.
+ * Scheduler state for the outer transport loop.
  *
- * The eventual multi-pool driver will own one queue or pool per transport
- * family and update has_work[] as families generate secondaries for each
- * other.  For now this struct only tracks which families are enabled for a
- * run and which of them currently have work pending.
+ * The multi-pool driver owns one queue or pool per transport family and updates
+ * has_work[] as families generate secondaries for each other.  This struct
+ * tracks which families are enabled for a run and which enabled families
+ * currently have work pending.
  */
 struct osh_transport_scheduler {
     char enabled[OSH_TRANSPORT_FAMILY_COUNT];

--- a/tests/unit/test_osh_transport_guards.c
+++ b/tests/unit/test_osh_transport_guards.c
@@ -11,17 +11,17 @@
  * dereferencing them, so a valid, never-read address is all that is required.
  */
 
-static void test_run_minimal_rejects_bad_args(void) {
+static void test_transport_run_rejects_bad_args(void) {
     struct osh_transport_context ctx;
 
     /* NULL context. */
-    ASSERT_TRUE(osh_transport_run_minimal(NULL, NULL, NULL, NULL, NULL) == OSH_EINVAL);
+    ASSERT_TRUE(osh_transport_run(NULL, NULL, NULL, NULL, NULL) == OSH_EINVAL);
 
     /* nstat == 0 is rejected before any pool is touched, so a zeroed context
      * (NULL pools) is enough to reach and return from that guard. */
     memset(&ctx, 0, sizeof(ctx));
     ctx.params.nstat = 0u;
-    ASSERT_TRUE(osh_transport_run_minimal(&ctx, NULL, NULL, NULL, NULL) == OSH_EINVAL);
+    ASSERT_TRUE(osh_transport_run(&ctx, NULL, NULL, NULL, NULL) == OSH_EINVAL);
 }
 
 static void test_ion_run_range_validates_arguments(void) {
@@ -57,7 +57,7 @@ static void test_ion_run_range_validates_arguments(void) {
 }
 
 int main(void) {
-    test_run_minimal_rejects_bad_args();
+    test_transport_run_rejects_bad_args();
     test_ion_run_range_validates_arguments();
     return 0;
 }


### PR DESCRIPTION
- Updated function names from `osh_transport_run_minimal` to `osh_transport_run` for consistency.
- Adjusted related documentation and comments to reflect the new naming.
- Modified tests to use the updated function names.