### PR TITLE
Add support for DirtyDose and DirtyDoseGy scoring

### DIFF
--- a/docs/user/detect.dat.md
+++ b/docs/user/detect.dat.md
@@ -98,7 +98,7 @@ Rules and semantics:
   computed from overlapping CSG primitives, so they must be given explicitly; a
   zone with no `Volume` warns and defaults to `1.0 cm3`.
 - The output bin order is exactly the order of the `Zone` lines.
-- Supported quantities: `Energy`, `Fluence`, `Dose`, `DoseGy`.
+- Supported quantities: `Energy`, `Fluence`, `Dose`, `DoseGy`, `DirtyDose`, `DirtyDoseGy`.
 - `FileFormat BDO` (default) records which transport zone each bin is (`GEO_ZONES`
   tag) for labelling; `FileFormat TEXT` writes one row per zone with a numeric
   zone-index column. The per-zone volume is not stored in either — it is consumed by
@@ -222,6 +222,8 @@ outer (slow) loop and Diff2 bins are the inner (fast) loop:
 |---------|------|-------------|
 | `Dose` | MeV/g | Absorbed dose, SH12A-compatible |
 | `DoseGy` | Gy | Absorbed dose in gray (`Dose * 1.602176634e-10`) |
+| `DirtyDose` | MeV/g | As `Dose`, but only charged particles above the mass-LET threshold (see below) |
+| `DirtyDoseGy` | Gy | As `DoseGy`, but only charged particles above the mass-LET threshold |
 | `Fluence` | 1/cm² | Particle fluence |
 | `Energy` | MeV | Energy deposited in the voxel |
 | `DLET` | MeV/cm | Dose-averaged LET |
@@ -245,11 +247,27 @@ Output
 `Dose inWater` and `DoseGy inWater` score using the stopping power of water
 regardless of the actual traversed material, equivalent to SH12A dose-to-water.
 
+### Dirty dose
+
+`DirtyDose` and `DirtyDoseGy` behave exactly like `Dose` and `DoseGy` but only
+accumulate the contribution of **charged particles whose mass stopping power
+(mass-LET) exceeds a fixed threshold** of `30 MeV·cm²/g` (equivalently `3 keV/µm`
+in water at `ρ = 1 g/cm³`). The threshold is a compile-time constant
+(`OSH_DIRTYDOSE_MASS_SP_THRESHOLD`). Neutral particles and any species without a
+stopping-power table entry contribute nothing.
+
+The mass-LET used for the gate follows the same medium as the dose: normally the
+local (transport) material, or — when a `Settings` block overrides the scoring
+medium — the override medium. So assuming a user-defined `inWater` settings override,
+then `DirtyDose inWater` scores dose-to-water **and**
+compares the mass-LET *in water* against the fixed threshold.
+A density-only override does not change the mass-LET (Fano-invariant).
+
 ## Statistical uncertainty (error bars)
 
-Per-bin Monte-Carlo **standard error** is off by default.  Turn it on **per
-estimator** by attaching a `Settings` block that carries `Variance On` to the
-`Quantity` line — the same mechanism as `Quantity Dose inWater`:
+Per-bin Monte-Carlo **standard error** acquisition is turned off by default.
+Turn it on **per estimator** by attaching a `Settings` block that carries
+`Variance On` to the `Quantity` line — the same mechanism as `Quantity Dose inWater`:
 
 ```text
 Settings
@@ -258,7 +276,7 @@ Settings
 
 Output
     Filename bragg.dat
-    Geo Depth
+    Geo MyDepthDoseCurve
     Quantity Dose withErr
 ```
 

--- a/src/scoring/runtime/osh_scoring_compile.c
+++ b/src/scoring/runtime/osh_scoring_compile.c
@@ -79,6 +79,12 @@ static enum osh_scoring_score_kind quantity_to_score_kind(char const *quantity) 
     if (strcmp(quantity, "dosegy") == 0) {
         return OSH_SCORING_SCORE_DOSEGY;
     }
+    if (strcmp(quantity, "dirtydose") == 0) {
+        return OSH_SCORING_SCORE_DIRTYDOSE;
+    }
+    if (strcmp(quantity, "dirtydosegy") == 0) {
+        return OSH_SCORING_SCORE_DIRTYDOSEGY;
+    }
     if (strcmp(quantity, "dlet") == 0) {
         return OSH_SCORING_SCORE_DLET;
     }
@@ -383,6 +389,8 @@ static int runtime_supports_score_kind(enum osh_scoring_score_kind score_kind) {
     case OSH_SCORING_SCORE_FLUENCE:
     case OSH_SCORING_SCORE_DOSE:
     case OSH_SCORING_SCORE_DOSEGY:
+    case OSH_SCORING_SCORE_DIRTYDOSE:
+    case OSH_SCORING_SCORE_DIRTYDOSEGY:
     case OSH_SCORING_SCORE_DLET:
     case OSH_SCORING_SCORE_TLET:
     case OSH_SCORING_SCORE_DQEFF:
@@ -911,10 +919,11 @@ enum osh_status osh_scoring_compile(struct osh_scoring_workspace const *ws,
             }
             if (rt->geometries[gidx].geo_kind == OSH_SCORING_GEO_ZONE && score_kind != OSH_SCORING_SCORE_ENERGY
                 && score_kind != OSH_SCORING_SCORE_FLUENCE && score_kind != OSH_SCORING_SCORE_DOSE
-                && score_kind != OSH_SCORING_SCORE_DOSEGY) {
+                && score_kind != OSH_SCORING_SCORE_DOSEGY && score_kind != OSH_SCORING_SCORE_DIRTYDOSE
+                && score_kind != OSH_SCORING_SCORE_DIRTYDOSEGY) {
                 OSH_DIAG_ERRORF(diag,
                                 "Scoring output '%s' uses quantity '%s' on Zone geometry '%s'; only Energy, Fluence, "
-                                "Dose, and DoseGy are supported for Zone scoring",
+                                "Dose, DoseGy, DirtyDose, and DirtyDoseGy are supported for Zone scoring",
                                 ws->outputs[i].filename ? ws->outputs[i].filename : "(unnamed)",
                                 ws->outputs[i].pages[j].quantity ? ws->outputs[i].pages[j].quantity : "(null)",
                                 ws->outputs[i].geometry_name ? ws->outputs[i].geometry_name : "(null)");

--- a/src/scoring/runtime/osh_scoring_defs.h
+++ b/src/scoring/runtime/osh_scoring_defs.h
@@ -155,6 +155,8 @@ enum osh_scoring_filter_op {
  * ---------------------------------------------------
  * DOSE    [MeV/g]       raw absorbed dose, no unit conversion (SH12A-compatible)
  * DOSEGY  [Gy]          absorbed dose in Gy — osh_scoring_postprocess() applies OSH_MEVG2GY
+ * DIRTYDOSE   [MeV/g]   as DOSE, but only charged particles with mass-LET > threshold
+ * DIRTYDOSEGY [Gy]      as DOSEGY, but only charged particles with mass-LET > threshold
  * FLUENCE [1/cm^2]
  * LET     [MeV/cm]      or [keV/um] depending on settings rescale
  * COUNT   [1]           raw event count (no normalisation)
@@ -198,7 +200,12 @@ enum osh_scoring_score_kind {
 
     /* --- Gy-converted dose ------------------------------------------------- */
 
-    OSH_SCORING_SCORE_DOSEGY = 14 /* absorbed dose [Gy] — applies OSH_MEVG2GY in postprocessing */
+    OSH_SCORING_SCORE_DOSEGY = 14, /* absorbed dose [Gy] — applies OSH_MEVG2GY in postprocessing */
+
+    /* --- LET-gated ("dirty") dose ----------------------------------------- */
+
+    OSH_SCORING_SCORE_DIRTYDOSE = 15,  /* dose [MeV/g] from charged particles with mass-LET > threshold */
+    OSH_SCORING_SCORE_DIRTYDOSEGY = 16 /* dose [Gy] from charged particles with mass-LET > threshold */
 };
 
 #ifdef __cplusplus

--- a/src/scoring/runtime/osh_scoring_estimator.c
+++ b/src/scoring/runtime/osh_scoring_estimator.c
@@ -18,6 +18,10 @@ static struct osh_scoring_estimator const k_dose = {
     osh_scoring_estimator_step_dose, osh_scoring_estimator_point_dose, postprocess_volume};
 static struct osh_scoring_estimator const k_dosegy = {
     osh_scoring_estimator_step_dose, osh_scoring_estimator_point_dose, postprocess_dosegy};
+static struct osh_scoring_estimator const k_dirtydose = {
+    osh_scoring_estimator_step_dirtydose, osh_scoring_estimator_point_dirtydose, postprocess_volume};
+static struct osh_scoring_estimator const k_dirtydosegy = {
+    osh_scoring_estimator_step_dirtydose, osh_scoring_estimator_point_dirtydose, postprocess_dosegy};
 static struct osh_scoring_estimator const k_dlet = {osh_scoring_estimator_step_dlet, NULL, postprocess_ratio};
 static struct osh_scoring_estimator const k_tlet = {osh_scoring_estimator_step_tlet, NULL, postprocess_ratio};
 static struct osh_scoring_estimator const k_dqeff = {osh_scoring_estimator_step_dqeff, NULL, postprocess_ratio};
@@ -34,6 +38,10 @@ struct osh_scoring_estimator const *osh_scoring_estimator_for(enum osh_scoring_s
         return &k_dose;
     case OSH_SCORING_SCORE_DOSEGY:
         return &k_dosegy;
+    case OSH_SCORING_SCORE_DIRTYDOSE:
+        return &k_dirtydose;
+    case OSH_SCORING_SCORE_DIRTYDOSEGY:
+        return &k_dirtydosegy;
     case OSH_SCORING_SCORE_DLET:
         return &k_dlet;
     case OSH_SCORING_SCORE_TLET:

--- a/src/scoring/runtime/osh_scoring_estimator_common.h
+++ b/src/scoring/runtime/osh_scoring_estimator_common.h
@@ -17,6 +17,11 @@
  * use them after geometry has already produced crossings or a located bin.
  */
 
+/* Dirty-dose mass-LET gate: DIRTYDOSE/DIRTYDOSEGY only score dose from charged
+ * particles whose mass stopping power exceeds this threshold [MeV*cm^2/g].
+ * 30 MeV*cm^2/g == 3 keV/um in water (rho = 1 g/cm^3).  Compile-time tunable. */
+#define OSH_DIRTYDOSE_MASS_SP_THRESHOLD 30.0
+
 struct osh_scoring_dose_sp_ctx {
     int have_proj;    /* projectile has an SP-table entry in the transport medium */
     size_t proj_idx;  /* projectile index into the SP tables */

--- a/src/scoring/runtime/osh_scoring_estimator_internal.h
+++ b/src/scoring/runtime/osh_scoring_estimator_internal.h
@@ -43,6 +43,15 @@ enum osh_status osh_scoring_estimator_step_dose(struct osh_scoring_runtime const
                                                 struct step const *st,
                                                 double score_len);
 
+enum osh_status osh_scoring_estimator_step_dirtydose(struct osh_scoring_runtime const *rt,
+                                                     struct osh_scoring_accumulator *acc_set,
+                                                     struct osh_scoring_geometry_score_group const *group,
+                                                     struct osh_voxel_crossing const *crossings,
+                                                     size_t ncross,
+                                                     struct particle const *part,
+                                                     struct step const *st,
+                                                     double score_len);
+
 enum osh_status osh_scoring_estimator_step_dlet(struct osh_scoring_runtime const *rt,
                                                 struct osh_scoring_accumulator *acc_set,
                                                 struct osh_scoring_geometry_score_group const *group,
@@ -92,5 +101,12 @@ enum osh_status osh_scoring_estimator_point_dose(struct osh_scoring_runtime cons
                                                  size_t spatial_idx,
                                                  struct particle const *part,
                                                  struct step const *st);
+
+enum osh_status osh_scoring_estimator_point_dirtydose(struct osh_scoring_runtime const *rt,
+                                                      struct osh_scoring_accumulator *acc_set,
+                                                      struct osh_scoring_geometry_score_group const *group,
+                                                      size_t spatial_idx,
+                                                      struct particle const *part,
+                                                      struct step const *st);
 
 #endif /* OSH_SCORING_ESTIMATOR_INTERNAL_H */

--- a/src/scoring/runtime/osh_scoring_estimator_point.c
+++ b/src/scoring/runtime/osh_scoring_estimator_point.c
@@ -105,3 +105,63 @@ enum osh_status osh_scoring_estimator_point_dose(struct osh_scoring_runtime cons
     }
     return OSH_OK;
 }
+
+/**
+ * @brief Point-deposit counterpart of osh_scoring_estimator_step_dirtydose.
+ *
+ * Identical to osh_scoring_estimator_point_dose(), except a page books dose only
+ * when the projectile's mass stopping power in that page's scoring medium exceeds
+ * OSH_DIRTYDOSE_MASS_SP_THRESHOLD [MeV*cm^2/g].  Neutrals are excluded up front
+ * (charge == 0); the mass-SP gate additionally drops charged particles below the
+ * threshold and any species without an SP-table entry.
+ */
+enum osh_status osh_scoring_estimator_point_dirtydose(struct osh_scoring_runtime const *rt,
+                                                      struct osh_scoring_accumulator *acc_set,
+                                                      struct osh_scoring_geometry_score_group const *group,
+                                                      size_t spatial_idx,
+                                                      struct particle const *part,
+                                                      struct step const *st) {
+    size_t i;
+    size_t db;
+    size_t db2;
+    size_t score_idx;
+    double sp_ratio;
+    double mass_sp;
+    double dose_score;
+    struct osh_scoring_dose_sp_ctx sp;
+    struct osh_scoring_page_runtime const *page;
+    struct osh_scoring_accumulator *acc;
+
+    if (part->charge == 0) {
+        return OSH_OK;
+    }
+    if (!(st->rho > 0.0)) {
+        return OSH_OK;
+    }
+    sp = osh_scoring_estimator_dose_sp_gather(rt, part, st);
+
+    for (i = 0; i < group->npages; ++i) {
+        page = &rt->pages[group->first_page + i];
+        acc = &acc_set[group->first_page + i];
+        if (!osh_scoring_page_passes_filters(page, part, st)) {
+            continue;
+        }
+        /* Mass-LET in this page's scoring medium [MeV*cm^2/g]; the override (if any)
+         * is folded in exactly as it is for the dose scale. */
+        sp_ratio = osh_scoring_estimator_dose_sp_ratio(&sp, rt, page);
+        mass_sp = sp.sp_tr * sp_ratio;
+        if (!(mass_sp > OSH_DIRTYDOSE_MASS_SP_THRESHOLD)) {
+            continue; /* below the dirty-dose LET threshold (or mass SP unavailable) */
+        }
+        if (!osh_scoring_estimator_resolve_diff_bins(page, rt, part, st, &db, &db2)) {
+            continue;
+        }
+        if (spatial_idx >= page->diff_stride) {
+            return OSH_ESTATE;
+        }
+        score_idx = osh_scoring_estimator_flat_bin(page, spatial_idx, db, db2);
+        dose_score = (st->de / st->rho) * sp_ratio;
+        osh_score_deposit(acc->data, score_idx, dose_score);
+    }
+    return OSH_OK;
+}

--- a/src/scoring/runtime/osh_scoring_estimator_step.c
+++ b/src/scoring/runtime/osh_scoring_estimator_step.c
@@ -174,6 +174,76 @@ enum osh_status osh_scoring_estimator_step_dose(struct osh_scoring_runtime const
 }
 
 /**
+ * @brief Accumulate LET-gated ("dirty") dose [MeV/g] into the DIRTYDOSE/DIRTYDOSEGY pages.
+ *
+ * Identical to osh_scoring_estimator_step_dose(), except a page books dose only
+ * when the projectile's mass stopping power in that page's scoring medium exceeds
+ * OSH_DIRTYDOSE_MASS_SP_THRESHOLD [MeV*cm^2/g].  The gate uses the same medium as
+ * the dose: sp_tr for the transport medium, or sp_tr*ratio == S(override) under a
+ * Settings medium override (dose-to-water then also gates on mass-LET in water).
+ * A density-only override is Fano-invariant (ratio == 1), so the gate uses the
+ * transport-medium mass SP.  When the mass SP is unavailable (neutral, no SP-table
+ * entry, or medium < 0) sp_tr is 0 and nothing is scored — dirty dose is a
+ * charged-particle, table-defined quantity.
+ */
+enum osh_status osh_scoring_estimator_step_dirtydose(struct osh_scoring_runtime const *rt,
+                                                     struct osh_scoring_accumulator *acc_set,
+                                                     struct osh_scoring_geometry_score_group const *group,
+                                                     struct osh_voxel_crossing const *crossings,
+                                                     size_t ncross,
+                                                     struct particle const *part,
+                                                     struct step const *st,
+                                                     double score_len) {
+    size_t i;
+    size_t j;
+    size_t db;        /* Index into the differential bins for the current spatial bin */
+    size_t db2;       /* Index into the differential bins for the current spatial bin */
+    size_t score_idx; /* Index into the scoring array for the current spatial bin */
+    double base_scale;
+    double sp_ratio;
+    double mass_sp;
+    double dose_scale;
+    double dose_score;
+    struct osh_scoring_dose_sp_ctx sp;
+    struct osh_scoring_page_runtime const *page;
+    struct osh_scoring_accumulator *acc;
+
+    if (!(st->rho > 0.0)) {
+        return OSH_OK;
+    }
+    base_scale = st->de / (score_len * st->rho);
+    sp = osh_scoring_estimator_dose_sp_gather(rt, part, st);
+
+    for (i = 0; i < group->npages; ++i) {
+        page = &rt->pages[group->first_page + i];
+        acc = &acc_set[group->first_page + i];
+        if (!osh_scoring_page_passes_filters(page, part, st)) {
+            continue;
+        }
+        /* Mass-LET in this page's scoring medium [MeV*cm^2/g]; the override (if any)
+         * is folded in exactly as it is for the dose scale below. */
+        sp_ratio = osh_scoring_estimator_dose_sp_ratio(&sp, rt, page);
+        mass_sp = sp.sp_tr * sp_ratio;
+        if (!(mass_sp > OSH_DIRTYDOSE_MASS_SP_THRESHOLD)) {
+            continue; /* below the dirty-dose LET threshold (or mass SP unavailable) */
+        }
+        dose_scale = base_scale * sp_ratio;
+        if (!osh_scoring_estimator_resolve_diff_bins(page, rt, part, st, &db, &db2)) {
+            continue;
+        }
+        for (j = 0; j < ncross; ++j) {
+            if (crossings[j].idx >= page->diff_stride) {
+                return OSH_ESTATE;
+            }
+            score_idx = osh_scoring_estimator_flat_bin(page, crossings[j].idx, db, db2);
+            dose_score = crossings[j].path_len * dose_scale;
+            osh_score_deposit(acc->data, score_idx, dose_score);
+        }
+    }
+    return OSH_OK;
+}
+
+/**
  * @brief Accumulate dose-averaged LET [MeV/cm] via a two-pass accumulator.
  *
  * Uses S(medium,E)*rho from the SP tables when available; falls back to de/score_len.

--- a/src/scoring/runtime/osh_scoring_postprocess.c
+++ b/src/scoring/runtime/osh_scoring_postprocess.c
@@ -14,6 +14,8 @@ int osh_scoring_postprocess_writes_data(enum osh_scoring_score_kind kind) {
     switch (kind) {
     case OSH_SCORING_SCORE_DOSE:
     case OSH_SCORING_SCORE_DOSEGY:
+    case OSH_SCORING_SCORE_DIRTYDOSE:
+    case OSH_SCORING_SCORE_DIRTYDOSEGY:
     case OSH_SCORING_SCORE_FLUENCE:
     case OSH_SCORING_SCORE_NKERMA:
     case OSH_SCORING_SCORE_DLET:

--- a/src/scoring/save/osh_scoring_save_bdo2019.c
+++ b/src/scoring/save/osh_scoring_save_bdo2019.c
@@ -300,8 +300,10 @@ static char const *page_data_unit(struct osh_scoring_page_runtime const *page) {
         /* SH12A spells reciprocal area units with a leading slash, not "1/". */
         return "/cm^2";
     case OSH_SCORING_SCORE_DOSE:
+    case OSH_SCORING_SCORE_DIRTYDOSE:
         return "MeV/g";
     case OSH_SCORING_SCORE_DOSEGY:
+    case OSH_SCORING_SCORE_DIRTYDOSEGY:
         return "Gy";
     case OSH_SCORING_SCORE_DLET:
     case OSH_SCORING_SCORE_TLET:
@@ -579,6 +581,10 @@ static int legacy_score_kind(struct osh_scoring_page_runtime const *page) {
         return 5;
     case OSH_SCORING_SCORE_DOSEGY:
         return 56;
+    case OSH_SCORING_SCORE_DIRTYDOSE:
+        return 57;
+    case OSH_SCORING_SCORE_DIRTYDOSEGY:
+        return 58;
     case OSH_SCORING_SCORE_LETFLU:
         return 4;
     case OSH_SCORING_SCORE_DLET:

--- a/tests/unit/test_osh_scoring_dirtydose.c
+++ b/tests/unit/test_osh_scoring_dirtydose.c
@@ -1,0 +1,496 @@
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "apps/osh/osh_app_osh.h"
+#include "common/osh_step.h"
+#include "material/runtime/osh_material_runtime.h"
+#include "openshieldhit/const.h"
+#include "openshieldhit/scoring.h"
+#include "openshieldhit/status.h"
+#include "particle/osh_particle.h"
+#include "particle/osh_particle_const.h"
+#include "scoring/runtime/osh_scoring_compile.h"
+#include "scoring/runtime/osh_scoring_defs.h"
+#include "scoring/runtime/osh_scoring_estimator_common.h"
+#include "scoring/runtime/osh_scoring_point.h"
+#include "scoring/runtime/osh_scoring_postprocess.h"
+#include "scoring/runtime/osh_scoring_step.h"
+
+/*
+ * DIRTYDOSE / DIRTYDOSEGY behave exactly like DOSE / DOSEGY but only accept the
+ * contribution of charged particles whose mass stopping power (mass-LET) in the
+ * scoring medium exceeds OSH_DIRTYDOSE_MASS_SP_THRESHOLD [MeV*cm^2/g].  These tests
+ * exercise the LET gate on the step path, the point path, and under a Settings
+ * medium override (dose-to-water, where the gate also uses mass-LET in water).
+ */
+
+#define ASSERT_TRUE(cond)                                                                                              \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            fprintf(stderr, "ASSERT FAILED: %s (%s:%d)\n", #cond, __FILE__, __LINE__);                                 \
+            exit(1);                                                                                                   \
+        }                                                                                                              \
+    } while (0)
+
+static int tmp_counter = 0;
+static double const proton_mass_mev = OSH_PART_MASS_PROTON;
+
+static void assert_close(double a, double b) {
+    ASSERT_TRUE(fabs(a - b) < 1.0e-12);
+}
+
+static void write_temp_file(char *path, size_t path_cap, char const *content) {
+    FILE *fp;
+
+    snprintf(path, path_cap, "osh_scoring_dirtydose_test_%d.tmp", tmp_counter++);
+    fp = fopen(path, "w");
+    ASSERT_TRUE(fp != NULL);
+    ASSERT_TRUE(fputs(content, fp) >= 0);
+    ASSERT_TRUE(fclose(fp) == 0);
+}
+
+static struct osh_scoring_page_runtime *find_page_by_kind(struct osh_scoring_runtime *rt,
+                                                          enum osh_scoring_score_kind kind) {
+    size_t i;
+    for (i = 0; i < rt->npages; ++i) {
+        if (rt->pages[i].score_kind == kind) {
+            return &rt->pages[i];
+        }
+    }
+    return NULL;
+}
+
+/* Build a flat single-material SP table with the given mass stopping power (the
+ * same value at both energy grid points, so the midpoint lookup returns it exactly).
+ * Caller owns the backing arrays passed in and must keep them alive for the test. */
+static void init_flat_mat_tables(struct osh_material_runtime *mat_rt,
+                                 unsigned int *proj_z,
+                                 unsigned int *proj_a,
+                                 double *proj_mass,
+                                 float *rho_arr,
+                                 float *sp_values,
+                                 float mass_sp) {
+    proj_z[0] = 1u;
+    proj_a[0] = 1u;
+    proj_mass[0] = proton_mass_mev;
+    rho_arr[0] = 1.0f;
+    sp_values[0] = mass_sp;
+    sp_values[1] = mass_sp;
+
+    memset(mat_rt, 0, sizeof(*mat_rt));
+    mat_rt->nprojectiles = 1u;
+    mat_rt->nmaterials = 1u;
+    mat_rt->nenergy = 2u;
+    mat_rt->emin = 1.0;
+    mat_rt->emax = 1000.0;
+    mat_rt->log_emin = log(mat_rt->emin);
+    mat_rt->inv_dlog = 1.0 / (log(mat_rt->emax) - log(mat_rt->emin));
+    mat_rt->projectile_z = proj_z;
+    mat_rt->projectile_a = proj_a;
+    mat_rt->projectile_mass_mev = proj_mass;
+    mat_rt->rho = rho_arr;
+    mat_rt->mass_stopping_power = sp_values;
+}
+
+/* Score one Z-directed proton step through a 1x1x3 mesh (1 cm bins), with a flat
+ * SP table of the given mass stopping power, and check DirtyDose against DOSE.
+ * When above_threshold is expected, DirtyDose equals DOSE (0.5, 1.0, 0.5) and
+ * DirtyDoseGy is that times OSH_MEVG2GY; otherwise DirtyDose is all zeros. */
+static void run_step_gate_case(float mass_sp, int expect_scored) {
+    char path[512];
+    char const *detect = "Geometry Mesh\n"
+                         "    Name G\n"
+                         "    X -0.5 0.5 1\n"
+                         "    Y -0.5 0.5 1\n"
+                         "    Z  0.0 3.0 3\n"
+                         "\n"
+                         "Output\n"
+                         "    Filename out.bdo\n"
+                         "    Geo G\n"
+                         "    Quantity Dose\n"
+                         "    Quantity DirtyDose\n"
+                         "    Quantity DirtyDoseGy\n";
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle part;
+    struct step st;
+    struct osh_scoring_page_runtime *dose_page;
+    struct osh_scoring_page_runtime *dirty_page;
+    struct osh_scoring_page_runtime *dirtygy_page;
+    unsigned int proj_z[1];
+    unsigned int proj_a[1];
+    double proj_mass[1];
+    float rho_arr[1];
+    float sp_values[2];
+    struct osh_material_runtime mat_rt;
+    enum osh_status rc;
+
+    write_temp_file(path, sizeof(path), detect);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    init_flat_mat_tables(&mat_rt, proj_z, proj_a, proj_mass, rho_arr, sp_values, mass_sp);
+    rt.mat_tables = &mat_rt;
+
+    memset(&part, 0, sizeof(part));
+    part.charge = 1;
+    part.z = 1u;
+    part.a = 1u;
+    part.mass = proton_mass_mev;
+
+    memset(&st, 0, sizeof(st));
+    st.p[2] = 0.5;
+    st.p[3] = 150.0;
+    st.q[2] = 2.5;
+    st.q[3] = 150.0;
+    st.v[2] = 1.0;
+    st.ds = 2.0;
+    st.de = 2.0;
+    st.rho = 1.0;
+    st.wt = 1.0;
+    st.medium = 0;
+
+    rc = osh_scoring_score_step(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    /* Postprocess so the DirtyDoseGy page gets its MeV/g -> Gy conversion; the
+     * 1 cm^3 bins make the volume division a no-op, so DOSE stays 0.5, 1, 0.5. */
+    rc = osh_scoring_postprocess(&rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    dose_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DOSE);
+    dirty_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DIRTYDOSE);
+    dirtygy_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DIRTYDOSEGY);
+    ASSERT_TRUE(dose_page != NULL);
+    ASSERT_TRUE(dirty_page != NULL);
+    ASSERT_TRUE(dirtygy_page != NULL);
+
+    /* DOSE is unaffected by the LET gate: base_scale = de/(score_len*rho) = 1.0. */
+    assert_close(dose_page->acc.data[0], 0.5);
+    assert_close(dose_page->acc.data[1], 1.0);
+    assert_close(dose_page->acc.data[2], 0.5);
+
+    if (expect_scored) {
+        assert_close(dirty_page->acc.data[0], 0.5);
+        assert_close(dirty_page->acc.data[1], 1.0);
+        assert_close(dirty_page->acc.data[2], 0.5);
+        assert_close(dirtygy_page->acc.data[0], 0.5 * OSH_MEVG2GY);
+        assert_close(dirtygy_page->acc.data[1], 1.0 * OSH_MEVG2GY);
+        assert_close(dirtygy_page->acc.data[2], 0.5 * OSH_MEVG2GY);
+    } else {
+        assert_close(dirty_page->acc.data[0], 0.0);
+        assert_close(dirty_page->acc.data[1], 0.0);
+        assert_close(dirty_page->acc.data[2], 0.0);
+        assert_close(dirtygy_page->acc.data[0], 0.0);
+        assert_close(dirtygy_page->acc.data[1], 0.0);
+        assert_close(dirtygy_page->acc.data[2], 0.0);
+    }
+
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+    remove(path);
+}
+
+/* A proton whose mass-LET is above the threshold contributes exactly like DOSE. */
+static void test_step_high_let_scores_like_dose(void) {
+    run_step_gate_case((float) (OSH_DIRTYDOSE_MASS_SP_THRESHOLD + 10.0), 1);
+}
+
+/* A proton whose mass-LET is below the threshold contributes nothing. */
+static void test_step_low_let_scores_zero(void) {
+    run_step_gate_case((float) (OSH_DIRTYDOSE_MASS_SP_THRESHOLD - 10.0), 0);
+}
+
+/* A neutral particle has no mass stopping power, so it never scores dirty dose even
+ * though it does deposit ordinary DOSE via its energy loss. */
+static void test_step_neutral_scores_zero(void) {
+    char path[512];
+    char const *detect = "Geometry Mesh\n"
+                         "    Name G\n"
+                         "    X -0.5 0.5 1\n"
+                         "    Y -0.5 0.5 1\n"
+                         "    Z  0.0 3.0 3\n"
+                         "\n"
+                         "Output\n"
+                         "    Filename out.bdo\n"
+                         "    Geo G\n"
+                         "    Quantity Dose\n"
+                         "    Quantity DirtyDose\n";
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle part;
+    struct step st;
+    struct osh_scoring_page_runtime *dose_page;
+    struct osh_scoring_page_runtime *dirty_page;
+    unsigned int proj_z[1];
+    unsigned int proj_a[1];
+    double proj_mass[1];
+    float rho_arr[1];
+    float sp_values[2];
+    struct osh_material_runtime mat_rt;
+    enum osh_status rc;
+
+    write_temp_file(path, sizeof(path), detect);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    init_flat_mat_tables(
+        &mat_rt, proj_z, proj_a, proj_mass, rho_arr, sp_values, (float) (OSH_DIRTYDOSE_MASS_SP_THRESHOLD + 10.0));
+    rt.mat_tables = &mat_rt;
+
+    /* Neutron: charge 0, z 0 — no SP-table column, so the gate value is 0. */
+    memset(&part, 0, sizeof(part));
+    part.charge = 0;
+    part.z = 0u;
+    part.a = 1u;
+
+    memset(&st, 0, sizeof(st));
+    st.p[2] = 0.5;
+    st.p[3] = 150.0;
+    st.q[2] = 2.5;
+    st.q[3] = 150.0;
+    st.v[2] = 1.0;
+    st.ds = 2.0;
+    st.de = 2.0;
+    st.rho = 1.0;
+    st.wt = 1.0;
+    st.medium = 0;
+
+    rc = osh_scoring_score_step(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    dose_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DOSE);
+    dirty_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DIRTYDOSE);
+    ASSERT_TRUE(dose_page != NULL);
+    ASSERT_TRUE(dirty_page != NULL);
+
+    /* Ordinary DOSE still books the neutral's energy deposit. */
+    assert_close(dose_page->acc.data[1], 1.0);
+    /* DirtyDose rejects it entirely. */
+    assert_close(dirty_page->acc.data[0], 0.0);
+    assert_close(dirty_page->acc.data[1], 0.0);
+    assert_close(dirty_page->acc.data[2], 0.0);
+
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+    remove(path);
+}
+
+/* With a Settings medium override, both the scored dose and the LET gate refer to
+ * the override medium.  Transport medium 0 has mass-LET below threshold (no dirty
+ * dose), while override medium 1 (water) is above threshold: the overridden page
+ * both passes the gate and scores dose-to-water (scaled by the S(water)/S(medium0)
+ * stopping-power ratio). */
+static void test_step_water_override_gates_and_scales(void) {
+    char path[512];
+    char const *detect = "Geometry Mesh\n"
+                         "    Name G\n"
+                         "    X -0.5 0.5 1\n"
+                         "    Y -0.5 0.5 1\n"
+                         "    Z  0.0 3.0 3\n"
+                         "\n"
+                         "Settings\n"
+                         "    Name toWater\n"
+                         "    Medium 1\n"
+                         "\n"
+                         "Output\n"
+                         "    Filename out.bdo\n"
+                         "    Geo G\n"
+                         "    Quantity DirtyDose\n"
+                         "    Quantity DirtyDose toWater\n";
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle part;
+    struct step st;
+    struct osh_scoring_page_runtime *dirty_local;
+    struct osh_scoring_page_runtime *dirty_water;
+    unsigned int proj_z[1];
+    unsigned int proj_a[1];
+    double proj_mass[1];
+    float rho_arr[2];
+    /* Two materials, one projectile, two energy points: layout is
+     * [mat][proj][energy].  Medium 0 (transport) below threshold, medium 1 (water)
+     * above, with S(water)/S(medium0) == 2. */
+    float sp_values[4];
+    struct osh_material_runtime mat_rt;
+    float const sp_transport = (float) (OSH_DIRTYDOSE_MASS_SP_THRESHOLD - 10.0);
+    float const sp_water = 2.0f * sp_transport;
+    enum osh_status rc;
+
+    write_temp_file(path, sizeof(path), detect);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    proj_z[0] = 1u;
+    proj_a[0] = 1u;
+    proj_mass[0] = proton_mass_mev;
+    rho_arr[0] = 1.0f;
+    rho_arr[1] = 1.0f;
+    sp_values[0] = sp_transport; /* mat 0 */
+    sp_values[1] = sp_transport;
+    sp_values[2] = sp_water; /* mat 1 */
+    sp_values[3] = sp_water;
+
+    memset(&mat_rt, 0, sizeof(mat_rt));
+    mat_rt.nprojectiles = 1u;
+    mat_rt.nmaterials = 2u;
+    mat_rt.nenergy = 2u;
+    mat_rt.emin = 1.0;
+    mat_rt.emax = 1000.0;
+    mat_rt.log_emin = log(mat_rt.emin);
+    mat_rt.inv_dlog = 1.0 / (log(mat_rt.emax) - log(mat_rt.emin));
+    mat_rt.projectile_z = proj_z;
+    mat_rt.projectile_a = proj_a;
+    mat_rt.projectile_mass_mev = proj_mass;
+    mat_rt.rho = rho_arr;
+    mat_rt.mass_stopping_power = sp_values;
+    rt.mat_tables = &mat_rt;
+
+    memset(&part, 0, sizeof(part));
+    part.charge = 1;
+    part.z = 1u;
+    part.a = 1u;
+    part.mass = proton_mass_mev;
+
+    memset(&st, 0, sizeof(st));
+    st.p[2] = 0.5;
+    st.p[3] = 150.0;
+    st.q[2] = 2.5;
+    st.q[3] = 150.0;
+    st.v[2] = 1.0;
+    st.ds = 2.0;
+    st.de = 2.0;
+    st.rho = 1.0;
+    st.wt = 1.0;
+    st.medium = 0;
+
+    rc = osh_scoring_score_step(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    ASSERT_TRUE(rt.noutputs == 1u);
+    ASSERT_TRUE(rt.outputs[0].npages == 2u);
+    dirty_local = &rt.pages[rt.outputs[0].page_indices[0]];
+    dirty_water = &rt.pages[rt.outputs[0].page_indices[1]];
+
+    /* Local (transport) medium is below threshold: gated out entirely. */
+    assert_close(dirty_local->acc.data[0], 0.0);
+    assert_close(dirty_local->acc.data[1], 0.0);
+    assert_close(dirty_local->acc.data[2], 0.0);
+
+    /* Override to water: mass-LET in water is above threshold, so the page scores,
+     * and the dose is dose-to-water = dose-to-medium * S(water)/S(medium0) = 2x. */
+    assert_close(dirty_water->acc.data[0], 1.0);
+    assert_close(dirty_water->acc.data[1], 2.0);
+    assert_close(dirty_water->acc.data[2], 1.0);
+
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+    remove(path);
+}
+
+/* Point-deposit path: a low-energy fragment born below transport threshold books
+ * de/rho at one bin only when its mass-LET clears the gate. */
+static void test_point_gate(void) {
+    char path[512];
+    char const *detect = "Geometry Mesh\n"
+                         "    Name G\n"
+                         "    X -0.5 0.5 1\n"
+                         "    Y -0.5 0.5 1\n"
+                         "    Z  0.0 3.0 3\n"
+                         "\n"
+                         "Output\n"
+                         "    Filename out.bdo\n"
+                         "    Geo G\n"
+                         "    Quantity DirtyDose\n";
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle part;
+    struct step st;
+    struct osh_scoring_page_runtime *dirty_page;
+    unsigned int proj_z[1];
+    unsigned int proj_a[1];
+    double proj_mass[1];
+    float rho_arr[1];
+    float sp_values[2];
+    struct osh_material_runtime mat_rt;
+    enum osh_status rc;
+
+    write_temp_file(path, sizeof(path), detect);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    /* Above threshold first: the point deposits de/rho = 4/2 = 2 at bin 1. */
+    init_flat_mat_tables(
+        &mat_rt, proj_z, proj_a, proj_mass, rho_arr, sp_values, (float) (OSH_DIRTYDOSE_MASS_SP_THRESHOLD + 10.0));
+    rt.mat_tables = &mat_rt;
+
+    memset(&part, 0, sizeof(part));
+    part.charge = 1;
+    part.z = 1u;
+    part.a = 1u;
+    part.mass = proton_mass_mev;
+
+    memset(&st, 0, sizeof(st));
+    st.p[2] = 1.5; /* inside mesh bin 1 (Z in [1,2)) */
+    st.p[3] = 150.0;
+    st.q[2] = 1.5;
+    st.q[3] = 150.0; /* point: q == p */
+    st.de = 4.0;
+    st.rho = 2.0;
+    st.wt = 1.0;
+    st.medium = 0;
+
+    rc = osh_scoring_score_point(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    dirty_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DIRTYDOSE);
+    ASSERT_TRUE(dirty_page != NULL);
+    assert_close(dirty_page->acc.data[0], 0.0);
+    assert_close(dirty_page->acc.data[1], 2.0);
+    assert_close(dirty_page->acc.data[2], 0.0);
+
+    /* Now below threshold: the same point books nothing. */
+    memset(dirty_page->acc.data, 0, dirty_page->len * sizeof(*dirty_page->acc.data));
+    init_flat_mat_tables(
+        &mat_rt, proj_z, proj_a, proj_mass, rho_arr, sp_values, (float) (OSH_DIRTYDOSE_MASS_SP_THRESHOLD - 10.0));
+
+    rc = osh_scoring_score_point(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+    assert_close(dirty_page->acc.data[1], 0.0);
+
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+    remove(path);
+}
+
+int main(void) {
+    test_step_high_let_scores_like_dose();
+    test_step_low_let_scores_zero();
+    test_step_neutral_scores_zero();
+    test_step_water_override_gates_and_scales();
+    test_point_gate();
+    return 0;
+}

--- a/tests/unit/test_osh_scoring_dirtydose.c
+++ b/tests/unit/test_osh_scoring_dirtydose.c
@@ -271,6 +271,10 @@ static void test_step_neutral_scores_zero(void) {
         &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
+    /* Assert on postprocessed output (1 cm^3 bins -> volume division is a no-op). */
+    rc = osh_scoring_postprocess(&rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
     dose_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DOSE);
     dirty_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DIRTYDOSE);
     ASSERT_TRUE(dose_page != NULL);
@@ -384,6 +388,10 @@ static void test_step_water_override_gates_and_scales(void) {
         &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
+    /* Assert on postprocessed output (1 cm^3 bins -> volume division is a no-op). */
+    rc = osh_scoring_postprocess(&rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
     ASSERT_TRUE(rt.noutputs == 1u);
     ASSERT_TRUE(rt.outputs[0].npages == 2u);
     dirty_local = &rt.pages[rt.outputs[0].page_indices[0]];
@@ -465,13 +473,18 @@ static void test_point_gate(void) {
         &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
     ASSERT_TRUE(rc == OSH_OK);
 
+    /* Assert on postprocessed output (1 cm^3 bins -> volume division is a no-op). */
+    rc = osh_scoring_postprocess(&rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
     dirty_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DIRTYDOSE);
     ASSERT_TRUE(dirty_page != NULL);
     assert_close(dirty_page->acc.data[0], 0.0);
     assert_close(dirty_page->acc.data[1], 2.0);
     assert_close(dirty_page->acc.data[2], 0.0);
 
-    /* Now below threshold: the same point books nothing. */
+    /* Now below threshold: the same point books nothing (raw check — the deposit is
+     * zero before any postprocessing). */
     memset(dirty_page->acc.data, 0, dirty_page->len * sizeof(*dirty_page->acc.data));
     init_flat_mat_tables(
         &mat_rt, proj_z, proj_a, proj_mass, rho_arr, sp_values, (float) (OSH_DIRTYDOSE_MASS_SP_THRESHOLD - 10.0));


### PR DESCRIPTION
- Introduced new scoring quantities: DirtyDose and DirtyDoseGy, which accumulate contributions from charged particles with mass-LET exceeding a threshold of 30 MeV·cm²/g.
- Updated documentation to reflect the new scoring options and their behavior.
- Modified scoring runtime to handle the new quantities, including their definitions, estimators, and post-processing.
- Implemented tests to validate the functionality of DirtyDose and DirtyDoseGy under various scenarios, including threshold checks and medium overrides.