### PR TITLE
Add pre-equilibrium emission model to nuclear physics module

### DIFF
--- a/docs/dev/bug-hunts/2026-07-05-deep-audit.md
+++ b/docs/dev/bug-hunts/2026-07-05-deep-audit.md
@@ -14,7 +14,7 @@
 | **Commit audited** | [`e3c619a`][e3c619a] on `main` (2026-07-05) |
 | **Source** | [PR #248][#248] |
 | **Scope** | Test infra · transport hot path & EM physics · scoring · nuclear/neutron transport · RNG & parallel readiness · GEMCA geometry · parsers/IO · architecture |
-| **Follow-up** | 11 suggested issues (1 filed — [#255][#255], fixed by [#257][#257]) — see [§8](#sec-8) |
+| **Follow-up** | 11 suggested issues (2 filed — [#255][#255], fixed by [#257][#257]; [#267][#267], fixed by [`a0f60a1`][a0f60a1]) — see [§8](#sec-8) |
 
 
 Deep audit of `main` (e3c619a) prompted by PR [#239][#239] (sanitizer wiring) and issues
@@ -160,6 +160,13 @@ cutoff kill is the same physical situation without the deposit.
   with the effective cutoff.
 
 ### P-2 (high, high) Non-default isotopes are transported with the representative isotope's range table and rest mass — deuteron range wrong by ≈2× {: #p-2 }
+
+!!! success "Resolved"
+    Filed as [#267][#267] and fixed by [`a0f60a1`][a0f60a1].  Transport still
+    shares stopping-power columns by `Z`, but CSDA range is now scaled by
+    `A_actual/A_table`, isotope-specific kinematics use `part->mass`, and a
+    regression unit covers non-default H/He isotopes in a non-unit-density
+    material.
 
 Mechanism, three coupled pieces:
 
@@ -895,7 +902,7 @@ case dir which fails at *someone else's* `ctest`).
 | [G-1](#g-1) | Ellipsoid/elliptic-cyl/cone distances wrong (missing ×2 on linear coefficient); empirically confirmed 0.651 vs 0.500 — filed as [#255][#255], fixed by [#257][#257] | **critical** (for ELL/ELLZ/CONE users) | `osh_gemca2_dist.c:413,443,467` |
 | [N-1](#n-1) | Neutron interactions deposit zero energy; n–p recoil energy vanishes; [TODO.md][todo-md] claims otherwise | **high** | `osh_transport_neutron.c:166-202`, `osh_neutron_reaction.c:91-108` |
 | [N-2](#n-2) | Neutron σ clamped at 20 MeV table edge — fast neutrons ×5–6 over-attenuated | **high** | `osh_neutron_xsec.c:84-87` |
-| [P-2](#p-2) | Isotope conflation: deuteron/triton/³He use wrong range table (×2/×3/×¾) and wrong rest mass | **high** | `osh_transport_ion_step.c:1258`, `osh_material_compile.c:698-716` |
+| [P-2](#p-2) | Isotope conflation: deuteron/triton/³He use wrong range table (×2/×3/×¾) and wrong rest mass — filed as [#267][#267], fixed by [`a0f60a1`][a0f60a1] | **high** (resolved) | `osh_transport_ion_step.c:1258`, `osh_material_compile.c:698-716` |
 | [P-1](#p-1) | Residual energy deleted at cutoff kill (scales with TCUT0) | **high** | `osh_transport_ion_step.c:539-543` |
 | [S-1](#s-1) | `st->wt` ignored by every scorer — latent for MCPL ([#41][#41])/VR | **high (latent)** | `src/scoring/runtime/*` |
 | [P-3](#p-3) | Bohr straggling missing relativistic factor; κ-dispatch variance discontinuity | medium | `osh_physics_strag_gauss.c:25-37` |
@@ -923,7 +930,7 @@ PR [#239][#239] validated and worth merging as-is ([T-4](#t-4)).
 1. GEMCA quadric linear-coefficient bug + per-surface distance unit tests ([G-1](#g-1), [G-2](#g-2)) — filed as [#255][#255], fixed by [#257][#257].
 2. Neutron energy deposition: point-deposit `local_deposit_mev` + fix [TODO.md][todo-md] claims ([N-1](#n-1)); follow-up: recoil-proton ion feedback.
 3. Neutron σ above 20 MeV: Tier-2 dispatch above Tier-1 grid ([N-2](#n-2)).
-4. Isotope-aware range/mass in transport (A-rescale within Z column + `part->mass` kinematics + once-per-species warning) ([P-2](#p-2)).
+4. Isotope-aware range/mass in transport (A-rescale within Z column + `part->mass` kinematics) ([P-2](#p-2)) — filed as [#267][#267], fixed by [`a0f60a1`][a0f60a1].
 5. Deposit residual energy at all cutoff/species kills ([P-1](#p-1), and neutron cutoff from [N-1](#n-1)).
 6. Weight-aware scoring + weighted-variance contract ([S-1](#s-1), feeds [#169][#169] and [#41][#41]).
 7. Relativistic Bohr straggling factor ([P-3](#p-3)).
@@ -962,5 +969,7 @@ current usage; "latent" items are correct today but break planned features.
 [#248]: https://github.com/openshieldhit/openshieldhit/pull/248
 [#255]: https://github.com/openshieldhit/openshieldhit/issues/255
 [#257]: https://github.com/openshieldhit/openshieldhit/pull/257
+[#267]: https://github.com/openshieldhit/openshieldhit/issues/267
 [todo-md]: https://github.com/openshieldhit/openshieldhit/blob/e3c619a1328e9351bcbc1dc599321ac2770ad622/TODO.md
 [e3c619a]: https://github.com/openshieldhit/openshieldhit/commit/e3c619a1328e9351bcbc1dc599321ac2770ad622
+[a0f60a1]: https://github.com/openshieldhit/openshieldhit/commit/a0f60a1d201ed147719f26751befbd65488ab536

--- a/docs/physics/nuclear-inelastic.md
+++ b/docs/physics/nuclear-inelastic.md
@@ -1,0 +1,197 @@
+# Nuclear inelastic reactions reference
+
+This page documents the proton-induced nuclear reaction chain in
+OpenShieldHIT: what happens when the inelastic hazard fires on a transport
+step, which models produce the secondary particles, and where the calibration
+knobs live.
+
+The implementation lives in `src/physics/nuclear/`:
+
+```text
+osh_nuclear_handler        per-step hazard evaluation, struck-element selection, chain dispatch
+osh_nuclear_tripathi       total reaction cross section σ_R (Tripathi 1999)
+osh_nuclear_pp             p+p (hydrogen) elastic channel
+osh_nuclear_elastic        p+A elastic channel (recoil nucleus)
+osh_nuclear_abrasion       fast stage: mini intranuclear cascade + knockout retention
+osh_nuclear_preeq          pre-equilibrium: single-component exciton model
+osh_nuclear_fermi_breakup  equilibrium stage: microcanonical Fermi break-up (A ≤ 16)
+osh_nuclear_compound       compound-nucleus router (neutron path; future SMM seam)
+```
+
+and is invoked from the ion stepper (`src/transport/osh_transport_ion_step.c`),
+which owns the event struct and dispatches the produced secondaries to the
+neutron/ion pools.
+
+## The `NUCRE` switch
+
+`NUCRE` in `beam.dat` selects the nuclear channels. Integer values match
+SHIELD-HIT12A where they exist.
+
+| mode | channels | note |
+|------|----------|------|
+| 0 | off | no nuclear interactions |
+| 1 | inelastic + elastic | the physical "on" setting |
+| 2 | elastic only | OpenShieldHIT-only decomposition of mode 1 |
+| 3 | inelastic only | OpenShieldHIT-only decomposition of mode 1 |
+
+## The inelastic chain
+
+An inelastic event runs a staged pipeline (the architecture of issue
+[#221](https://github.com/openshieldhit/openshieldhit/issues/221); stage
+boundaries are fixed interfaces so that a future real intranuclear cascade
+and a coalescence stage for ion projectiles can slot in without rework):
+
+```text
+σ_R hazard (Tripathi)  →  struck-element selection (per-nuclide rates)
+  →  1. FAST STAGE      abrasion: knockout nucleons + excited prefragment (A, Z, E*, p, h)
+  →  2. (coalescence)   reserved slot — no-op for proton projectiles
+  →  3. PRE-EQUILIBRIUM exciton model: fast {n, p, d, t, ³He, α} emission
+  →  4. EQUILIBRIUM     Fermi break-up (A ≤ 16); heavier residues: sink (future SMM/evaporation)
+  →  fragment pool → ion/neutron transport or point deposit
+```
+
+Only protons run this pipeline today; ion projectiles resolve as `ABSORB`
+(energy deposited locally) until the ion-projectile fast stage lands.
+Hydrogen targets are excluded from the inelastic hazard for protons below
+280 MeV (no open channel below the pion threshold); the p+p elastic channel
+covers them.
+
+### Fast stage — abrasion with knockout retention
+
+`osh_nuclear_abrasion.c` implements a Bowman-Swiatecki-Tsang abrasion in an
+intranuclear-cascade picture: the proton undergoes ν quasi-elastic collisions
+(⟨ν⟩ = σ_pN·A/σ_pA, zero-truncated Poisson), each knocking out one nucleon
+(isotropic CM, full relativistic equal-mass kinematics) and deflecting the
+continuing cascade proton. Each hole charges
+`OSH_ABRASION_EXCITATION_PER_HOLE_MEV` (13.3 MeV, Gaimard–Schmidt) to the
+cascade proton, booked as prefragment excitation, so the kinetic budget
+`T_in = Σ KE_escaped + E*` is exact.
+
+Low-energy knockouts are **re-absorbed** ("back to spectator", INCL4.6,
+Boudard et al. PRC 87 (2013) 014606 Sec. II D1): a smooth Fermi-function
+retention around `OSH_ABRASION_RETENTION_THRESHOLD_MEV` (ξ = 7 MeV; protons
+add ⅔ of the Coulomb barrier). Retained kinetic energy funds E\*; the
+retained nucleon becomes a **particle exciton**. Every collision leaves a
+**hole exciton**; the exciton configuration (p, h) is exported in
+`struct osh_nuclear_fragment` as the input of the pre-equilibrium stage.
+The INCL4.6 paper's own ξ = 18 MeV experiment traded nucleon-spectrum
+fidelity for cluster yield — do not raise ξ to chase excitation energy
+(measured in [#260](https://github.com/openshieldhit/openshieldhit/issues/260)
+/ [#263](https://github.com/openshieldhit/openshieldhit/issues/263)).
+
+| knob (compile-time) | default | meaning |
+|---|---|---|
+| `OSH_ABRASION_SIGMA_PN_MB` | 30.0 | p+nucleon σ for ⟨ν⟩ |
+| `OSH_ABRASION_EXCITATION_PER_HOLE_MEV` | 13.3 | hole excitation (do not retune — #260) |
+| `OSH_ABRASION_RETENTION_THRESHOLD_MEV` | 7.0 | back-to-spectator ξ (0 disables) |
+| `OSH_ABRASION_RETENTION_WIDTH_MEV` | 2.0 | smooth turn-on width |
+
+### Pre-equilibrium — single-component exciton model
+
+`osh_nuclear_preeq.c` (issue
+[#225](https://github.com/openshieldhit/openshieldhit/issues/225)) de-excites
+the prefragment before equilibrium break-up. Starting from (p, h, E\*), each
+step either emits an ejectile or thermalizes one Δn = +2 collision, until the
+equilibrium exciton number n_eq = √(2 g E\*) is reached:
+
+- **State density**: Williams, ω(p, h, E) = g (gE)^(p+h−1) / (p! h! (p+h−1)!),
+  with g = `OSH_PREEQ_LEVEL_DENSITY_PER_A`·A (0.075/MeV per nucleon).
+- **Emission widths** (detailed balance, Betak-Dobes form) for
+  {n, p, d, t, ³He, α}: exact mass-table separation energies,
+  Dostrovsky-style inverse cross sections, a composition factor from the
+  residue N/Z, and for clusters the condensation probability γ_j
+  (γ_d = 16/A, γ_t = γ_³He = 243/A², γ_α = 4096/A³ — the Geant4 closed
+  forms), each times a per-species calibration scale.
+- **Transition rate** λ₊ (Δn = +2 only): CEM form — in-medium NN cross
+  section at the mean exciton relative energy, Pauli-blocking factor,
+  interaction volume (Gudima–Mashnik–Toneev).
+- **Contracts**: a fragment with (p, h) = (0, 0) is thermalized and passes
+  through untouched (compound nuclei, break-up residues); per-emission
+  bookkeeping is exact (E\* before = E\* after + B_j + T); only the
+  whitelist {n, p, d, t, ³He, α} is emitted. Emission angles are isotropic
+  (Kalbach continuum systematics are a planned refinement).
+
+| knob (compile-time) | default | meaning |
+|---|---|---|
+| `OSH_PREEQ_LEVEL_DENSITY_PER_A` | 0.075 | single-particle level density / A [1/MeV] |
+| `OSH_PREEQ_FERMI_ENERGY_MEV` | 35.0 | Fermi energy in λ₊ |
+| `OSH_PREEQ_TRANSITIONS_R0_FM` | 0.6 | interaction-volume radius in λ₊ |
+| `OSH_PREEQ_EMISSION_R0_FM` | 1.25 | inverse-σ radius parameter |
+| `OSH_PREEQ_GAMMA_SCALE_{D,T,HE3,ALPHA}` | 1.0 | cluster condensation calibration scales |
+
+**Calibration status.** The γ scales ship neutral (1.0) and are *expected*
+to be fitted (CEM03.03 multiplies its equivalent factors by empirical fits).
+The #225 measurement showed that on abrasion-fed exciton configurations the
+deuteron channel responds strongly to γ_d while t/³He/α are exciton-starved
+(they need p ≥ 3–4 particle excitons), and that cluster emission is
+E\*-redistributive against the break-up stage — the hard α component needs a
+direct knockout channel (Stage 3 of #221) or a richer cascade. The joint fit
+is deferred until the isotope range-table defect
+([#267](https://github.com/openshieldhit/openshieldhit/issues/267)) is fixed,
+because it distorts the transported d/t/³He fluences the fit targets.
+
+### Equilibrium — Fermi break-up
+
+`osh_nuclear_fermi_breakup.c` de-excites light residues (A ≤ 16) by the
+microcanonical statistical Fermi break-up: all N = 2..6 ground-state
+partitions over the isotope database, weighted by the canonical phase-space
+probability with a free-volume coefficient (single knob
+`OSH_FERMI_BREAKUP_R0_FM` = 0.50 fm, calibrated against G4FermiBreakUp
+multiplicities). Particle-unstable intermediates (Be-8, He-5, Li-5) decay on
+a work stack; only the whitelist {n, p, d, t, ³He, α} is ever transported;
+bound non-whitelist nuclides go to the fragment pool. Ground states only —
+systematic excited-state level tables are issue
+[#196](https://github.com/openshieldhit/openshieldhit/issues/196).
+
+### Compound routing and heavier residues
+
+`osh_nuclear_compound.c` routes an equilibrated compound nucleus: A ≤ 16 to
+Fermi break-up, A > 16 to a warn-once sink that deposits E\* locally — the
+seam where evaporation
+([#175](https://github.com/openshieldhit/openshieldhit/issues/175)) and SMM
+([#176](https://github.com/openshieldhit/openshieldhit/issues/176)) will plug
+in. The neutron-capture path (`src/physics/neutron/osh_neutron_reaction.c`)
+enters here with a thermalized (p, h) = (0, 0) configuration.
+
+## Event contract and transport handoff
+
+The chain writes one `struct osh_nuclear_event`: up to 32 secondaries
+(direction, kinetic energy, species pointer) and up to 4 residual fragments
+(A, Z, E\*, lab momentum, exciton configuration). Transport injects
+secondaries into the neutron/ion pools; fragments above the per-nucleon
+threshold enter the ion pool as recoil species, below it they are
+point-deposited. Kinetic energy is conserved exactly through abrasion, and
+total energy (with masses) through pre-equilibrium and break-up; unit tests
+enforce both (`tests/unit/test_osh_nuclear_*.c`).
+
+## Validation tooling
+
+- `tests/reference/idd_water_200mev_nucre{0..3}/` — NUCRE isolation decks
+  (200 MeV p → water, MSCAT/STRAGG off) with species-resolved dose/fluence,
+  plateau spectra, and LET; SH12A mirror fixtures under
+  `tests/reference/shieldhit/`.
+- `tools/plot_nucre.py` — OpenShieldHIT vs SH12A overlay report.
+- `examples/06_nucre_validation/nucre_scan` — transport-free production
+  spectra of the abrasion → preeq → break-up chain (yields per event,
+  per-species spectra, prefragment E\* and exciton statistics).
+
+## Provenance and references
+
+The models are implemented from the published literature; Geant4 sources
+were consulted as a formula cross-reference only (no code reuse — license
+differs from OpenShieldHIT's MIT). SHIELD-HIT12A shares the input format and
+application domain, not code; its reference spectra are used as validation
+fixtures only.
+
+- Tripathi, Cucinotta, Wilson, NASA/TP-1999-209726 — reaction cross section.
+- Bowman, Swiatecki, Tsang (1973); Gaimard & Schmidt, Nucl. Phys. A 531
+  (1991) 709 — abrasion, hole excitation.
+- Boudard, Cugnon, David, Leray, Mancusi, Phys. Rev. C 87 (2013) 014606 —
+  INCL4.6; knockout retention ("back to spectator").
+- Gudima, Mashnik, Toneev, Nucl. Phys. A 401 (1983) 329; Mashnik et al.,
+  arXiv:0805.0751 (CEM03.03) — exciton model, transition rate, n_eq exit.
+- Betak & Dobes, Z. Phys. A 279 (1976) 319 — cluster emission widths.
+- Dostrovsky, Fraenkel, Friedlander, Phys. Rev. 116 (1959) 683 — inverse
+  cross sections.
+- Fermi, Prog. Theor. Phys. 5 (1950) 570 — break-up; validated against
+  G4FermiBreakUp (Pshenichnov test data, used with permission).

--- a/docs/physics/nuclear-inelastic.md
+++ b/docs/physics/nuclear-inelastic.md
@@ -74,16 +74,19 @@ add ⅔ of the Coulomb barrier). Retained kinetic energy funds E\*; the
 retained nucleon becomes a **particle exciton**. Every collision leaves a
 **hole exciton**; the exciton configuration (p, h) is exported in
 `struct osh_nuclear_fragment` as the input of the pre-equilibrium stage.
-The INCL4.6 paper's own ξ = 18 MeV experiment traded nucleon-spectrum
-fidelity for cluster yield — do not raise ξ to chase excitation energy
-(measured in [#260](https://github.com/openshieldhit/openshieldhit/issues/260)
-/ [#263](https://github.com/openshieldhit/openshieldhit/issues/263)).
+The threshold default (ξ = 15 MeV) was calibrated at transport level in the
+[#225](https://github.com/openshieldhit/openshieldhit/issues/225) study:
+retaining the 10–15 MeV knockouts broadens the prefragment E\* tail and
+hardens the break-up alpha sector into its acceptance windows, at a measured
+cost confined to the already-low sub-20 MeV proton bands (the validated
+20–50 MeV band is untouched) — the quantitative form of INCL4.6's caution
+about their earlier ξ = 18 MeV variant.
 
 | knob (compile-time) | default | meaning |
 |---|---|---|
 | `OSH_ABRASION_SIGMA_PN_MB` | 30.0 | p+nucleon σ for ⟨ν⟩ |
 | `OSH_ABRASION_EXCITATION_PER_HOLE_MEV` | 13.3 | hole excitation (do not retune — #260) |
-| `OSH_ABRASION_RETENTION_THRESHOLD_MEV` | 7.0 | back-to-spectator ξ (0 disables) |
+| `OSH_ABRASION_RETENTION_THRESHOLD_MEV` | 15.0 | back-to-spectator ξ (0 disables); calibrated in #225 (ξ ∈ {7,12,15,18} transport scan) |
 | `OSH_ABRASION_RETENTION_WIDTH_MEV` | 2.0 | smooth turn-on width |
 
 ### Pre-equilibrium — single-component exciton model

--- a/examples/06_nucre_validation/README.md
+++ b/examples/06_nucre_validation/README.md
@@ -11,8 +11,11 @@ for p + (Z, A) at a fixed incident energy, with no transport. It tabulates the
 cannot see directly:
 
 - per-species (n, p, d, t, ³He, α) yields per inelastic event, mean energies,
-  and kinetic-energy histograms (150 log bins, 0.1–300 MeV — the same axis as
-  the NUCRE reference-deck plateau spectra);
+  and kinetic-energy histograms (150 log bins, 0.1–300 MeV — the same
+  *binning and axes* as the NUCRE reference-deck plateau spectra, for
+  convenient shape comparison only: production-at-emission and transported
+  plateau fluence are different observables, and the quantitative SH12A
+  comparison is always deck-vs-deck at transport level);
 - the prefragment excitation-energy distribution *before* de-excitation
   (the E\* supply feeding the break-up stage);
 - leftover unprocessed fragments and their residual excitation after break-up.

--- a/examples/06_nucre_validation/nucre_scan.c
+++ b/examples/06_nucre_validation/nucre_scan.c
@@ -35,6 +35,7 @@
 #include "physics/nuclear/osh_nuclear_abrasion.h"
 #include "physics/nuclear/osh_nuclear_fermi_breakup.h"
 #include "physics/nuclear/osh_nuclear_handler.h"
+#include "physics/nuclear/osh_nuclear_preeq.h"
 #include "physics/nuclear/osh_nuclear_tripathi.h"
 #include "random/osh_rng.h"
 
@@ -146,6 +147,7 @@ static int energy_bin(double e_mev) {
 
 int main(int argc, char **argv) {
     struct osh_nuclear_fermi_breakup fbu;
+    struct osh_nuclear_preeq preeq;
     struct osh_rng rng;
     struct osh_nuclear_event ev;
     static double hist[NUCRE_SCAN_NSPECIES][NUCRE_SCAN_NBINS];
@@ -215,6 +217,10 @@ int main(int argc, char **argv) {
         fprintf(stderr, "nucre_scan: Fermi break-up compile failed\n");
         return 1;
     }
+    if (osh_nuclear_preeq_compile(&preeq) != OSH_OK) {
+        fprintf(stderr, "nucre_scan: pre-equilibrium compile failed\n");
+        return 1;
+    }
     osh_rng_init(&rng, OSH_RNG_TYPE_PCG32, seed, 0u);
 
     memset(hist, 0, sizeof(hist));
@@ -253,6 +259,7 @@ int main(int argc, char **argv) {
             }
             excp_sum += (double) ev.fragments[0].excitons_p;
             exch_sum += (double) ev.fragments[0].excitons_h;
+            osh_nuclear_preeq_step(&preeq, &ev.fragments[0], &rng, &ev);
             osh_nuclear_fermi_breakup_step(&fbu, &ev.fragments[0], &rng, &ev);
         }
 

--- a/examples/06_nucre_validation/nucre_scan.c
+++ b/examples/06_nucre_validation/nucre_scan.c
@@ -311,7 +311,7 @@ int main(int argc, char **argv) {
     estar_std = 0.0;
     if (n_with_fragment > 0UL) {
         estar_mean = estar_sum / (double) n_with_fragment;
-        estar_std = sqrt(fmax(0.0, estar_sq_sum / (double) n_with_fragment - estar_mean * estar_mean));
+        estar_std = sqrt(fmax(0.0, (estar_sq_sum / (double) n_with_fragment) - (estar_mean * estar_mean)));
         excp_sum /= (double) n_with_fragment;
         exch_sum /= (double) n_with_fragment;
     }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
     - mat.dat reference: user/mat.dat.md
     - detect.dat reference: user/detect.dat.md
   - Physics Reference:
+    - Nuclear inelastic reactions: physics/nuclear-inelastic.md
     - Neutron transport: physics/neutron-transport.md
     - Neutron cross sections: physics/neutron-cross-sections.md
   - Developer Guide:

--- a/src/physics/nuclear/CMakeLists.txt
+++ b/src/physics/nuclear/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(osh_nuclear
     osh_nuclear_elastic.c
     osh_nuclear_abrasion.c
     osh_nuclear_fermi_breakup.c
+    osh_nuclear_preeq.c
     osh_nuclear_handler.c
     osh_nuclear_compound.c
 )

--- a/src/physics/nuclear/osh_nuclear_abrasion.c
+++ b/src/physics/nuclear/osh_nuclear_abrasion.c
@@ -99,6 +99,7 @@ void osh_nuclear_abrasion_step(double T_lab_mev,
     int is_neutron;
     int n_knockout_p;
     int n_knockout_n;
+    int cascade_absorbed;
     unsigned int n_excitons_p;
     unsigned int n_excitons_h;
     int nu; /* sampled number of participant nucleons */
@@ -175,6 +176,7 @@ void osh_nuclear_abrasion_step(double T_lab_mev,
     e_star = 0.0;
     n_knockout_p = 0;
     n_knockout_n = 0;
+    cascade_absorbed = 0;
     n_excitons_p = 0u;
     n_excitons_h = 0u;
     w_curr[0] = incident_dir[0];
@@ -291,6 +293,7 @@ void osh_nuclear_abrasion_step(double T_lab_mev,
          * outside, so no hole is associated with it). */
         e_star += T_current;
         ++n_excitons_p;
+        cascade_absorbed = 1;
     }
 
     if (event_out->n_fragments > 0u) {
@@ -307,6 +310,21 @@ void osh_nuclear_abrasion_step(double T_lab_mev,
         } else {
             event_out->fragments[0].z = 0u;
         }
+
+        /* Capture bookkeeping (issue #265): an absorbed cascade proton adds
+         * its mass and charge to the residue, mirroring the neutron path's
+         * (Z, A+1) compound convention — but only while the resulting
+         * nuclide stays inside the shared de-excitation table domain.  Full
+         * capture on a max-domain target (O-16 -> F-17) keeps the old
+         * identity: the energy and momentum are still absorbed, and growing
+         * the tables is not worth this rare corner. */
+        if (cascade_absorbed && event_out->fragments[0].a >= 1u && event_out->fragments[0].z >= 1u
+            && event_out->fragments[0].z + 1u <= (unsigned int) OSH_FERMI_BREAKUP_ZMAX
+            && event_out->fragments[0].a + 1u <= (unsigned int) OSH_FERMI_BREAKUP_AMAX) {
+            event_out->fragments[0].a += 1u;
+            event_out->fragments[0].z += 1u;
+        }
+
         if (event_out->fragments[0].a == 0u || event_out->fragments[0].z == 0u) {
             /* Fully disassembled residual (light targets): any accumulated
              * excitation is dropped with it — rare edge, accepted. */

--- a/src/physics/nuclear/osh_nuclear_abrasion.h
+++ b/src/physics/nuclear/osh_nuclear_abrasion.h
@@ -59,20 +59,30 @@
 #define OSH_ABRASION_EXCITATION_PER_HOLE_MEV 13.3
 #endif
 
-/** Knockout-nucleon retention threshold [MeV] (issue #263): a knocked-out
- *  nucleon with lab kinetic energy in the neighbourhood of this value or
- *  below is re-absorbed into the prefragment instead of escaping — the lean
- *  analog of INCL4.6's "back to spectator" recipe (Boudard et al., PRC 87
- *  (2013) 014606, Sec. II D1: neutrons return to spectator status below the
- *  neutron-emission threshold, xi ~= 7 MeV; protons below their emission
- *  threshold plus ~2/3 of the Coulomb barrier).  The same paper's earlier
- *  xi = 18 MeV variant improved low-energy cluster yields but distorted the
- *  nucleon spectra — do not raise this knob to chase E*.  The retained
- *  kinetic energy is booked into E* and the nucleon becomes a particle
- *  exciton, so the event energy balance stays exact.  Override via
- *  -DOSH_ABRASION_RETENTION_THRESHOLD_MEV=<value>; 0 disables retention. */
+/** Knockout-nucleon retention threshold [MeV] (issues #263 / #225): a
+ *  knocked-out nucleon with lab kinetic energy in the neighbourhood of this
+ *  value or below is re-absorbed into the prefragment instead of escaping —
+ *  the lean analog of INCL4.6's "back to spectator" recipe (Boudard et al.,
+ *  PRC 87 (2013) 014606, Sec. II D1; there xi ~= 7 MeV, protons adding ~2/3
+ *  of the Coulomb barrier).  The retained kinetic energy is booked into E*
+ *  and the nucleon becomes a particle exciton, so the event energy balance
+ *  stays exact.
+ *
+ *  The default 15.0 was calibrated in the #225 study (1M-primary nucre1
+ *  transports vs the SH12A 2.5M fixture, xi in {7, 12, 15, 18}): retaining
+ *  the 10-15 MeV knockouts broadens the prefragment E* tail, which hardens
+ *  the break-up alpha sector into its acceptance windows (Phi_alpha 0.77 ->
+ *  0.92, D_alpha 1.02 -> 1.16 of SH12A) and brings t/He-3 fluences near
+ *  unity.  The measured cost — the analog of INCL4.6's caution about their
+ *  earlier xi = 18 MeV variant — is confined to the already-low sub-20 MeV
+ *  proton bands (-12%/-7% at xi = 15; the validated 20-50 MeV band is
+ *  untouched).  The remaining hard-alpha tail is owned by the quasi-free
+ *  knockout stage of #221, not by this knob: xi = 18 buys the tail criterion
+ *  but doubles the soft-band cost and pushes D_alpha to the window edge.
+ *  Override via -DOSH_ABRASION_RETENTION_THRESHOLD_MEV=<value>; 0 disables
+ *  retention. */
 #ifndef OSH_ABRASION_RETENTION_THRESHOLD_MEV
-#define OSH_ABRASION_RETENTION_THRESHOLD_MEV 7.0
+#define OSH_ABRASION_RETENTION_THRESHOLD_MEV 15.0
 #endif
 
 /** Width [MeV] of the smooth (Fermi-function) turn-on of the retention

--- a/src/physics/nuclear/osh_nuclear_abrasion.h
+++ b/src/physics/nuclear/osh_nuclear_abrasion.h
@@ -113,10 +113,12 @@ struct osh_nuclear_event;
  * (the primary slot is terminated; the cascade proton continues as a secondary).
  *
  * The surviving residual is written to event_out->fragments[0] with its mass
- * and atomic number reduced by the escaped knockouts, the accumulated
- * excitation energy E* (hole charges + retained kinetic energy), the exciton
- * configuration (particles, holes), and a lab momentum from the event
- * momentum balance — input for the pre-equilibrium / Fermi break-up
+ * and atomic number reduced by the escaped knockouts — and increased by a
+ * captured cascade proton (issue #265; skipped when the nuclide would leave
+ * the de-excitation table domain, e.g. full capture on O-16) — the
+ * accumulated excitation energy E* (hole charges + retained kinetic energy),
+ * the exciton configuration (particles, holes), and a lab momentum from the
+ * event momentum balance — input for the pre-equilibrium / Fermi break-up
  * de-excitation stages.  Kinetic energy is conserved exactly:
  * T_in = Σ KE_secondaries + E*.
  *

--- a/src/physics/nuclear/osh_nuclear_handler.c
+++ b/src/physics/nuclear/osh_nuclear_handler.c
@@ -152,6 +152,14 @@ enum osh_status osh_nuclear_handler_compile(struct osh_material_workspace const 
         return rc;
     }
 
+    /* Pre-equilibrium exciton model (issue #225): fast-ejectile emission
+     * between abrasion and the equilibrium break-up. */
+    rc = osh_nuclear_preeq_compile(&out->preeq);
+    if (rc != OSH_OK) {
+        osh_nuclear_handler_free(out);
+        return rc;
+    }
+
     /* Persistent (Z,A) ion species table for recoil / fragment transport and
      * scoring.  Built once here (const during stepping): a heavy recoil or FBU
      * fragment needs a stable species pointer to be injected into the ion pool
@@ -517,13 +525,15 @@ void osh_nuclear_handler_step(struct osh_nuclear_handler const *handler,
             return;
         }
 
-        /* Abrasion (fast stage) followed by Fermi break-up de-excitation of
-         * the surviving prefragment (ablation stage).  The break-up consumes
-         * the fragment slot when it fires and appends its products to the
-         * same event; un-broken residues stay for the fragment pool. */
+        /* Abrasion (fast stage), pre-equilibrium exciton emission of fast
+         * ejectiles (issue #225), then Fermi break-up de-excitation of the
+         * thermalized residue (ablation stage).  The break-up consumes the
+         * fragment slot when it fires and appends its products to the same
+         * event; un-broken residues stay for the fragment pool. */
         osh_nuclear_abrasion_step(
             final_energy_mev, incident_dir, selected_a, selected_z, selected_sigma_inel, rng, event_out);
         if (event_out->n_fragments > 0u) {
+            osh_nuclear_preeq_step(&handler->preeq, &event_out->fragments[0], rng, event_out);
             osh_nuclear_fermi_breakup_step(&handler->fbu, &event_out->fragments[0], rng, event_out);
         }
     }

--- a/src/physics/nuclear/osh_nuclear_handler.h
+++ b/src/physics/nuclear/osh_nuclear_handler.h
@@ -27,6 +27,7 @@
 
 #include "openshieldhit/status.h"
 #include "physics/nuclear/osh_nuclear_fermi_breakup.h"
+#include "physics/nuclear/osh_nuclear_preeq.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -119,6 +120,7 @@ struct osh_nuclear_elem {
  */
 struct osh_nuclear_handler {
     struct osh_nuclear_fermi_breakup fbu; /**< Fermi break-up channel table.            */
+    struct osh_nuclear_preeq preeq;       /**< Pre-equilibrium exciton model (issue #225). */
     struct osh_nuclear_elem *elem_pool;   /**< Flat array: all materials, all elements. */
     size_t *elem_offset;                  /**< elem_offset[i]: start of material i.    */
     size_t *elem_count;                   /**< elem_count[i]:  element count.          */

--- a/src/physics/nuclear/osh_nuclear_preeq.c
+++ b/src/physics/nuclear/osh_nuclear_preeq.c
@@ -441,7 +441,7 @@ void osh_nuclear_preeq_step(struct osh_nuclear_preeq const *model,
         cum = 0.0;
         for (i = 0; i < nbins - 1; ++i) {
             cum += grid[i];
-            if (u <= cum) {
+            if (u < cum) {
                 break;
             }
         }

--- a/src/physics/nuclear/osh_nuclear_preeq.c
+++ b/src/physics/nuclear/osh_nuclear_preeq.c
@@ -211,7 +211,7 @@ static double emission_width(struct osh_nuclear_preeq const *model,
     for (i = 0; i < nbins; ++i) {
         t_mid = ((double) i + 0.5) * dt;
         u_res = t_max - t_mid; /* = E* - B_j - T, residual excitation */
-        ratio = comb * exp((double) n_minus * log(g_level * u_res) - ((double) n_exc - 1.0) * log_ge);
+        ratio = comb * exp(((double) n_minus * log(g_level * u_res)) - (((double) n_exc - 1.0) * log_ge));
         w = prefactor * t_mid * inverse_sigma_fm2(spec, t_mid, (double) a_res, (double) z_res) * gamma_j * r_comp
             * ratio * dt;
         if (w < 0.0) {
@@ -449,7 +449,7 @@ void osh_nuclear_preeq_step(struct osh_nuclear_preeq const *model,
 
         /* Isotropic lab emission (Kalbach systematics: planned refinement). */
         cos_theta = 2.0 * osh_rng_double(rng) - 1.0;
-        sin_theta = sqrt(fmax(0.0, 1.0 - cos_theta * cos_theta));
+        sin_theta = sqrt(fmax(0.0, 1.0 - (cos_theta * cos_theta)));
         osh_kinematics_azimuth(rng, &cos_phi, &sin_phi);
         dir[0] = sin_theta * cos_phi;
         dir[1] = sin_theta * sin_phi;

--- a/src/physics/nuclear/osh_nuclear_preeq.c
+++ b/src/physics/nuclear/osh_nuclear_preeq.c
@@ -357,8 +357,8 @@ void osh_nuclear_preeq_step(struct osh_nuclear_preeq const *model,
     }
 
     for (iter = 0; iter < PREEQ_MAX_ITER; ++iter) {
-        /* Thermalized, empty, or out-of-domain residues are left untouched:
-         * the compound/neutron path and break-up residues carry (0, 0). */
+        /* Residues without particle excitons, without excitation, or out of domain are left untouched.
+         * (p, h) = (0, 0) is the thermalized contract used for compound/neutron paths and break-up residues. */
         if (fragment->excitons_p == 0u || fragment->excitation_energy <= 0.0) {
             return;
         }

--- a/src/physics/nuclear/osh_nuclear_preeq.c
+++ b/src/physics/nuclear/osh_nuclear_preeq.c
@@ -410,7 +410,7 @@ void osh_nuclear_preeq_step(struct osh_nuclear_preeq const *model,
         spec = OSH_PREEQ_NSPECIES - 1;
         for (i = 0; i < OSH_PREEQ_NSPECIES; ++i) {
             cum += width[i];
-            if (u <= cum) {
+            if (u < cum) {
                 spec = i;
                 break;
             }

--- a/src/physics/nuclear/osh_nuclear_preeq.c
+++ b/src/physics/nuclear/osh_nuclear_preeq.c
@@ -1,0 +1,485 @@
+#include "physics/nuclear/osh_nuclear_preeq.h"
+
+#include <math.h> /* sqrt, exp, log, cbrt, lgamma, ceil */
+#include <string.h>
+
+#include "openshieldhit/const.h"
+#include "particle/osh_particle.h"
+#include "particle/osh_particle_const.h"
+#include "particle/osh_particle_pdg.h"
+#include "physics/nuclear/osh_nuclear_handler.h"
+#include "physics/osh_kinematics.h"
+#include "random/osh_rng.h"
+
+/* Ejectile species indices (order matches the species tables below). */
+enum preeq_species {
+    PREEQ_SPECIES_NEUTRON = 0,
+    PREEQ_SPECIES_PROTON,
+    PREEQ_SPECIES_DEUTERON,
+    PREEQ_SPECIES_TRITON,
+    PREEQ_SPECIES_HE3,
+    PREEQ_SPECIES_HE4
+};
+
+static int const s_pdg[OSH_PREEQ_NSPECIES] = {
+    OSH_PART_PDG_NEUTRON,
+    OSH_PART_PDG_PROTON,
+    OSH_PART_PDG_DEUTERON,
+    OSH_PART_PDG_TRITON,
+    OSH_PART_PDG_HE3,
+    OSH_PART_PDG_HE4,
+};
+
+static unsigned int const s_z[OSH_PREEQ_NSPECIES] = {0u, 1u, 1u, 1u, 2u, 2u};
+static unsigned int const s_a[OSH_PREEQ_NSPECIES] = {1u, 1u, 2u, 3u, 3u, 4u};
+
+/* Spin multiplicity 2s+1 of the ejectile ground state. */
+static double const s_spin_mult[OSH_PREEQ_NSPECIES] = {2.0, 2.0, 3.0, 2.0, 2.0, 1.0};
+
+/* Binomial C(a_j, z_j) of the ejectile composition (for the R_j factor). */
+static double const s_comp_binom[OSH_PREEQ_NSPECIES] = {1.0, 1.0, 2.0, 3.0, 3.0, 6.0};
+
+/* Emission energy grid: bins of at most ~1 MeV, capped for stack safety. */
+#define PREEQ_GRID_MAX 512
+
+/* Hard bound on emission + transition steps per fragment; physically the
+ * loop ends at n_eq = sqrt(2 g E*) <~ 25 for any residue this table holds. */
+#define PREEQ_MAX_ITER 128
+
+/* Dense (z, a) index into the mass table. */
+static inline size_t _za_idx(unsigned int z, unsigned int a) {
+    return ((size_t) z * (size_t) (OSH_PREEQ_AMAX + 1)) + (size_t) a;
+}
+
+/* Condensation probability gamma_j for cluster ejectiles (Geant4 closed
+ * forms: 16/A, 243/A^2, 4096/A^3), times the per-species calibration scale;
+ * 1 for nucleons. */
+static double condensation_gamma(int spec, double a_parent) {
+    if (spec == PREEQ_SPECIES_DEUTERON) {
+        return OSH_PREEQ_GAMMA_SCALE_D * 16.0 / a_parent;
+    }
+    if (spec == PREEQ_SPECIES_TRITON) {
+        return OSH_PREEQ_GAMMA_SCALE_T * 243.0 / (a_parent * a_parent);
+    }
+    if (spec == PREEQ_SPECIES_HE3) {
+        return OSH_PREEQ_GAMMA_SCALE_HE3 * 243.0 / (a_parent * a_parent);
+    }
+    if (spec == PREEQ_SPECIES_HE4) {
+        return OSH_PREEQ_GAMMA_SCALE_ALPHA * 4096.0 / (a_parent * a_parent * a_parent);
+    }
+    return 1.0;
+}
+
+/* Inverse cross section [fm^2], Dostrovsky-style geometric estimate.
+ * Neutrons: pi R^2 alpha (1 + beta / T); charged: pi R^2 (1 - V_C / T),
+ * clamped at zero below the barrier. */
+static double inverse_sigma_fm2(int spec, double t_mev, double a_res, double z_res) {
+    double r_fm;
+    double sigma_geom;
+    double alpha;
+    double beta;
+    double v_coul;
+
+    r_fm = OSH_PREEQ_EMISSION_R0_FM * (cbrt(a_res) + cbrt((double) s_a[spec]));
+    sigma_geom = OSH_M_PI * r_fm * r_fm;
+
+    if (spec == PREEQ_SPECIES_NEUTRON) {
+        alpha = 0.76 + 2.2 / cbrt(a_res);
+        beta = (2.12 / (cbrt(a_res) * cbrt(a_res)) - 0.05) / alpha;
+        return sigma_geom * alpha * (1.0 + beta / t_mev);
+    }
+
+    v_coul = OSH_E2_MEV_FM * (double) s_z[spec] * z_res / r_fm;
+    if (t_mev <= v_coul) {
+        return 0.0;
+    }
+    return sigma_geom * (1.0 - v_coul / t_mev);
+}
+
+/*
+ * Emission width of species spec from configuration (p, h, E*) of the parent
+ * (z, a), integrated over the ejectile energy grid [Betak-Dobes detailed
+ * balance with Williams state densities; see the header].  Returns the total
+ * width [1/fm].  When grid_out is non-NULL it receives the per-bin
+ * contributions (nbins_out entries of width dt_out), for CDF sampling.
+ */
+static double emission_width(struct osh_nuclear_preeq const *model,
+                             int spec,
+                             unsigned int z,
+                             unsigned int a,
+                             double e_star,
+                             unsigned int exc_p,
+                             unsigned int exc_h,
+                             double *grid_out,
+                             int *nbins_out,
+                             double *dt_out,
+                             double *b_sep_out) {
+    double m_parent;
+    double m_res;
+    double m_ej;
+    double b_sep;
+    double t_max;
+    double g_level;
+    double mu_red;
+    double prefactor;
+    double gamma_j;
+    double r_comp;
+    double comb;
+    double log_ge;
+    double f_p;
+    double f_n;
+    double total;
+    double t_mid;
+    double u_res;
+    double ratio;
+    double w;
+    double dt;
+    unsigned int z_res;
+    unsigned int a_res;
+    unsigned int n_exc;
+    int nbins;
+    int i;
+    int n_minus;
+
+    if (grid_out != NULL) {
+        *nbins_out = 0;
+        *dt_out = 0.0;
+    }
+    if (b_sep_out != NULL) {
+        *b_sep_out = 0.0;
+    }
+
+    /* Channel-closure guards: enough particle excitons of any kind, a real
+     * residual nucleus left behind (A_res >= 2, so no bare-nucleon residues
+     * enter the fragment pool), and both nuclides in the mass table. */
+    n_exc = exc_p + exc_h;
+    if (exc_p < s_a[spec] || n_exc < s_a[spec] + 1u) {
+        return 0.0;
+    }
+    if (a < s_a[spec] + 2u || z < s_z[spec] || (a - s_a[spec]) < (z - s_z[spec])) {
+        return 0.0;
+    }
+    z_res = z - s_z[spec];
+    a_res = a - s_a[spec];
+    if (z > OSH_PREEQ_ZMAX || a > OSH_PREEQ_AMAX) {
+        return 0.0;
+    }
+    m_parent = model->mass_mev[_za_idx(z, a)];
+    m_res = model->mass_mev[_za_idx(z_res, a_res)];
+    m_ej = model->species[spec].mass;
+    if (m_parent <= 0.0 || m_res <= 0.0) {
+        return 0.0;
+    }
+
+    b_sep = m_res + m_ej - m_parent;
+    if (b_sep_out != NULL) {
+        *b_sep_out = b_sep;
+    }
+    t_max = e_star - b_sep;
+    if (t_max <= 0.0) {
+        return 0.0;
+    }
+
+    /* Williams-ratio combinatorics (independent of T):
+     *   omega(p - a_j, h, U) / omega(p, h, E) =
+     *     p!/(p-a_j)! * (n-1)!/(n-a_j-1)! * (gU)^(n-a_j-1) / (gE)^(n-1) */
+    comb = exp(lgamma((double) exc_p + 1.0) - lgamma((double) (exc_p - s_a[spec]) + 1.0) + lgamma((double) n_exc)
+               - lgamma((double) (n_exc - s_a[spec])));
+
+    g_level = OSH_PREEQ_LEVEL_DENSITY_PER_A * (double) a;
+    log_ge = log(g_level * e_star);
+    n_minus = (int) n_exc - (int) s_a[spec] - 1;
+
+    mu_red = m_ej * m_res / (m_ej + m_res);
+    prefactor = s_spin_mult[spec] * mu_red / (OSH_M_PI * OSH_M_PI * OSH_HBARC * OSH_HBARC * OSH_HBARC);
+    gamma_j = condensation_gamma(spec, (double) a);
+
+    f_p = (double) z / (double) a;
+    f_n = ((double) a - (double) z) / (double) a;
+    r_comp = s_comp_binom[spec] * pow(f_p, (double) s_z[spec]) * pow(f_n, (double) (s_a[spec] - s_z[spec]));
+
+    nbins = (int) ceil(t_max);
+    if (nbins < 1) {
+        nbins = 1;
+    }
+    if (nbins > PREEQ_GRID_MAX) {
+        nbins = PREEQ_GRID_MAX;
+    }
+    dt = t_max / (double) nbins;
+
+    total = 0.0;
+    for (i = 0; i < nbins; ++i) {
+        t_mid = ((double) i + 0.5) * dt;
+        u_res = t_max - t_mid; /* = E* - B_j - T, residual excitation */
+        ratio = comb * exp((double) n_minus * log(g_level * u_res) - ((double) n_exc - 1.0) * log_ge);
+        w = prefactor * t_mid * inverse_sigma_fm2(spec, t_mid, (double) a_res, (double) z_res) * gamma_j * r_comp
+            * ratio * dt;
+        if (w < 0.0) {
+            w = 0.0;
+        }
+        if (grid_out != NULL) {
+            grid_out[i] = w;
+        }
+        total += w;
+    }
+    if (grid_out != NULL) {
+        *nbins_out = nbins;
+        *dt_out = dt;
+    }
+    return total;
+}
+
+/*
+ * Intranuclear transition rate lambda_plus (Delta-n = +2) [1/fm], CEM form
+ * (Gudima-Mashnik-Toneev; same expressions as the Geant4
+ * G4PreCompoundTransitions CEM branch): averaged in-medium NN cross section
+ * at the mean exciton relative energy, Pauli-blocking factor, interaction
+ * volume from the transitions radius.
+ */
+static double lambda_plus(unsigned int z, unsigned int a, double e_star, unsigned int n_exc) {
+    double e_rel;
+    double v_rel;
+    double v_sq;
+    double sigma_pp;
+    double sigma_np;
+    double sigma_avg;
+    double f_p;
+    double f_n;
+    double pauli;
+    double pauli_x;
+    double ratio;
+    double xx;
+    double v_int;
+    double za;
+    double na;
+
+    if (n_exc == 0u || a < 2u) {
+        return 0.0;
+    }
+
+    e_rel = 1.6 * OSH_PREEQ_FERMI_ENERGY_MEV + e_star / (double) n_exc;
+    v_sq = 2.0 * e_rel / OSH_PART_MASS_PROTON;
+    v_rel = sqrt(v_sq);
+
+    /* In-medium NN cross sections [fm^2]; parametrisation in beta = v/c
+     * (1 mb = 0.1 fm^2). */
+    sigma_pp = (10.63 / v_sq - 29.92 / v_rel + 42.9) * 0.1;
+    sigma_np = (34.10 / v_sq - 82.20 / v_rel + 82.2) * 0.1;
+
+    /* Average over the (untracked) charge of the fast exciton with the
+     * residue proton/neutron fractions as weights. */
+    za = (double) z;
+    na = (double) (a - z);
+    f_p = za / (double) a;
+    f_n = na / (double) a;
+    sigma_avg = f_p * ((za - 1.0) * sigma_pp + na * sigma_np) / ((double) a - 1.0)
+                + f_n * ((na - 1.0) * sigma_pp + za * sigma_np) / ((double) a - 1.0);
+
+    ratio = OSH_PREEQ_FERMI_ENERGY_MEV / e_rel;
+    pauli = 1.0 - 1.4 * ratio;
+    if (ratio > 0.5) {
+        pauli_x = 2.0 - 1.0 / ratio;
+        pauli += 0.4 * ratio * pauli_x * pauli_x * sqrt(pauli_x);
+    }
+
+    xx = 2.0 * OSH_PREEQ_TRANSITIONS_R0_FM + OSH_HBARC / (OSH_PART_MASS_PROTON * v_rel);
+    v_int = (4.0 / 3.0) * OSH_M_PI * xx * xx * xx;
+
+    if (sigma_avg < 0.0) {
+        return 0.0;
+    }
+    if (pauli < 0.0) {
+        return 0.0;
+    }
+    return sigma_avg * pauli * v_rel / v_int;
+}
+
+enum osh_status osh_nuclear_preeq_compile(struct osh_nuclear_preeq *model) {
+    unsigned int z;
+    unsigned int a;
+    double m;
+    int i;
+
+    if (model == NULL) {
+        return OSH_EINVAL;
+    }
+    memset(model, 0, sizeof(*model));
+
+    model->mass_mev[_za_idx(0u, 1u)] = OSH_PART_MASS_NEUTRON;
+    for (z = 1u; z <= OSH_PREEQ_ZMAX; ++z) {
+        for (a = z; a <= OSH_PREEQ_AMAX; ++a) {
+            if (osh_particle_nuclear_mass_mev_from_za(z, a, &m)) {
+                model->mass_mev[_za_idx(z, a)] = m;
+            }
+        }
+    }
+
+    for (i = 0; i < OSH_PREEQ_NSPECIES; ++i) {
+        if (!osh_particle_from_pdg(&model->species[i], s_pdg[i])) {
+            return OSH_ESTATE;
+        }
+    }
+
+    model->compiled = 1;
+    return OSH_OK;
+}
+
+void osh_nuclear_preeq_step(struct osh_nuclear_preeq const *model,
+                            struct osh_nuclear_fragment *fragment,
+                            struct osh_rng *rng,
+                            struct osh_nuclear_event *event_out) {
+    double grid[PREEQ_GRID_MAX];
+    double width[OSH_PREEQ_NSPECIES];
+    double b_sep[OSH_PREEQ_NSPECIES];
+    double width_total;
+    double lp;
+    double g_level;
+    double n_eq;
+    double u;
+    double cum;
+    double t_emit;
+    double dt;
+    double p_ej;
+    double cos_theta;
+    double sin_theta;
+    double cos_phi;
+    double sin_phi;
+    double dir[3];
+    unsigned int n_exc;
+    int nbins;
+    int iter;
+    int spec;
+    int i;
+    size_t slot;
+
+    if (model == NULL || !model->compiled || fragment == NULL || rng == NULL || event_out == NULL) {
+        return;
+    }
+
+    for (iter = 0; iter < PREEQ_MAX_ITER; ++iter) {
+        /* Thermalized, empty, or out-of-domain residues are left untouched:
+         * the compound/neutron path and break-up residues carry (0, 0). */
+        if (fragment->excitons_p == 0u || fragment->excitation_energy <= 0.0) {
+            return;
+        }
+        if (fragment->z > OSH_PREEQ_ZMAX || fragment->a > OSH_PREEQ_AMAX || fragment->a < 2u) {
+            return;
+        }
+
+        /* Equilibrium exit: n_eq = sqrt(2 g E*) (CEM03.03 Eq. 34). */
+        n_exc = fragment->excitons_p + fragment->excitons_h;
+        g_level = OSH_PREEQ_LEVEL_DENSITY_PER_A * (double) fragment->a;
+        n_eq = sqrt(2.0 * g_level * fragment->excitation_energy);
+        if ((double) n_exc >= n_eq) {
+            return;
+        }
+
+        width_total = 0.0;
+        for (spec = 0; spec < OSH_PREEQ_NSPECIES; ++spec) {
+            width[spec] = emission_width(model,
+                                         spec,
+                                         fragment->z,
+                                         fragment->a,
+                                         fragment->excitation_energy,
+                                         fragment->excitons_p,
+                                         fragment->excitons_h,
+                                         NULL,
+                                         NULL,
+                                         NULL,
+                                         &b_sep[spec]);
+            width_total += width[spec];
+        }
+        lp = lambda_plus(fragment->z, fragment->a, fragment->excitation_energy, n_exc);
+
+        if (width_total + lp <= 0.0) {
+            return;
+        }
+
+        u = osh_rng_double(rng) * (width_total + lp);
+        if (u < lp) {
+            /* Intranuclear collision: one more particle-hole pair; the
+             * configuration random-walks toward equilibrium. */
+            fragment->excitons_p += 1u;
+            fragment->excitons_h += 1u;
+            continue;
+        }
+
+        /* Emission: pick the species proportional to its width. */
+        u -= lp;
+        cum = 0.0;
+        spec = OSH_PREEQ_NSPECIES - 1;
+        for (i = 0; i < OSH_PREEQ_NSPECIES; ++i) {
+            cum += width[i];
+            if (u <= cum) {
+                spec = i;
+                break;
+            }
+        }
+
+        if (event_out->n_secondaries >= OSH_NUCLEAR_MAX_SECONDARIES) {
+            return; /* out of slots: leave the rest to equilibrium break-up */
+        }
+
+        /* Sample the ejectile energy from the per-bin width grid. */
+        emission_width(model,
+                       spec,
+                       fragment->z,
+                       fragment->a,
+                       fragment->excitation_energy,
+                       fragment->excitons_p,
+                       fragment->excitons_h,
+                       grid,
+                       &nbins,
+                       &dt,
+                       &b_sep[spec]);
+        if (nbins < 1) {
+            return;
+        }
+        /* CDF walk over the bins; falls through to the last bin on float
+         * round-off. */
+        u = osh_rng_double(rng) * width[spec];
+        cum = 0.0;
+        for (i = 0; i < nbins - 1; ++i) {
+            cum += grid[i];
+            if (u <= cum) {
+                break;
+            }
+        }
+        t_emit = ((double) i + osh_rng_double(rng)) * dt;
+
+        /* Isotropic lab emission (Kalbach systematics: planned refinement). */
+        cos_theta = 2.0 * osh_rng_double(rng) - 1.0;
+        sin_theta = sqrt(fmax(0.0, 1.0 - cos_theta * cos_theta));
+        osh_kinematics_azimuth(rng, &cos_phi, &sin_phi);
+        dir[0] = sin_theta * cos_phi;
+        dir[1] = sin_theta * sin_phi;
+        dir[2] = cos_theta;
+
+        slot = event_out->n_secondaries;
+        event_out->secondaries[slot].dir[0] = dir[0];
+        event_out->secondaries[slot].dir[1] = dir[1];
+        event_out->secondaries[slot].dir[2] = dir[2];
+        event_out->secondaries[slot].energy = t_emit;
+        event_out->secondaries[slot].species = &model->species[spec];
+        event_out->n_secondaries = slot + 1u;
+
+        /* Momentum balance: the ejectile momentum leaves the residue. */
+        p_ej = sqrt(t_emit * (t_emit + 2.0 * model->species[spec].mass));
+        fragment->p[0] -= p_ej * dir[0];
+        fragment->p[1] -= p_ej * dir[1];
+        fragment->p[2] -= p_ej * dir[2];
+
+        /* Exact bookkeeping: E* loses the separation energy and the
+         * ejectile kinetic energy; the residue drops a_j particle excitons
+         * and (z_j, a_j) nucleons. */
+        fragment->excitation_energy -= b_sep[spec] + t_emit;
+        if (fragment->excitation_energy < 0.0) {
+            fragment->excitation_energy = 0.0;
+        }
+        fragment->a -= s_a[spec];
+        fragment->z -= s_z[spec];
+        fragment->excitons_p -= s_a[spec];
+
+        event_out->kind = OSH_NUCLEAR_EVENT_FRAGMENTATION;
+    }
+}

--- a/src/physics/nuclear/osh_nuclear_preeq.h
+++ b/src/physics/nuclear/osh_nuclear_preeq.h
@@ -1,0 +1,165 @@
+#ifndef OSH_NUCLEAR_PREEQ_H
+#define OSH_NUCLEAR_PREEQ_H
+
+/**
+ * @file osh_nuclear_preeq.h
+ * @brief Pre-equilibrium emission — single-component exciton model (issue #225).
+ *
+ * @details
+ * De-excites the abrasion prefragment BEFORE the equilibrium Fermi break-up
+ * stage: starting from the exciton configuration (particles p, holes h) and
+ * excitation energy E* exported by the fast stage, the residue either emits a
+ * fast ejectile {n, p, d, t, He-3, He-4} or thermalizes one step (a Delta-n
+ * = +2 intranuclear collision), until it reaches the equilibrium exciton
+ * number n_eq = sqrt(2 g E*), runs out of excitation, or exhausts its
+ * particle excitons.  This is the mechanism that produces the fast light
+ * clusters (in particular the hard alpha/deuteron components) that pure
+ * statistical break-up cannot generate — see the #260 measurement and the
+ * roadmap on #221.
+ *
+ * Model (approximate by design; the #221 tolerance note applies):
+ *  - Exciton state density: Williams,
+ *      omega(p, h, E) = g (gE)^(p+h-1) / (p! h! (p+h-1)!),
+ *    with a single-particle level density g = OSH_PREEQ_LEVEL_DENSITY_PER_A
+ *    * A (equidistant model; no pairing or finite-well corrections).
+ *  - Emission width, detailed balance (Betak-Dobes form; equals the
+ *    Geant4/CEM closed forms for nucleons when the same g is used):
+ *      lambda_j(T) dT = (2 s_j + 1) mu_j T sigma_inv(T) / (pi^2 (hbar c)^3)
+ *                       * gamma_j R_j [omega(p - a_j, h, U) / omega(p, h, E)] dT,
+ *    U = E* - B_j - T, with B_j the exact separation energy from the isotope
+ *    mass table.  R_j is a composition factor C(a_j, z_j) f_p^z_j f_n^(a_j-z_j)
+ *    built from the residue proton/neutron fractions (single-component model;
+ *    the exciton charge split is not tracked).
+ *  - Cluster condensation probability gamma_j (Geant4 closed forms):
+ *      gamma_d = 16/A, gamma_t = gamma_He3 = 243/A^2, gamma_alpha = 4096/A^3,
+ *    each multiplied by one calibration scale knob (CEM fits the equivalent
+ *    factor against data — expect to tune, see OSH_PREEQ_GAMMA_SCALE_*).
+ *  - Inverse cross sections: Dostrovsky-style geometric form,
+ *    sigma = pi R^2 alpha_n (1 + beta_n / T) for neutrons and
+ *    sigma = pi R^2 (1 - V_C / T) (clamped at 0) for charged ejectiles,
+ *    R = OSH_PREEQ_EMISSION_R0_FM (A_res^(1/3) + a_j^(1/3)).
+ *  - Transition rate lambda_plus (Delta-n = +2 only, "never go back"):
+ *    CEM form — averaged in-medium NN cross section at the mean exciton
+ *    relative energy 1.6 E_F + E_star_per_exciton, Pauli-blocking factor,
+ *    interaction volume from OSH_PREEQ_TRANSITIONS_R0_FM
+ *    (Gudima-Mashnik-Toneev; the Geant4 G4PreCompoundTransitions CEM branch
+ *    implements the same expressions).
+ *  - Emission angles: isotropic (lab).  Kalbach continuum systematics are a
+ *    planned refinement within #225 calibration.
+ *
+ * Contracts:
+ *  - A fragment with (p, h) = (0, 0) is thermalized: the step is a no-op
+ *    (this preserves the neutron-capture compound path and all break-up
+ *    residues untouched).
+ *  - Emission bookkeeping is exact: E* before equals E* after plus B_j
+ *    plus T for every emission (mass-table B_j); fragment momentum is
+ *    reduced by every emitted ejectile; A, Z and exciton counts are updated
+ *    in place.
+ *  - Only whitelist species {n, p, d, t, He-3, He-4} are emitted, appended
+ *    to the caller-owned event; the step performs no allocation.
+ */
+
+#include <stddef.h>
+
+#include "openshieldhit/status.h"
+#include "particle/osh_particle.h"
+
+/** Single-particle level density per nucleon [1/MeV]: g = value * A.
+ *  Geant4 de-excitation default (G4DeexPrecoParameters). */
+#ifndef OSH_PREEQ_LEVEL_DENSITY_PER_A
+#define OSH_PREEQ_LEVEL_DENSITY_PER_A 0.075
+#endif
+
+/** Fermi energy [MeV] entering the CEM transition rate. */
+#ifndef OSH_PREEQ_FERMI_ENERGY_MEV
+#define OSH_PREEQ_FERMI_ENERGY_MEV 35.0
+#endif
+
+/** Radius parameter [fm] of the intranuclear interaction volume in the CEM
+ *  transition rate (Geant4 default 0.6 fm). */
+#ifndef OSH_PREEQ_TRANSITIONS_R0_FM
+#define OSH_PREEQ_TRANSITIONS_R0_FM 0.6
+#endif
+
+/** Radius parameter [fm] of the emission inverse-cross-section estimate. */
+#ifndef OSH_PREEQ_EMISSION_R0_FM
+#define OSH_PREEQ_EMISSION_R0_FM 1.25
+#endif
+
+/** Per-species calibration scales on the cluster condensation probability
+ *  gamma_j.  CEM03.03 multiplies its own gamma_j ("a rather crude estimate")
+ *  by empirically fitted factors; these knobs are that fit surface.  1.0 =
+ *  bare Geant4 closed forms. */
+#ifndef OSH_PREEQ_GAMMA_SCALE_D
+#define OSH_PREEQ_GAMMA_SCALE_D 1.0
+#endif
+#ifndef OSH_PREEQ_GAMMA_SCALE_T
+#define OSH_PREEQ_GAMMA_SCALE_T 1.0
+#endif
+#ifndef OSH_PREEQ_GAMMA_SCALE_HE3
+#define OSH_PREEQ_GAMMA_SCALE_HE3 1.0
+#endif
+#ifndef OSH_PREEQ_GAMMA_SCALE_ALPHA
+#define OSH_PREEQ_GAMMA_SCALE_ALPHA 1.0
+#endif
+
+/** Dense mass-table domain (shared with the Fermi break-up stage). */
+#define OSH_PREEQ_ZMAX 8
+#define OSH_PREEQ_AMAX 16
+
+/** Number of emittable ejectile species: n, p, d, t, He-3, He-4. */
+#define OSH_PREEQ_NSPECIES 6
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct osh_rng;
+struct osh_nuclear_event;
+struct osh_nuclear_fragment;
+
+/** Compiled pre-equilibrium model: dense ground-state nuclear mass table
+ *  [MeV/c^2] over z in [0, OSH_PREEQ_ZMAX], a in [0, OSH_PREEQ_AMAX], plus
+ *  the emitted-species descriptors.  No heap allocation; compile fills the
+ *  tables from the isotope database. */
+struct osh_nuclear_preeq {
+    double mass_mev[(OSH_PREEQ_ZMAX + 1) * (OSH_PREEQ_AMAX + 1)];
+    struct particle species[OSH_PREEQ_NSPECIES];
+    int compiled;
+};
+
+/**
+ * @brief Build the mass tables from the isotope database.
+ *
+ * @param model  Model storage (caller-owned).
+ * @returns OSH_OK on success.
+ */
+enum osh_status osh_nuclear_preeq_compile(struct osh_nuclear_preeq *model);
+
+/**
+ * @brief Run pre-equilibrium emission on one excited fragment, in place.
+ *
+ * @details
+ * Emits fast ejectiles into event_out->secondaries and cools the fragment
+ * (E*, A, Z, momentum, exciton counts updated) until equilibrium.  A
+ * fragment outside the mass-table domain, without particle excitons, or
+ * below every emission threshold is left untouched.  Sets
+ * event_out->kind = OSH_NUCLEAR_EVENT_FRAGMENTATION when at least one
+ * ejectile was emitted.  No allocation; only the RNG state and the given
+ * structs are mutated.
+ *
+ * @param model     Compiled model.
+ * @param fragment  Excited fragment (mutated in place).
+ * @param rng       RNG state (mutated).
+ * @param event_out Event to append emitted secondaries to.
+ */
+void osh_nuclear_preeq_step(struct osh_nuclear_preeq const *model,
+                            struct osh_nuclear_fragment *fragment,
+                            struct osh_rng *rng,
+                            struct osh_nuclear_event *event_out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OSH_NUCLEAR_PREEQ_H */

--- a/src/scoring/runtime/osh_scoring_estimator_common.c
+++ b/src/scoring/runtime/osh_scoring_estimator_common.c
@@ -150,24 +150,21 @@ static double compute_step_let_with_override(struct osh_scoring_runtime const *r
 }
 
 /* Compute (z_eff/beta)^2 at step midpoint.
- * Returns 0 for neutrals or when tables are unavailable. */
+ * Returns 0 for neutrals or species without a valid rest mass. */
 static double
 compute_step_qeff(struct osh_scoring_runtime const *rt, struct particle const *part, struct step const *st) {
     double mean_energy; /* kinetic energy at step midpoint [MeV] */
     double beta;        /* particle velocity / c */
-    size_t proj_idx;    /* projectile row in table (provides rest mass) */
 
+    (void) rt;
     if (part->z == 0) {
         return 0.0;
     }
-    if (!rt->mat_tables) {
-        return 0.0;
-    }
-    if (!osh_scoring_estimator_find_proj_idx(rt->mat_tables, (unsigned int) part->z, &proj_idx)) {
+    if (!(part->mass > 0.0)) {
         return 0.0;
     }
     mean_energy = 0.5 * (st->p[3] + st->q[3]);
-    beta = osh_scoring_estimator_particle_beta(mean_energy, rt->mat_tables->projectile_mass_mev[proj_idx]);
+    beta = osh_scoring_estimator_particle_beta(mean_energy, part->mass);
     if (!(beta > 0.0)) {
         return 0.0;
     }

--- a/src/scoring/runtime/osh_scoring_estimator_step.c
+++ b/src/scoring/runtime/osh_scoring_estimator_step.c
@@ -340,26 +340,20 @@ enum osh_status osh_scoring_estimator_step_dqeff(struct osh_scoring_runtime cons
     double dose_weight;
     double dqeff_numerator;
     double dqeff_denominator;
-    size_t proj_idx;
     struct osh_scoring_page_runtime const *page;
     struct osh_scoring_accumulator *acc;
-    struct osh_material_runtime const *mat_tables;
 
-    mat_tables = rt->mat_tables;
     if (part->z == 0) {
         return OSH_OK;
     }
-    if (!mat_tables) {
-        return OSH_OK;
-    }
-    if (!osh_scoring_estimator_find_proj_idx(mat_tables, (unsigned int) part->z, &proj_idx)) {
+    if (!(part->mass > 0.0)) {
         return OSH_OK;
     }
 
     /* Qeff depends on projectile charge and beta at the step midpoint.  It is a
      * single scalar for this step; only the averaging weight varies per crossing. */
     mean_energy = 0.5 * (st->p[3] + st->q[3]);
-    beta = osh_scoring_estimator_particle_beta(mean_energy, mat_tables->projectile_mass_mev[proj_idx]);
+    beta = osh_scoring_estimator_particle_beta(mean_energy, part->mass);
     if (!(beta > 0.0)) {
         return OSH_OK;
     }
@@ -429,25 +423,20 @@ enum osh_status osh_scoring_estimator_step_tqeff(struct osh_scoring_runtime cons
     double track_weight;      /* Track-length weight for the current spatial bin */
     double tqeff_numerator;   /* Scoring numerator for the TQEFF calculation */
     double tqeff_denominator; /* Scoring denominator for the TQEFF calculation */
-    size_t proj_idx;          /* Column index for given projectile in the stopping-power table */
     struct osh_scoring_page_runtime const *page;
     struct osh_scoring_accumulator *acc;
-    struct osh_material_runtime const *mat_tables;
-    mat_tables = rt->mat_tables;
+
     if (part->z == 0) {
         return OSH_OK;
     }
-    if (!mat_tables) {
-        return OSH_OK;
-    }
-    if (!osh_scoring_estimator_find_proj_idx(mat_tables, (unsigned int) part->z, &proj_idx)) {
+    if (!(part->mass > 0.0)) {
         return OSH_OK;
     }
 
     /* Qeff is computed once for the step midpoint.  TQEFF then averages that
      * value with geometric track-length weights in each crossed bin. */
     mean_energy = 0.5 * (st->p[3] + st->q[3]);
-    beta = osh_scoring_estimator_particle_beta(mean_energy, mat_tables->projectile_mass_mev[proj_idx]);
+    beta = osh_scoring_estimator_particle_beta(mean_energy, part->mass);
     if (!(beta > 0.0)) {
         return OSH_OK;
     }

--- a/src/transport/osh_transport_ion_step.c
+++ b/src/transport/osh_transport_ion_step.c
@@ -84,6 +84,7 @@ struct ion_step_ctx {
     char has_voxel;              /* non-zero when voxel_idx is valid     */
     double e0;                   /* entry total kinetic energy [MeV]     */
     double a_proj;               /* mass number (float cast, ≥ 1)        */
+    double range_scale;          /* actual-A / table-A scale for CSDA range */
     double cutoff;               /* energy cutoff for this particle [MeV]*/
     double demin_total;          /* minimum energy loss per step [MeV]   */
     double boundary_ds;          /* distance to zone boundary [cm]       */
@@ -177,6 +178,12 @@ static enum osh_status ion_step_commit(struct ion_step_ctx const *ctx,
 static double cutoff_total_energy(struct osh_transport_params const *params,
                                   struct osh_material_runtime const *material_rt,
                                   struct particle const *part);
+static double isotope_range_scale(struct osh_material_runtime const *material_rt, size_t projectile_idx, double a_proj);
+static double isotope_range_lookup(struct osh_material_runtime const *material_rt,
+                                   size_t material_idx,
+                                   size_t projectile_idx,
+                                   double e_per_nuc,
+                                   double range_scale);
 static double energy_from_residual_range(struct osh_material_runtime const *material_rt,
                                          size_t material_idx,
                                          size_t projectile_idx,
@@ -588,7 +595,11 @@ static void ion_step_setup(struct ion_step_ctx *ctx,
     ctx->mat_x0_gcm2 = (double) material_rt->rad_length[zone_ref->material_idx];
     ctx->mat_moliere_chic2 = (double) material_rt->moliere_chic2[zone_ref->material_idx];
     ctx->mat_moliere_screen_z = (double) material_rt->moliere_screen_z[zone_ref->material_idx];
-    ctx->proj_mass_mev = material_rt->projectile_mass_mev[ctx->projectile_idx];
+    ctx->range_scale = isotope_range_scale(material_rt, ctx->projectile_idx, ctx->a_proj);
+    ctx->proj_mass_mev = ctx->part->mass;
+    if (!(ctx->proj_mass_mev > 0.0)) {
+        ctx->proj_mass_mev = material_rt->projectile_mass_mev[ctx->projectile_idx];
+    }
     ctx->enable_mcs = (params && params->mcs_mode != OSH_TRANSPORT_MCS_OFF);
     ctx->mcs_model = params ? (char) params->mcs_mode : (char) OSH_MCS_OFF;
     ctx->enable_straggling = (params && params->straggling_mode != OSH_TRANSPORT_STRAGGLING_OFF);
@@ -680,10 +691,10 @@ static void ion_step_length(struct ion_step_ctx *ctx,
         return;
     }
 
-    ctx->r0 = osh_material_runtime_range_lookup(
-        material_rt, ctx->zone_material_idx, ctx->projectile_idx, ctx->e0 / ctx->a_proj);
-    r1_csda = osh_material_runtime_range_lookup(
-        material_rt, ctx->zone_material_idx, ctx->projectile_idx, ctx->e1_target / ctx->a_proj);
+    ctx->r0 = isotope_range_lookup(
+        material_rt, ctx->zone_material_idx, ctx->projectile_idx, ctx->e0 / ctx->a_proj, ctx->range_scale);
+    r1_csda = isotope_range_lookup(
+        material_rt, ctx->zone_material_idx, ctx->projectile_idx, ctx->e1_target / ctx->a_proj, ctx->range_scale);
 
     ds_csda = (ctx->r0 - r1_csda) / ctx->rho;
     if (ds_csda <= 0.0) {
@@ -785,7 +796,8 @@ static enum osh_status ion_step_hinge_and_scatter(struct ion_step_ctx *ctx,
         proposed_exit_energy = ctx->e1_target;
     } else {
         proposed_exit_energy =
-            energy_from_residual_range(material_rt, ctx->zone_material_idx, ctx->projectile_idx, residual_range)
+            energy_from_residual_range(
+                material_rt, ctx->zone_material_idx, ctx->projectile_idx, residual_range / ctx->range_scale)
             * ctx->a_proj;
         if (proposed_exit_energy > ctx->e0)
             proposed_exit_energy = ctx->e0;
@@ -895,7 +907,8 @@ static void ion_step_energy_and_straggling(struct ion_step_ctx *ctx,
         ctx->exit_energy = ctx->e1_target;
     } else {
         ctx->exit_energy =
-            energy_from_residual_range(material_rt, ctx->zone_material_idx, ctx->projectile_idx, residual_range)
+            energy_from_residual_range(
+                material_rt, ctx->zone_material_idx, ctx->projectile_idx, residual_range / ctx->range_scale)
             * ctx->a_proj;
         if (ctx->exit_energy > ctx->e0)
             ctx->exit_energy = ctx->e0;
@@ -1182,6 +1195,28 @@ static double cutoff_total_energy(struct osh_transport_params const *params,
     return cutoff_total;
 }
 
+static double
+isotope_range_scale(struct osh_material_runtime const *material_rt, size_t projectile_idx, double a_proj) {
+    double table_a; /* representative isotope A used to integrate this Z column */
+
+    table_a = (double) material_rt->projectile_a[projectile_idx];
+    if (!(table_a > 0.0)) {
+        return 1.0;
+    }
+    return a_proj / table_a;
+}
+
+static double isotope_range_lookup(struct osh_material_runtime const *material_rt,
+                                   size_t material_idx,
+                                   size_t projectile_idx,
+                                   double e_per_nuc,
+                                   double range_scale) {
+    double table_range; /* representative-isotope CSDA range [g/cm2] */
+
+    table_range = osh_material_runtime_range_lookup(material_rt, material_idx, projectile_idx, e_per_nuc);
+    return table_range * range_scale;
+}
+
 static double energy_from_residual_range(struct osh_material_runtime const *material_rt,
                                          size_t material_idx,
                                          size_t projectile_idx,
@@ -1262,8 +1297,9 @@ static enum osh_status find_projectile_index(struct osh_material_runtime const *
         return OSH_ESTATE;
     }
     if (a_match != 0u && material_rt->projectile_a[projectile_idx] != a_match) {
-        /* Runtime columns are keyed primarily by Z; differing isotopes share the
-         * representative projectile for that Z for now. */
+        /* Runtime SP columns are keyed by Z.  Later phases rescale the stored
+         * representative-isotope range by A_actual/A_table and use part->mass
+         * for isotope-specific transport kinematics. */
     }
     *projectile_idx_out = projectile_idx;
     return OSH_OK;

--- a/tests/unit/test_osh_nuclear_abrasion.c
+++ b/tests/unit/test_osh_nuclear_abrasion.c
@@ -326,6 +326,43 @@ static void test_retention_low_energy(void) {
     ASSERT_TRUE(mean_p <= 2.0);
 }
 
+static void test_capture_bookkeeping(void) {
+    /* Issue #265: an absorbed cascade proton adds (Z+1, A+1) to the residue
+     * when the resulting nuclide stays inside the de-excitation domain.  At
+     * T = 3 MeV on C-12 the cascade proton is always absorbed; when the
+     * knock-out is also retained (no secondaries) the residue must be N-13
+     * with the full budget in E*.  On O-16 (max-domain target) the identity
+     * is capped instead — covered by test_retention_low_energy. */
+    struct osh_rng rng;
+    struct osh_nuclear_event ev;
+    double dir[3];
+    double t_in;
+    int n_captured;
+    int i;
+
+    dir[0] = 0.0;
+    dir[1] = 0.0;
+    dir[2] = 1.0;
+    t_in = 3.0;
+    n_captured = 0;
+
+    osh_rng_init(&rng, OSH_RNG_TYPE_PCG32, 83u, 0u);
+    for (i = 0; i < 2000; ++i) {
+        osh_nuclear_abrasion_step(t_in, dir, 12.0, 6.0, SIGMA_PA_CM2, &rng, &ev);
+        ASSERT_TRUE(ev.n_fragments == 1u);
+        if (ev.n_secondaries == 0u) {
+            /* Knock-out retained AND cascade proton captured: C-12 + p. */
+            ASSERT_TRUE(ev.fragments[0].a == 13u);
+            ASSERT_TRUE(ev.fragments[0].z == 7u);
+            ASSERT_TRUE(ev.fragments[0].excitons_p == 2u);
+            ASSERT_NEAR(ev.fragments[0].excitation_energy, t_in, 1.0e-9);
+            ++n_captured;
+        }
+    }
+    /* Retention probability at ~1.5 MeV is >0.9: captures must dominate. */
+    ASSERT_TRUE(n_captured > 1500);
+}
+
 int main(void) {
     test_event_kind();
     test_energy_conservation();
@@ -336,5 +373,6 @@ int main(void) {
     test_fragment_momentum_balance();
     test_exciton_bookkeeping();
     test_retention_low_energy();
+    test_capture_bookkeeping();
     return 0;
 }

--- a/tests/unit/test_osh_nuclear_preeq.c
+++ b/tests/unit/test_osh_nuclear_preeq.c
@@ -1,0 +1,230 @@
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "openshieldhit/const.h"
+#include "particle/osh_particle.h"
+#include "particle/osh_particle_pdg.h"
+#include "physics/nuclear/osh_nuclear_handler.h"
+#include "physics/nuclear/osh_nuclear_preeq.h"
+#include "random/osh_rng.h"
+
+#define ASSERT_TRUE(cond)                                                                                              \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            fprintf(stderr, "ASSERT FAILED: %s (%s:%d)\n", #cond, __FILE__, __LINE__);                                 \
+            exit(1);                                                                                                   \
+        }                                                                                                              \
+    } while (0)
+
+#define ASSERT_NEAR(a, b, tol) ASSERT_TRUE(fabs((a) - (b)) <= (tol))
+
+/* Whitelist check: (z, a) of every emittable species. */
+static int is_whitelisted(struct particle const *sp) {
+    if (sp->pdg == OSH_PART_PDG_NEUTRON || sp->pdg == OSH_PART_PDG_PROTON) {
+        return 1;
+    }
+    if (sp->z == 1u && (sp->a == 2u || sp->a == 3u)) {
+        return 1;
+    }
+    if (sp->z == 2u && (sp->a == 3u || sp->a == 4u)) {
+        return 1;
+    }
+    return 0;
+}
+
+/* Build a bare excited O-16-like fragment with a given exciton config. */
+static void make_fragment(
+    struct osh_nuclear_fragment *f, unsigned int z, unsigned int a, double e_star, unsigned int np, unsigned int nh) {
+    memset(f, 0, sizeof(*f));
+    f->z = z;
+    f->a = a;
+    f->excitation_energy = e_star;
+    f->excitons_p = np;
+    f->excitons_h = nh;
+}
+
+static void test_thermalized_noop(void) {
+    /* (p, h) = (0, 0) is the thermalized contract: compound nuclei and
+     * break-up residues must pass through untouched. */
+    struct osh_nuclear_preeq model;
+    struct osh_rng rng;
+    struct osh_nuclear_event ev;
+    struct osh_nuclear_fragment f;
+    struct osh_nuclear_fragment before;
+    int i;
+
+    ASSERT_TRUE(osh_nuclear_preeq_compile(&model) == OSH_OK);
+    osh_rng_init(&rng, OSH_RNG_TYPE_PCG32, 11u, 0u);
+
+    for (i = 0; i < 100; ++i) {
+        memset(&ev, 0, sizeof(ev));
+        make_fragment(&f, 8u, 16u, 40.0, 0u, 0u);
+        before = f;
+        osh_nuclear_preeq_step(&model, &f, &rng, &ev);
+        ASSERT_TRUE(memcmp(&before, &f, sizeof(f)) == 0);
+        ASSERT_TRUE(ev.n_secondaries == 0u);
+    }
+}
+
+static void test_below_threshold_noop(void) {
+    /* Excitation below every separation energy: nothing can be emitted;
+     * the fragment may only thermalize (excitons change, E* and A/Z not). */
+    struct osh_nuclear_preeq model;
+    struct osh_rng rng;
+    struct osh_nuclear_event ev;
+    struct osh_nuclear_fragment f;
+    int i;
+
+    ASSERT_TRUE(osh_nuclear_preeq_compile(&model) == OSH_OK);
+    osh_rng_init(&rng, OSH_RNG_TYPE_PCG32, 13u, 0u);
+
+    for (i = 0; i < 200; ++i) {
+        memset(&ev, 0, sizeof(ev));
+        make_fragment(&f, 8u, 16u, 3.0, 1u, 1u);
+        osh_nuclear_preeq_step(&model, &f, &rng, &ev);
+        ASSERT_TRUE(ev.n_secondaries == 0u);
+        ASSERT_TRUE(f.z == 8u && f.a == 16u);
+        ASSERT_NEAR(f.excitation_energy, 3.0, 1.0e-12);
+    }
+}
+
+static void test_conservation(void) {
+    /* Exact per-event bookkeeping with masses:
+     *   M(parent) + E*_before == sum(m_j + T_j) + M(residue) + E*_after
+     * and fragment momentum == -(sum of emitted momenta) for a parent at
+     * rest.  Uses the same isotope masses the model compiled. */
+    struct osh_nuclear_preeq model;
+    struct osh_rng rng;
+    struct osh_nuclear_event ev;
+    struct osh_nuclear_fragment f;
+    double m_parent;
+    double m_res;
+    double m_j;
+    double lhs;
+    double rhs;
+    double p_expect[3];
+    double p_j;
+    size_t j;
+    int i;
+
+    ASSERT_TRUE(osh_nuclear_preeq_compile(&model) == OSH_OK);
+    osh_rng_init(&rng, OSH_RNG_TYPE_PCG32, 17u, 0u);
+    ASSERT_TRUE(osh_particle_nuclear_mass_mev_from_za(8u, 16u, &m_parent));
+
+    for (i = 0; i < 5000; ++i) {
+        memset(&ev, 0, sizeof(ev));
+        make_fragment(&f, 8u, 16u, 45.0, 2u, 2u);
+        osh_nuclear_preeq_step(&model, &f, &rng, &ev);
+
+        ASSERT_TRUE(osh_particle_nuclear_mass_mev_from_za(f.z, f.a, &m_res));
+        lhs = m_parent + 45.0;
+        rhs = m_res + f.excitation_energy;
+        p_expect[0] = 0.0;
+        p_expect[1] = 0.0;
+        p_expect[2] = 0.0;
+        for (j = 0u; j < ev.n_secondaries; ++j) {
+            m_j = ev.secondaries[j].species->mass;
+            rhs += m_j + ev.secondaries[j].energy;
+            p_j = sqrt(ev.secondaries[j].energy * (ev.secondaries[j].energy + 2.0 * m_j));
+            p_expect[0] -= p_j * ev.secondaries[j].dir[0];
+            p_expect[1] -= p_j * ev.secondaries[j].dir[1];
+            p_expect[2] -= p_j * ev.secondaries[j].dir[2];
+        }
+        ASSERT_NEAR(lhs, rhs, 1.0e-6);
+        ASSERT_NEAR(f.p[0], p_expect[0], 1.0e-9);
+        ASSERT_NEAR(f.p[1], p_expect[1], 1.0e-9);
+        ASSERT_NEAR(f.p[2], p_expect[2], 1.0e-9);
+        ASSERT_TRUE(f.excitation_energy >= 0.0);
+    }
+}
+
+static void test_whitelist_and_kind(void) {
+    /* Only {n, p, d, t, He-3, He-4} may be emitted; FRAGMENTATION is set
+     * exactly when something was emitted. */
+    struct osh_nuclear_preeq model;
+    struct osh_rng rng;
+    struct osh_nuclear_event ev;
+    struct osh_nuclear_fragment f;
+    size_t j;
+    int i;
+
+    ASSERT_TRUE(osh_nuclear_preeq_compile(&model) == OSH_OK);
+    osh_rng_init(&rng, OSH_RNG_TYPE_PCG32, 19u, 0u);
+
+    for (i = 0; i < 5000; ++i) {
+        memset(&ev, 0, sizeof(ev));
+        make_fragment(&f, 8u, 16u, 50.0, 3u, 2u);
+        osh_nuclear_preeq_step(&model, &f, &rng, &ev);
+        for (j = 0u; j < ev.n_secondaries; ++j) {
+            ASSERT_TRUE(is_whitelisted(ev.secondaries[j].species));
+            ASSERT_TRUE(ev.secondaries[j].energy > 0.0);
+        }
+        if (ev.n_secondaries > 0u) {
+            ASSERT_TRUE(ev.kind == OSH_NUCLEAR_EVENT_FRAGMENTATION);
+        }
+    }
+}
+
+static void test_emission_statistics(void) {
+    /* Physics smoke test at the #212-relevant configuration: O-16 with
+     * E* = 45 MeV and a (2, 2) exciton config must emit fast ejectiles in a
+     * sizeable fraction of events, including clusters, with mean nucleon
+     * energy well above the FBU evaporation-like scale, and must always
+     * lower the excitation it hands to the equilibrium stage. */
+    struct osh_nuclear_preeq model;
+    struct osh_rng rng;
+    struct osh_nuclear_event ev;
+    struct osh_nuclear_fragment f;
+    double n_events;
+    double n_emitting;
+    double n_cluster;
+    double e_nucleon_sum;
+    double n_nucleon;
+    size_t j;
+    int i;
+
+    ASSERT_TRUE(osh_nuclear_preeq_compile(&model) == OSH_OK);
+    osh_rng_init(&rng, OSH_RNG_TYPE_PCG32, 23u, 0u);
+
+    n_events = 20000.0;
+    n_emitting = 0.0;
+    n_cluster = 0.0;
+    e_nucleon_sum = 0.0;
+    n_nucleon = 0.0;
+
+    for (i = 0; i < (int) n_events; ++i) {
+        memset(&ev, 0, sizeof(ev));
+        make_fragment(&f, 8u, 16u, 45.0, 2u, 2u);
+        osh_nuclear_preeq_step(&model, &f, &rng, &ev);
+        ASSERT_TRUE(f.excitation_energy <= 45.0 + 1.0e-9);
+        if (ev.n_secondaries > 0u) {
+            n_emitting += 1.0;
+        }
+        for (j = 0u; j < ev.n_secondaries; ++j) {
+            if (ev.secondaries[j].species->a >= 2u) {
+                n_cluster += 1.0;
+            } else {
+                e_nucleon_sum += ev.secondaries[j].energy;
+                n_nucleon += 1.0;
+            }
+        }
+    }
+
+    /* Loose statistical bands: the exact fractions are calibration targets
+     * (#225 gamma scales), but the channels must exist and be fast. */
+    ASSERT_TRUE(n_emitting / n_events > 0.10);
+    ASSERT_TRUE(n_cluster > 0.0);
+    ASSERT_TRUE(n_nucleon > 0.0);
+    ASSERT_TRUE(e_nucleon_sum / n_nucleon > 5.0);
+}
+
+int main(void) {
+    test_thermalized_noop();
+    test_below_threshold_noop();
+    test_conservation();
+    test_whitelist_and_kind();
+    test_emission_statistics();
+    return 0;
+}

--- a/tests/unit/test_osh_nuclear_preeq.c
+++ b/tests/unit/test_osh_nuclear_preeq.c
@@ -45,6 +45,19 @@ static void make_fragment(
     f->excitons_h = nh;
 }
 
+/* Compare the physically meaningful fragment state field-by-field.
+ * Padding bytes are not stable, so memcmp() is not valid here. */
+static void assert_fragment_equal(struct osh_nuclear_fragment const *lhs, struct osh_nuclear_fragment const *rhs) {
+    ASSERT_NEAR(lhs->excitation_energy, rhs->excitation_energy, 1.0e-12);
+    ASSERT_NEAR(lhs->p[0], rhs->p[0], 1.0e-12);
+    ASSERT_NEAR(lhs->p[1], rhs->p[1], 1.0e-12);
+    ASSERT_NEAR(lhs->p[2], rhs->p[2], 1.0e-12);
+    ASSERT_TRUE(lhs->z == rhs->z);
+    ASSERT_TRUE(lhs->a == rhs->a);
+    ASSERT_TRUE(lhs->excitons_p == rhs->excitons_p);
+    ASSERT_TRUE(lhs->excitons_h == rhs->excitons_h);
+}
+
 static void test_thermalized_noop(void) {
     /* (p, h) = (0, 0) is the thermalized contract: compound nuclei and
      * break-up residues must pass through untouched. */
@@ -63,7 +76,7 @@ static void test_thermalized_noop(void) {
         make_fragment(&f, 8u, 16u, 40.0, 0u, 0u);
         before = f;
         osh_nuclear_preeq_step(&model, &f, &rng, &ev);
-        ASSERT_TRUE(memcmp(&before, &f, sizeof(f)) == 0);
+        assert_fragment_equal(&before, &f);
         ASSERT_TRUE(ev.n_secondaries == 0u);
     }
 }

--- a/tests/unit/test_osh_scoring_step.c
+++ b/tests/unit/test_osh_scoring_step.c
@@ -371,7 +371,8 @@ static void test_score_mesh_dose_and_let_geometric(void) {
     memset(&rt, 0, sizeof(rt));
     rc = osh_scoring_compile(ws, NULL, &rt);
     ASSERT_TRUE(rc == OSH_OK);
-    /* mat_tables stays NULL → geometric LET fallback, DQEFF/TQEFF skipped */
+    /* mat_tables stays NULL -> geometric LET fallback.  part.mass stays unset
+     * here, so DQEFF/TQEFF are skipped because beta cannot be computed. */
 
     memset(&part, 0, sizeof(part));
     part.z = 1u;
@@ -511,6 +512,7 @@ static void test_score_mesh_dqeff_tqeff(void) {
     memset(&part, 0, sizeof(part));
     part.z = 1u;
     part.a = 1u;
+    part.mass = proton_mass_mev;
 
     memset(&st, 0, sizeof(st));
     st.p[0] = 0.0;
@@ -637,6 +639,7 @@ static void test_score_mesh_fluence_diff_let_qeff(void) {
     memset(&part, 0, sizeof(part));
     part.z = 1u;
     part.a = 1u;
+    part.mass = proton_mass_mev;
 
     memset(&st, 0, sizeof(st));
     st.p[0] = 0.0;

--- a/tests/unit/test_osh_transport_guards.c
+++ b/tests/unit/test_osh_transport_guards.c
@@ -1,8 +1,16 @@
+#include <math.h>
 #include <string.h>
 
+#include "common/osh_particle_pool.h"
+#include "common/osh_step_segment.h"
+#include "material/runtime/osh_material_runtime.h"
+#include "particle/osh_particle_pdg.h"
+#include "random/osh_rng.h"
+#include "scoring/runtime/osh_scoring_runtime.h"
 #include "test_assert.h"
 #include "transport/osh_transport.h"
 #include "transport/osh_transport_ion.h"
+#include "transport/osh_transport_ion_step.h"
 
 /*
  * Argument-validation guards for the transport entry points.  These exercise the
@@ -56,8 +64,124 @@ static void test_ion_run_range_validates_arguments(void) {
     ASSERT_TRUE(osh_transport_ion_run_range(&ctx, nn, nn, nn, nn, NULL, 0u, 10u, &completed) == OSH_EINVAL);
 }
 
+static double run_boundary_step_energy_loss(int pdg, double energy_mev_per_u) {
+    struct osh_particle_pool pool;
+    struct particle part;
+    struct osh_zone_ref zone_ref;
+    struct osh_step_segment segment;
+    struct osh_transport_context ctx;
+    struct osh_material_runtime mat_rt;
+    struct osh_scoring_runtime score_rt;
+    struct osh_rng rng;
+    float rho_f[3];                /* Runtime density table [g/cm3]. */
+    float zero_material[3];        /* Unused material scalar table entries. */
+    float range_csda[12];          /* [3 materials][projectile H,He][energy 0,1]. */
+    unsigned int projectile_z[2];  /* Runtime projectile columns: H and He. */
+    unsigned int projectile_a[2];  /* Representative isotope A for each Z column. */
+    double projectile_mass_mev[2]; /* Representative masses; part.mass should override. */
+    double e0;                     /* Entry total kinetic energy [MeV]. */
+
+    ASSERT_TRUE(osh_particle_from_pdg(&part, pdg) == 1);
+    ASSERT_TRUE(part.a > 0u);
+    e0 = energy_mev_per_u * (double) part.a;
+
+    projectile_z[0] = 1u;
+    projectile_z[1] = 2u;
+    projectile_a[0] = 1u;
+    projectile_a[1] = 4u;
+    projectile_mass_mev[0] = 938.272046;
+    projectile_mass_mev[1] = 3727.379378;
+
+    memset(range_csda, 0, sizeof(range_csda));
+    range_csda[8] = 0.0f;
+    range_csda[9] = 100.0f;
+    range_csda[10] = 0.0f;
+    range_csda[11] = 400.0f;
+
+    rho_f[0] = 0.0f;
+    rho_f[1] = 0.0f;
+    rho_f[2] = 1.19f;
+    zero_material[0] = 0.0f;
+    zero_material[1] = 0.0f;
+    zero_material[2] = 0.0f;
+
+    memset(&mat_rt, 0, sizeof(mat_rt));
+    mat_rt.emin = 1.0e-6;
+    mat_rt.emax = energy_mev_per_u;
+    mat_rt.log_emin = log(mat_rt.emin);
+    mat_rt.inv_dlog = 1.0 / log(mat_rt.emax / mat_rt.emin);
+    mat_rt.nmaterials = 3u;
+    mat_rt.nprojectiles = 2u;
+    mat_rt.nenergy = 2u;
+    mat_rt.range_csda = range_csda;
+    mat_rt.rho = rho_f;
+    mat_rt.z_mean = zero_material;
+    mat_rt.z_over_a = zero_material;
+    mat_rt.rad_length = zero_material;
+    mat_rt.moliere_chic2 = zero_material;
+    mat_rt.moliere_screen_z = zero_material;
+    mat_rt.projectile_z = projectile_z;
+    mat_rt.projectile_a = projectile_a;
+    mat_rt.projectile_mass_mev = projectile_mass_mev;
+
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.params.deltae = 0.99f;
+    ctx.params.mcs_mode = OSH_TRANSPORT_MCS_OFF;
+    ctx.params.straggling_mode = OSH_TRANSPORT_STRAGGLING_OFF;
+    ctx.params.nuclear_inelastic = 0;
+    ctx.params.nuclear_elastic = 0;
+
+    memset(&zone_ref, 0, sizeof(zone_ref));
+    zone_ref.zone_idx = 0u;
+    zone_ref.material_idx = 2u;
+
+    segment.ds = 10.0;
+
+    memset(&score_rt, 0, sizeof(score_rt));
+    osh_rng_init(&rng, OSH_RNG_TYPE_PCG32, 123u, 0u);
+
+    ASSERT_TRUE(osh_particle_pool_init(&pool, 1u) == OSH_OK);
+    pool.n = 1u;
+    pool.x[0] = 0.0;
+    pool.y[0] = 0.0;
+    pool.z[0] = 0.0;
+    pool.ux[0] = 0.0;
+    pool.uy[0] = 0.0;
+    pool.uz[0] = 1.0;
+    pool.e[0] = e0;
+    pool.wt[0] = 1.0;
+    pool.prim_idx[0] = 0u;
+    pool.gen[0] = 0u;
+    pool.species[0] = &part;
+
+    ASSERT_TRUE(
+        osh_transport_ion_step(&pool, 0u, &zone_ref, &segment, 1u, NULL, &ctx, NULL, &mat_rt, &score_rt, NULL, &rng)
+        == OSH_OK);
+    ASSERT_TRUE(pool.e[0] > 0.0);
+
+    e0 -= pool.e[0];
+    osh_particle_pool_free(&pool);
+    return e0;
+}
+
+static void test_nondefault_isotope_range_scaling(void) {
+    double proton_loss;
+    double deuteron_loss;
+    double he3_loss;
+    double he4_loss;
+
+    proton_loss = run_boundary_step_energy_loss(OSH_PART_PDG_PROTON, 100.0);
+    deuteron_loss = run_boundary_step_energy_loss(OSH_PART_PDG_DEUTERON, 100.0);
+    he3_loss = run_boundary_step_energy_loss(OSH_PART_PDG_HE3, 100.0);
+    he4_loss = run_boundary_step_energy_loss(OSH_PART_PDG_HE4, 100.0);
+
+    ASSERT_TRUE(fabs(deuteron_loss - proton_loss) < 1.0e-4);
+    ASSERT_TRUE(fabs(he3_loss - he4_loss) < 1.0e-4);
+}
+
 int main(void) {
     test_transport_run_rejects_bad_args();
     test_ion_run_range_validates_arguments();
+    test_nondefault_isotope_range_scaling();
     return 0;
 }


### PR DESCRIPTION
- Implemented the pre-equilibrium exciton model to handle fast ejectile emissions between abrasion and equilibrium break-up stages.
- Added new source files: osh_nuclear_preeq.c and osh_nuclear_preeq.h for the model's implementation and interface.
- Updated osh_nuclear_handler to integrate the pre-equilibrium model, ensuring proper compilation and stepping of the model.
- Enhanced nucre_scan example to utilize the new pre-equilibrium model.
- Created unit tests for the pre-equilibrium model, covering various scenarios including thermalized fragments, conservation laws, and emission statistics.