### PR TITLE
scoring: add dose/track-averaged kinetic energy and beta (v/c) scorers

### DIFF
--- a/docs/dev/scoring.md
+++ b/docs/dev/scoring.md
@@ -211,8 +211,8 @@ because it reads the raw sums. Rather than the absolute `SE` it stores the per-b
 into `data_var`; the save layer then emits the absolute error column as
 `|value| · data_var`, so whatever per-primary / physical-mean / unit scaling the
 writer applies to the value applies to its error automatically — the stored error
-is normalisation-invariant. For the two-pass **AVER** quantities (DLET/TLET/Qeff)
-the reported value is the ratio `data / data2`, so the numerator and denominator
+is normalisation-invariant. For the two-pass **AVER** quantities (DLET/TLET/Qeff/
+AVGE/BETA) the reported value is the ratio `data / data2`, so the numerator and denominator
 relative errors are combined in quadrature (`rel² = rel_num² + rel_den²`); this
 ignores their strong positive correlation and is therefore deliberately
 **conservative** — an over-estimate, never an under-estimate. A bin with
@@ -242,8 +242,8 @@ DICOM RTDOSE is a specialised round-trip writer.
 
 For quick inspection and single-run use. Values are normalised **per primary
 particle** (divided by `nstat`) at write time, except averaged quantities
-(DLET, TLET) which are already physical means after post-processing and are
-written as-is. ASCII output is **not** suitable for merging partial results:
+(DLET, TLET, DQEFF, TQEFF, DAVGE, TAVGE, DBETA, TBETA) which are already physical
+means after post-processing and are written as-is. ASCII output is **not** suitable for merging partial results:
 once divided by `nstat`, each run's absolute weight is lost.
 
 When a page has variance tracking enabled each quantity gains a paired `NAME_ERR`
@@ -265,7 +265,7 @@ supports two merging paths:
 2. **Embarrassingly-parallel / multi-node**: independent runs each emit a
    `.bdo`, and a merge tool weights per scorer kind using each file's `nstat`:
      - `NORM` (DOSE, FLUENCE, ENERGY, …): `X = (sum_j x_j) / (sum_j nstat_j)`
-     - `AVER` (DLET, TLET): `X = (sum_j x_j * nstat_j) / (sum_j nstat_j)`
+     - `AVER` (DLET, TLET, DQEFF, TQEFF, DAVGE, TAVGE, DBETA, TBETA): `X = (sum_j x_j * nstat_j) / (sum_j nstat_j)`
      - `SUM` (COUNT, …): `X = sum_j x_j`
      - `APPEND` (MCPL): concatenation
 
@@ -312,10 +312,16 @@ at score time and never at save.
 | `FLUENCE` | `osh_scoring_estimator_step_fluence` | — | `postprocess_volume` | track length → ÷volume [1/cm²] |
 | `DOSE`    | `osh_scoring_estimator_step_dose`    | `osh_scoring_estimator_point_dose`  | `postprocess_volume` | `de·(path/score_len)/ρ` [+SP-ratio] → ÷volume [MeV/g] |
 | `DOSEGY`  | `osh_scoring_estimator_step_dose`    | `osh_scoring_estimator_point_dose`  | `postprocess_dosegy` | as `DOSE` → ÷volume, ×`OSH_MEVG2GY` [Gy] |
+| `DIRTYDOSE`   | `osh_scoring_estimator_step_dirtydose` | `osh_scoring_estimator_point_dirtydose` | `postprocess_volume` | as `DOSE`, gated on mass-LET > threshold → ÷volume [MeV/g] |
+| `DIRTYDOSEGY` | `osh_scoring_estimator_step_dirtydose` | `osh_scoring_estimator_point_dirtydose` | `postprocess_dosegy` | as `DIRTYDOSE` → ÷volume, ×`OSH_MEVG2GY` [Gy] |
 | `DLET`    | `osh_scoring_estimator_step_dlet`    | — | `postprocess_ratio` | dose-weighted `(LET·w, w)` → `data/data2` [MeV/cm] |
 | `TLET`    | `osh_scoring_estimator_step_tlet`    | — | `postprocess_ratio` | track-weighted `(LET·w, w)` → `data/data2` [MeV/cm] |
 | `DQEFF`   | `osh_scoring_estimator_step_dqeff`   | — | `postprocess_ratio` | dose-weighted `((z_eff/β)²·w, w)` → `data/data2` |
 | `TQEFF`   | `osh_scoring_estimator_step_tqeff`   | — | `postprocess_ratio` | track-weighted `((z_eff/β)²·w, w)` → `data/data2` |
+| `DAVGE`   | `osh_scoring_estimator_step_davge`   | — | `postprocess_ratio` | dose-weighted `(E_kin·w, w)` → `data/data2` [MeV] |
+| `TAVGE`   | `osh_scoring_estimator_step_tavge`   | — | `postprocess_ratio` | track-weighted `(E_kin·w, w)` → `data/data2` [MeV] |
+| `DBETA`   | `osh_scoring_estimator_step_dbeta`   | — | `postprocess_ratio` | dose-weighted `(β·w, w)` → `data/data2` |
+| `TBETA`   | `osh_scoring_estimator_step_tbeta`   | — | `postprocess_ratio` | track-weighted `(β·w, w)` → `data/data2` |
 | `NKERMA`  | —                    | — | `postprocess_volume` | (neutron kerma) → ÷volume [MeV/g] |
 
 **Adding a `Quantity`** = write its handler(s), then add one row to the registry
@@ -349,7 +355,7 @@ one of these states:
 |---|---|---|
 | NORM (DOSE, FLUENCE, …) | intensive per-primary sum (÷volume applied) | divide by `nstat` |
 | NORM (ENERGY, …) | raw accumulated sum (no transform) | divide by `nstat` |
-| AVER (DLET, TLET, DQEFF, TQEFF) | physical mean (`data ÷ data2` done) | none — written as-is |
+| AVER (DLET, TLET, DQEFF, TQEFF, DAVGE, TAVGE, DBETA, TBETA) | physical mean (`data ÷ data2` done) | none — written as-is |
 | SUM (COUNT, …) | raw count | none |
 
 **Merging caveat**: AVER pages cannot be naively summed across BDO files

--- a/docs/user/detect.dat.md
+++ b/docs/user/detect.dat.md
@@ -142,7 +142,8 @@ Supported axis type keywords (same for Diff1Type and Diff2Type):
 | `QEFF` | `ZEFF2BETA2` | (z_eff/β)² |
 
 Differential scoring is supported for `Fluence`, `Dose`, `DoseGy`, and `Energy`.
-Averaged quantities (`DLET`, `TLET`, `DQEFF`, `TQEFF`) cannot carry a differential axis.
+Averaged quantities (`DLET`, `TLET`, `DQEFF`, `TQEFF`, `DAVGE`, `TAVGE`, `DBETA`, `TBETA`)
+cannot carry a differential axis.
 Additive differential pages are reported as differential quantities: after
 spatial postprocessing, each bin is divided by the width of its `Diff1` bin, and
 by the product of `Diff1` and `Diff2` widths for double-differential pages.  For
@@ -230,6 +231,10 @@ outer (slow) loop and Diff2 bins are the inner (fast) loop:
 | `TLET` | MeV/cm | Track-averaged LET |
 | `DQEFF` | dim.less | Dose-averaged `(z_eff/beta)^2` |
 | `TQEFF` | dim.less | Track-averaged `(z_eff/beta)^2` |
+| `DAVGE` | MeV | Dose-averaged kinetic energy |
+| `TAVGE` | MeV | Track-averaged kinetic energy |
+| `DBETA` | dim.less | Dose-averaged relative speed `beta = v/c` |
+| `TBETA` | dim.less | Track-averaged relative speed `beta = v/c` |
 
 Quantities can be restricted to a material via `Settings`:
 
@@ -262,6 +267,18 @@ medium — the override medium. So assuming a user-defined `inWater` settings ov
 then `DirtyDose inWater` scores dose-to-water **and**
 compares the mass-LET *in water* against the fixed threshold.
 A density-only override does not change the mass-LET (Fano-invariant).
+
+### Average kinetic energy and beta
+
+`DAVGE`/`TAVGE` and `DBETA`/`TBETA` are dose- and track-averaged quantities built
+the same way as `DLET`/`TLET` and `DQEFF`/`TQEFF`: each contributing step books a
+per-step scalar — kinetic energy at the step midpoint, or the corresponding
+relative speed `beta = v/c` — weighted by the energy deposited in the bin
+(dose-averaged) or by the physical track length in the bin (track-averaged).
+
+Unlike `DLET`/`TLET`/`DQEFF`/`TQEFF`, kinetic energy and beta are well-defined for
+**any** particle, including neutrals and photons, so `DAVGE`/`TAVGE`/`DBETA`/`TBETA`
+apply no charge gate and require no stopping-power table.
 
 ## Statistical uncertainty (error bars)
 
@@ -305,9 +322,10 @@ immediately after its value column, e.g.
 The error is the standard error of that cell's reported value, in the **same
 units** (it already carries the per-primary or physical-mean scaling), so a plot
 can use it directly as a `± ` bar.  For the averaged quantities (`DLET`, `TLET`,
-`DQEFF`, `TQEFF`) the numerator and denominator errors are combined in
-quadrature; ignoring their (strong, positive) correlation makes this a slightly
-**conservative** over-estimate, never an under-estimate.
+`DQEFF`, `TQEFF`, `DAVGE`, `TAVGE`, `DBETA`, `TBETA`) the numerator and
+denominator errors are combined in quadrature; ignoring their (strong, positive)
+correlation makes this a slightly **conservative** over-estimate, never an
+under-estimate.
 
 **Cost & scope.** Enabling `Variance On` roughly doubles the scoring memory of the
 affected pages (a companion sum-of-squares array per accumulator) and adds one

--- a/src/scoring/runtime/osh_scoring_compile.c
+++ b/src/scoring/runtime/osh_scoring_compile.c
@@ -97,6 +97,18 @@ static enum osh_scoring_score_kind quantity_to_score_kind(char const *quantity) 
     if (strcmp(quantity, "tqeff") == 0) {
         return OSH_SCORING_SCORE_TQEFF;
     }
+    if (strcmp(quantity, "davge") == 0) {
+        return OSH_SCORING_SCORE_DAVGE;
+    }
+    if (strcmp(quantity, "tavge") == 0) {
+        return OSH_SCORING_SCORE_TAVGE;
+    }
+    if (strcmp(quantity, "dbeta") == 0) {
+        return OSH_SCORING_SCORE_DBETA;
+    }
+    if (strcmp(quantity, "tbeta") == 0) {
+        return OSH_SCORING_SCORE_TBETA;
+    }
     return OSH_SCORING_SCORE_UNKNOWN;
 }
 
@@ -187,6 +199,10 @@ static char score_kind_uses_data2(enum osh_scoring_score_kind score_kind) {
     case OSH_SCORING_SCORE_TLET:
     case OSH_SCORING_SCORE_DQEFF:
     case OSH_SCORING_SCORE_TQEFF:
+    case OSH_SCORING_SCORE_DAVGE:
+    case OSH_SCORING_SCORE_TAVGE:
+    case OSH_SCORING_SCORE_DBETA:
+    case OSH_SCORING_SCORE_TBETA:
         return 1;
     default:
         return 0;
@@ -395,6 +411,10 @@ static int runtime_supports_score_kind(enum osh_scoring_score_kind score_kind) {
     case OSH_SCORING_SCORE_TLET:
     case OSH_SCORING_SCORE_DQEFF:
     case OSH_SCORING_SCORE_TQEFF:
+    case OSH_SCORING_SCORE_DAVGE:
+    case OSH_SCORING_SCORE_TAVGE:
+    case OSH_SCORING_SCORE_DBETA:
+    case OSH_SCORING_SCORE_TBETA:
         return 1;
     default:
         return 0;
@@ -1050,9 +1070,10 @@ enum osh_status osh_scoring_compile(struct osh_scoring_workspace const *ws,
         dst_page->diff_stride = rt->geometries[dst_page->geometry_idx].nbins;
         if (src_page->diff_nbins > 0u) {
             if (dst_page->has_data2) {
-                /* Two-pass averaged quantities (DLET, TLET, DQEFF, TQEFF) cannot be
-                 * used as the primary quantity of a differential scorer because the
-                 * two-pass postprocessor operates on the full flat array. */
+                /* Two-pass averaged quantities (DLET, TLET, DQEFF, TQEFF, DAVGE,
+                 * TAVGE, DBETA, TBETA) cannot be used as the primary quantity of a
+                 * differential scorer because the two-pass postprocessor operates
+                 * on the full flat array. */
                 OSH_DIAG_ERRORF(diag,
                                 "Scoring page '%s': differential axis not supported for averaged quantities",
                                 src_page->quantity ? src_page->quantity : "(unnamed)");

--- a/src/scoring/runtime/osh_scoring_defs.h
+++ b/src/scoring/runtime/osh_scoring_defs.h
@@ -162,6 +162,8 @@ enum osh_scoring_filter_op {
  * COUNT   [1]           raw event count (no normalisation)
  * NKERMA  [MeV/g]       neutron kerma (no Gy conversion yet)
  * QEFF    [dim.less]    dose/track-averaged (z_eff/β)²
+ * AVGE    [MeV]         dose/track-averaged kinetic energy
+ * BETA    [dim.less]    dose/track-averaged v/c
  */
 enum osh_scoring_score_kind {
 
@@ -204,8 +206,15 @@ enum osh_scoring_score_kind {
 
     /* --- LET-gated ("dirty") dose ----------------------------------------- */
 
-    OSH_SCORING_SCORE_DIRTYDOSE = 15,  /* dose [MeV/g] from charged particles with mass-LET > threshold */
-    OSH_SCORING_SCORE_DIRTYDOSEGY = 16 /* dose [Gy] from charged particles with mass-LET > threshold */
+    OSH_SCORING_SCORE_DIRTYDOSE = 15,   /* dose [MeV/g] from charged particles with mass-LET > threshold */
+    OSH_SCORING_SCORE_DIRTYDOSEGY = 16, /* dose [Gy] from charged particles with mass-LET > threshold */
+
+    /* --- Kinetic-energy- and velocity-averaged quantities ---------------- */
+
+    OSH_SCORING_SCORE_DAVGE = 17, /* dose-averaged kinetic energy  [MeV] */
+    OSH_SCORING_SCORE_TAVGE = 18, /* track-averaged kinetic energy [MeV] */
+    OSH_SCORING_SCORE_DBETA = 19, /* dose-averaged v/c  [dimensionless] */
+    OSH_SCORING_SCORE_TBETA = 20  /* track-averaged v/c [dimensionless] */
 };
 
 #ifdef __cplusplus

--- a/src/scoring/runtime/osh_scoring_estimator.c
+++ b/src/scoring/runtime/osh_scoring_estimator.c
@@ -26,6 +26,10 @@ static struct osh_scoring_estimator const k_dlet = {osh_scoring_estimator_step_d
 static struct osh_scoring_estimator const k_tlet = {osh_scoring_estimator_step_tlet, NULL, postprocess_ratio};
 static struct osh_scoring_estimator const k_dqeff = {osh_scoring_estimator_step_dqeff, NULL, postprocess_ratio};
 static struct osh_scoring_estimator const k_tqeff = {osh_scoring_estimator_step_tqeff, NULL, postprocess_ratio};
+static struct osh_scoring_estimator const k_davge = {osh_scoring_estimator_step_davge, NULL, postprocess_ratio};
+static struct osh_scoring_estimator const k_tavge = {osh_scoring_estimator_step_tavge, NULL, postprocess_ratio};
+static struct osh_scoring_estimator const k_dbeta = {osh_scoring_estimator_step_dbeta, NULL, postprocess_ratio};
+static struct osh_scoring_estimator const k_tbeta = {osh_scoring_estimator_step_tbeta, NULL, postprocess_ratio};
 static struct osh_scoring_estimator const k_nkerma = {NULL, NULL, postprocess_volume};
 
 struct osh_scoring_estimator const *osh_scoring_estimator_for(enum osh_scoring_score_kind kind) {
@@ -50,6 +54,14 @@ struct osh_scoring_estimator const *osh_scoring_estimator_for(enum osh_scoring_s
         return &k_dqeff;
     case OSH_SCORING_SCORE_TQEFF:
         return &k_tqeff;
+    case OSH_SCORING_SCORE_DAVGE:
+        return &k_davge;
+    case OSH_SCORING_SCORE_TAVGE:
+        return &k_tavge;
+    case OSH_SCORING_SCORE_DBETA:
+        return &k_dbeta;
+    case OSH_SCORING_SCORE_TBETA:
+        return &k_tbeta;
     case OSH_SCORING_SCORE_NKERMA:
         return &k_nkerma;
     default:

--- a/src/scoring/runtime/osh_scoring_estimator_internal.h
+++ b/src/scoring/runtime/osh_scoring_estimator_internal.h
@@ -88,6 +88,42 @@ enum osh_status osh_scoring_estimator_step_tqeff(struct osh_scoring_runtime cons
                                                  struct step const *st,
                                                  double score_len);
 
+enum osh_status osh_scoring_estimator_step_davge(struct osh_scoring_runtime const *rt,
+                                                 struct osh_scoring_accumulator *acc_set,
+                                                 struct osh_scoring_geometry_score_group const *group,
+                                                 struct osh_voxel_crossing const *crossings,
+                                                 size_t ncross,
+                                                 struct particle const *part,
+                                                 struct step const *st,
+                                                 double score_len);
+
+enum osh_status osh_scoring_estimator_step_tavge(struct osh_scoring_runtime const *rt,
+                                                 struct osh_scoring_accumulator *acc_set,
+                                                 struct osh_scoring_geometry_score_group const *group,
+                                                 struct osh_voxel_crossing const *crossings,
+                                                 size_t ncross,
+                                                 struct particle const *part,
+                                                 struct step const *st,
+                                                 double score_len);
+
+enum osh_status osh_scoring_estimator_step_dbeta(struct osh_scoring_runtime const *rt,
+                                                 struct osh_scoring_accumulator *acc_set,
+                                                 struct osh_scoring_geometry_score_group const *group,
+                                                 struct osh_voxel_crossing const *crossings,
+                                                 size_t ncross,
+                                                 struct particle const *part,
+                                                 struct step const *st,
+                                                 double score_len);
+
+enum osh_status osh_scoring_estimator_step_tbeta(struct osh_scoring_runtime const *rt,
+                                                 struct osh_scoring_accumulator *acc_set,
+                                                 struct osh_scoring_geometry_score_group const *group,
+                                                 struct osh_voxel_crossing const *crossings,
+                                                 size_t ncross,
+                                                 struct particle const *part,
+                                                 struct step const *st,
+                                                 double score_len);
+
 enum osh_status osh_scoring_estimator_point_energy(struct osh_scoring_runtime const *rt,
                                                    struct osh_scoring_accumulator *acc_set,
                                                    struct osh_scoring_geometry_score_group const *group,

--- a/src/scoring/runtime/osh_scoring_estimator_step.c
+++ b/src/scoring/runtime/osh_scoring_estimator_step.c
@@ -545,3 +545,229 @@ enum osh_status osh_scoring_estimator_step_tqeff(struct osh_scoring_runtime cons
     }
     return OSH_OK;
 }
+
+/**
+ * @brief Accumulate dose-averaged kinetic energy [MeV] via a two-pass accumulator.
+ *
+ * Averages the step-midpoint kinetic energy 0.5*(p[3]+q[3]) [MeV] — the same
+ * scalar already computed for DQEFF — weighted by the per-crossing
+ * energy-deposition share.  Unlike LET/QEFF, kinetic energy is well-defined
+ * for neutrals too, so this handler applies no charge/mass gate.
+ *
+ * Raw accumulator meaning before postprocess:
+ *   acc->data  = sum(mean_energy * dose_weight) per spatial bin
+ *   acc->data2 = sum(dose_weight) per spatial bin
+ *
+ * postprocess_ratio() later returns acc->data / acc->data2, i.e. DAVGE.
+ */
+enum osh_status osh_scoring_estimator_step_davge(struct osh_scoring_runtime const *rt,
+                                                 struct osh_scoring_accumulator *acc_set,
+                                                 struct osh_scoring_geometry_score_group const *group,
+                                                 struct osh_voxel_crossing const *crossings,
+                                                 size_t ncross,
+                                                 struct particle const *part,
+                                                 struct step const *st,
+                                                 double score_len) {
+    size_t i;
+    size_t j;
+    double mean_energy;       /* kinetic energy at the step midpoint [MeV] */
+    double dose_weight;       /* energy-deposition weight for the crossed bin [MeV] */
+    double davge_numerator;   /* mean_energy * dose_weight, booked into acc->data */
+    double davge_denominator; /* dose_weight, booked into acc->data2 */
+    struct osh_scoring_page_runtime const *page;
+    struct osh_scoring_accumulator *acc;
+
+    /* Kinetic energy is a single scalar for this step; only the averaging
+     * weight varies per crossing. */
+    mean_energy = 0.5 * (st->p[3] + st->q[3]);
+
+    for (i = 0; i < group->npages; ++i) {
+        page = &rt->pages[group->first_page + i];
+        acc = &acc_set[group->first_page + i];
+        if (!osh_scoring_page_passes_filters(page, part, st)) {
+            continue;
+        }
+        /* DAVGE stores a dose-weighted average in two explicit accumulators.
+         * Differential axes are not valid for DAVGE pages, so crossing.idx is
+         * the complete bin index. */
+        for (j = 0; j < ncross; ++j) {
+            if (crossings[j].idx >= page->diff_stride) {
+                return OSH_ESTATE;
+            }
+            dose_weight = st->de * crossings[j].path_len / score_len;
+            davge_numerator = mean_energy * dose_weight;
+            davge_denominator = dose_weight;
+            osh_score_deposit(acc->data, crossings[j].idx, davge_numerator);
+            osh_score_deposit(acc->data2, crossings[j].idx, davge_denominator);
+        }
+    }
+    return OSH_OK;
+}
+
+/**
+ * @brief Accumulate track-averaged kinetic energy [MeV] via a two-pass accumulator.
+ *
+ * Same as osh_scoring_estimator_step_davge() but uses track-length ds_vox as
+ * the weight rather than dose weight.
+ *
+ * Raw accumulator meaning before postprocess:
+ *   acc->data  = sum(mean_energy * track_weight) per spatial bin
+ *   acc->data2 = sum(track_weight) per spatial bin
+ *
+ * postprocess_ratio() later returns acc->data / acc->data2, i.e. TAVGE.
+ */
+enum osh_status osh_scoring_estimator_step_tavge(struct osh_scoring_runtime const *rt,
+                                                 struct osh_scoring_accumulator *acc_set,
+                                                 struct osh_scoring_geometry_score_group const *group,
+                                                 struct osh_voxel_crossing const *crossings,
+                                                 size_t ncross,
+                                                 struct particle const *part,
+                                                 struct step const *st,
+                                                 double score_len) {
+    size_t i;
+    size_t j;
+    double mean_energy;       /* kinetic energy at the step midpoint [MeV] */
+    double track_weight;      /* track-length weight for the crossed bin [cm] */
+    double tavge_numerator;   /* mean_energy * track_weight, booked into acc->data */
+    double tavge_denominator; /* track_weight, booked into acc->data2 */
+    struct osh_scoring_page_runtime const *page;
+    struct osh_scoring_accumulator *acc;
+
+    mean_energy = 0.5 * (st->p[3] + st->q[3]);
+
+    for (i = 0; i < group->npages; ++i) {
+        page = &rt->pages[group->first_page + i];
+        acc = &acc_set[group->first_page + i];
+        if (!osh_scoring_page_passes_filters(page, part, st)) {
+            continue;
+        }
+        for (j = 0; j < ncross; ++j) {
+            if (crossings[j].idx >= page->diff_stride) {
+                return OSH_ESTATE;
+            }
+            track_weight = st->ds * crossings[j].path_len / score_len;
+            tavge_numerator = mean_energy * track_weight;
+            tavge_denominator = track_weight;
+            osh_score_deposit(acc->data, crossings[j].idx, tavge_numerator);
+            osh_score_deposit(acc->data2, crossings[j].idx, tavge_denominator);
+        }
+    }
+    return OSH_OK;
+}
+
+/**
+ * @brief Accumulate dose-averaged relative speed beta = v/c [dimensionless]
+ *        via a two-pass accumulator.
+ *
+ * beta is derived from the same step-midpoint kinetic energy as DAVGE via
+ * osh_scoring_estimator_particle_beta(), which is exact for massless
+ * particles too (part->mass == 0 for photons), so no charge/mass gate is
+ * needed.  The isnan-style guard below only rejects the degenerate case where
+ * both kinetic energy and rest mass are zero (0/0).
+ *
+ * Raw accumulator meaning before postprocess:
+ *   acc->data  = sum(beta * dose_weight) per spatial bin
+ *   acc->data2 = sum(dose_weight) per spatial bin
+ *
+ * postprocess_ratio() later returns acc->data / acc->data2, i.e. DBETA.
+ */
+enum osh_status osh_scoring_estimator_step_dbeta(struct osh_scoring_runtime const *rt,
+                                                 struct osh_scoring_accumulator *acc_set,
+                                                 struct osh_scoring_geometry_score_group const *group,
+                                                 struct osh_voxel_crossing const *crossings,
+                                                 size_t ncross,
+                                                 struct particle const *part,
+                                                 struct step const *st,
+                                                 double score_len) {
+    size_t i;
+    size_t j;
+    double mean_energy;
+    double beta;
+    double dose_weight;
+    double dbeta_numerator;
+    double dbeta_denominator;
+    struct osh_scoring_page_runtime const *page;
+    struct osh_scoring_accumulator *acc;
+
+    mean_energy = 0.5 * (st->p[3] + st->q[3]);
+    beta = osh_scoring_estimator_particle_beta(mean_energy, part->mass);
+    if (!(beta >= 0.0)) {
+        return OSH_OK;
+    }
+
+    for (i = 0; i < group->npages; ++i) {
+        page = &rt->pages[group->first_page + i];
+        acc = &acc_set[group->first_page + i];
+        if (!osh_scoring_page_passes_filters(page, part, st)) {
+            continue;
+        }
+        for (j = 0; j < ncross; ++j) {
+            if (crossings[j].idx >= page->diff_stride) {
+                return OSH_ESTATE;
+            }
+            dose_weight = st->de * crossings[j].path_len / score_len;
+            dbeta_numerator = beta * dose_weight;
+            dbeta_denominator = dose_weight;
+            osh_score_deposit(acc->data, crossings[j].idx, dbeta_numerator);
+            osh_score_deposit(acc->data2, crossings[j].idx, dbeta_denominator);
+        }
+    }
+    return OSH_OK;
+}
+
+/**
+ * @brief Accumulate track-averaged relative speed beta = v/c [dimensionless]
+ *        via a two-pass accumulator.
+ *
+ * Same as osh_scoring_estimator_step_dbeta() but uses track-length ds_vox as
+ * the weight rather than dose weight.
+ *
+ * Raw accumulator meaning before postprocess:
+ *   acc->data  = sum(beta * track_weight) per spatial bin
+ *   acc->data2 = sum(track_weight) per spatial bin
+ *
+ * postprocess_ratio() later returns acc->data / acc->data2, i.e. TBETA.
+ */
+enum osh_status osh_scoring_estimator_step_tbeta(struct osh_scoring_runtime const *rt,
+                                                 struct osh_scoring_accumulator *acc_set,
+                                                 struct osh_scoring_geometry_score_group const *group,
+                                                 struct osh_voxel_crossing const *crossings,
+                                                 size_t ncross,
+                                                 struct particle const *part,
+                                                 struct step const *st,
+                                                 double score_len) {
+    size_t i;
+    size_t j;
+    double mean_energy;
+    double beta;
+    double track_weight;
+    double tbeta_numerator;
+    double tbeta_denominator;
+    struct osh_scoring_page_runtime const *page;
+    struct osh_scoring_accumulator *acc;
+
+    mean_energy = 0.5 * (st->p[3] + st->q[3]);
+    beta = osh_scoring_estimator_particle_beta(mean_energy, part->mass);
+    if (!(beta >= 0.0)) {
+        return OSH_OK;
+    }
+
+    for (i = 0; i < group->npages; ++i) {
+        page = &rt->pages[group->first_page + i];
+        acc = &acc_set[group->first_page + i];
+        if (!osh_scoring_page_passes_filters(page, part, st)) {
+            continue;
+        }
+        for (j = 0; j < ncross; ++j) {
+            if (crossings[j].idx >= page->diff_stride) {
+                return OSH_ESTATE;
+            }
+            track_weight = st->ds * crossings[j].path_len / score_len;
+            tbeta_numerator = beta * track_weight;
+            tbeta_denominator = track_weight;
+            osh_score_deposit(acc->data, crossings[j].idx, tbeta_numerator);
+            osh_score_deposit(acc->data2, crossings[j].idx, tbeta_denominator);
+        }
+    }
+    return OSH_OK;
+}

--- a/src/scoring/runtime/osh_scoring_postprocess.c
+++ b/src/scoring/runtime/osh_scoring_postprocess.c
@@ -22,6 +22,10 @@ int osh_scoring_postprocess_writes_data(enum osh_scoring_score_kind kind) {
     case OSH_SCORING_SCORE_TLET:
     case OSH_SCORING_SCORE_DQEFF:
     case OSH_SCORING_SCORE_TQEFF:
+    case OSH_SCORING_SCORE_DAVGE:
+    case OSH_SCORING_SCORE_TAVGE:
+    case OSH_SCORING_SCORE_DBETA:
+    case OSH_SCORING_SCORE_TBETA:
         return 1;
     default:
         return 0;

--- a/src/scoring/runtime/osh_scoring_postprocess.h
+++ b/src/scoring/runtime/osh_scoring_postprocess.h
@@ -124,7 +124,7 @@ int osh_scoring_postprocess_page_writes_data(struct osh_scoring_page_runtime con
  * (osh_scoring_estimator.c).  Each finalises one page's accumulator:
  *   postprocess_volume — DOSE/FLUENCE/NKERMA: multiply each bin by geo->bin_vol_inv.
  *   postprocess_dosegy — as volume, then MeV/g -> Gy.
- *   postprocess_ratio  — DLET/TLET/DQEFF/TQEFF: finalise the data/data2 average. */
+ *   postprocess_ratio  — DLET/TLET/DQEFF/TQEFF/DAVGE/TAVGE/DBETA/TBETA: finalise the data/data2 average. */
 enum osh_status postprocess_volume(struct osh_scoring_page_runtime *dst,
                                    struct osh_scoring_page_runtime const *src,
                                    struct osh_scoring_geometry_runtime const *geo);

--- a/src/scoring/runtime/osh_scoring_step.h
+++ b/src/scoring/runtime/osh_scoring_step.h
@@ -18,7 +18,8 @@ extern "C" {
  * This is the hot-path entry for step-based scorers.  The current
  * implementation supports Mesh (X,Y,Z), Cyl (R,Z), and Zone geometries and the
  * step-based page kinds implemented in osh_scoring_step.c (ENERGY, FLUENCE,
- * DOSE, DOSEGY, DLET, TLET, DQEFF, TQEFF).
+ * DOSE, DOSEGY, DIRTYDOSE, DIRTYDOSEGY, DLET, TLET, DQEFF, TQEFF, DAVGE,
+ * TAVGE, DBETA, TBETA).
  *
  * @p rt is the read-only compiled descriptor (bin layout, filters, geometry,
  * group ranges); the deposit path never writes through it.  @p acc_set is the

--- a/src/scoring/save/osh_scoring_save_bdo2019.c
+++ b/src/scoring/save/osh_scoring_save_bdo2019.c
@@ -610,13 +610,18 @@ static int legacy_score_kind(struct osh_scoring_page_runtime const *page) {
         return 13;
     case OSH_SCORING_SCORE_MCPL:
         return 63;
-    case OSH_SCORING_SCORE_DAVGE:
-        return 64;
+    /* Track-averaged kinetic energy and beta reuse the existing SH12A
+     * detector-type IDs (SH_SDET_AVGENERGY = 8, SH_SDET_AVGBETA = 9); both are
+     * track-averaged in SH12A.  SH12A has no dose-averaged counterparts, so
+     * DAVGE/DBETA take the next free IDs (66, 67).  64/65 are reserved for
+     * DIRTYDOSE/DIRTYDOSEGY and must not be reused here. */
     case OSH_SCORING_SCORE_TAVGE:
-        return 65;
-    case OSH_SCORING_SCORE_DBETA:
-        return 66;
+        return 8;
     case OSH_SCORING_SCORE_TBETA:
+        return 9;
+    case OSH_SCORING_SCORE_DAVGE:
+        return 66;
+    case OSH_SCORING_SCORE_DBETA:
         return 67;
     default:
         return -1;

--- a/src/scoring/save/osh_scoring_save_bdo2019.c
+++ b/src/scoring/save/osh_scoring_save_bdo2019.c
@@ -310,7 +310,12 @@ static char const *page_data_unit(struct osh_scoring_page_runtime const *page) {
         return "MeV/cm";
     case OSH_SCORING_SCORE_DQEFF:
     case OSH_SCORING_SCORE_TQEFF:
+    case OSH_SCORING_SCORE_DBETA:
+    case OSH_SCORING_SCORE_TBETA:
         return "dim.less";
+    case OSH_SCORING_SCORE_DAVGE:
+    case OSH_SCORING_SCORE_TAVGE:
+        return "MeV";
     default:
         return "arb";
     }
@@ -605,6 +610,14 @@ static int legacy_score_kind(struct osh_scoring_page_runtime const *page) {
         return 13;
     case OSH_SCORING_SCORE_MCPL:
         return 63;
+    case OSH_SCORING_SCORE_DAVGE:
+        return 64;
+    case OSH_SCORING_SCORE_TAVGE:
+        return 65;
+    case OSH_SCORING_SCORE_DBETA:
+        return 66;
+    case OSH_SCORING_SCORE_TBETA:
+        return 67;
     default:
         return -1;
     }

--- a/tests/unit/test_osh_scoring_postprocess_into.c
+++ b/tests/unit/test_osh_scoring_postprocess_into.c
@@ -35,10 +35,12 @@ make_page(struct osh_scoring_page_runtime *p, enum osh_scoring_score_kind kind, 
     p->score_kind = kind;
     p->has_data2 = (char) (want_data2 ? 1 : 0);
     p->divide = 0;
-    p->postproc = (kind == OSH_SCORING_SCORE_DLET || kind == OSH_SCORING_SCORE_TLET || kind == OSH_SCORING_SCORE_DQEFF
-                   || kind == OSH_SCORING_SCORE_TQEFF)
-                      ? OSH_SCORING_POSTPROC_AVER
-                      : OSH_SCORING_POSTPROC_NONE;
+    p->postproc =
+        (kind == OSH_SCORING_SCORE_DLET || kind == OSH_SCORING_SCORE_TLET || kind == OSH_SCORING_SCORE_DQEFF
+         || kind == OSH_SCORING_SCORE_TQEFF || kind == OSH_SCORING_SCORE_DAVGE || kind == OSH_SCORING_SCORE_TAVGE
+         || kind == OSH_SCORING_SCORE_DBETA || kind == OSH_SCORING_SCORE_TBETA)
+            ? OSH_SCORING_POSTPROC_AVER
+            : OSH_SCORING_POSTPROC_NONE;
 }
 
 static void make_runtime(struct osh_scoring_runtime *rt, struct osh_scoring_page_runtime *pages, size_t npages) {
@@ -55,6 +57,10 @@ static void test_writes_data_predicate(void) {
     ASSERT_TRUE(osh_scoring_postprocess_writes_data(OSH_SCORING_SCORE_TLET) == 1);
     ASSERT_TRUE(osh_scoring_postprocess_writes_data(OSH_SCORING_SCORE_DQEFF) == 1);
     ASSERT_TRUE(osh_scoring_postprocess_writes_data(OSH_SCORING_SCORE_TQEFF) == 1);
+    ASSERT_TRUE(osh_scoring_postprocess_writes_data(OSH_SCORING_SCORE_DAVGE) == 1);
+    ASSERT_TRUE(osh_scoring_postprocess_writes_data(OSH_SCORING_SCORE_TAVGE) == 1);
+    ASSERT_TRUE(osh_scoring_postprocess_writes_data(OSH_SCORING_SCORE_DBETA) == 1);
+    ASSERT_TRUE(osh_scoring_postprocess_writes_data(OSH_SCORING_SCORE_TBETA) == 1);
 
     /* DOSE/FLUENCE (and NKERMA) now transform in postprocess too — they divide by
      * the per-bin volume, so they write data out-of-place like DOSEGY/LET. */

--- a/tests/unit/test_osh_scoring_postprocess_into.c
+++ b/tests/unit/test_osh_scoring_postprocess_into.c
@@ -26,6 +26,23 @@
 
 static void assert_bytes_equal(unsigned char const *expected, unsigned char const *actual, size_t nbytes);
 
+/* True for the two-pass AVER score kinds exercised by this test file. */
+static int kind_is_aver(enum osh_scoring_score_kind kind) {
+    switch (kind) {
+    case OSH_SCORING_SCORE_DLET:
+    case OSH_SCORING_SCORE_TLET:
+    case OSH_SCORING_SCORE_DQEFF:
+    case OSH_SCORING_SCORE_TQEFF:
+    case OSH_SCORING_SCORE_DAVGE:
+    case OSH_SCORING_SCORE_TAVGE:
+    case OSH_SCORING_SCORE_DBETA:
+    case OSH_SCORING_SCORE_TBETA:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
 /* Build a single page descriptor with an allocated accumulator. */
 static void
 make_page(struct osh_scoring_page_runtime *p, enum osh_scoring_score_kind kind, size_t len, int want_data2) {
@@ -35,12 +52,11 @@ make_page(struct osh_scoring_page_runtime *p, enum osh_scoring_score_kind kind, 
     p->score_kind = kind;
     p->has_data2 = (char) (want_data2 ? 1 : 0);
     p->divide = 0;
-    p->postproc =
-        (kind == OSH_SCORING_SCORE_DLET || kind == OSH_SCORING_SCORE_TLET || kind == OSH_SCORING_SCORE_DQEFF
-         || kind == OSH_SCORING_SCORE_TQEFF || kind == OSH_SCORING_SCORE_DAVGE || kind == OSH_SCORING_SCORE_TAVGE
-         || kind == OSH_SCORING_SCORE_DBETA || kind == OSH_SCORING_SCORE_TBETA)
-            ? OSH_SCORING_POSTPROC_AVER
-            : OSH_SCORING_POSTPROC_NONE;
+    if (kind_is_aver(kind)) {
+        p->postproc = OSH_SCORING_POSTPROC_AVER;
+    } else {
+        p->postproc = OSH_SCORING_POSTPROC_NONE;
+    }
 }
 
 static void make_runtime(struct osh_scoring_runtime *rt, struct osh_scoring_page_runtime *pages, size_t npages) {

--- a/tests/unit/test_osh_scoring_save.c
+++ b/tests/unit/test_osh_scoring_save.c
@@ -44,7 +44,11 @@ static void test_save_bdo2019_with_dose_and_dlet(void) {
                               "    Quantity DLET\n"
                               "    Quantity TLET\n"
                               "    Quantity DQEFF\n"
-                              "    Quantity TQEFF\n";
+                              "    Quantity TQEFF\n"
+                              "    Quantity DAVGE\n"
+                              "    Quantity TAVGE\n"
+                              "    Quantity DBETA\n"
+                              "    Quantity TBETA\n";
     struct osh_scoring_workspace *ws;
     struct osh_scoring_runtime rt;
     unsigned char bdo_head[6];
@@ -59,7 +63,7 @@ static void test_save_bdo2019_with_dose_and_dlet(void) {
     ASSERT_TRUE(rc == OSH_OK);
     rc = osh_scoring_compile(ws, NULL, &rt);
     ASSERT_TRUE(rc == OSH_OK);
-    ASSERT_TRUE(rt.npages == 5u);
+    ASSERT_TRUE(rt.npages == 9u);
 
     /* Seed non-zero values and wire data2 (two-pass pages) with matching weights */
     for (i = 0; i < rt.npages; ++i) {

--- a/tests/unit/test_osh_scoring_step.c
+++ b/tests/unit/test_osh_scoring_step.c
@@ -563,6 +563,185 @@ static void test_score_mesh_dqeff_tqeff(void) {
     osh_scoring_workspace_free(ws);
 }
 
+/* Verify DAVGE and TAVGE produce the step-midpoint kinetic energy, and DBETA
+ * and TBETA produce the corresponding beta = v/c, dose- and track-averaged.
+ * A single monoenergetic step contributes the same scalar to every crossed
+ * bin, so the two-pass ratio equals that scalar regardless of the per-bin
+ * dose/track weight — mirrors test_score_mesh_dqeff_tqeff(), but needs no
+ * mat_tables since kinetic energy and beta are derived from the step and
+ * part.mass alone. */
+static void test_score_mesh_davge_tavge_dbeta_tbeta(void) {
+    char path[512];
+    char const *detect = "Geometry Mesh\n"
+                         "    Name G\n"
+                         "    X -0.5 0.5 1\n"
+                         "    Y -0.5 0.5 1\n"
+                         "    Z  0.0 3.0 3\n"
+                         "\n"
+                         "Output\n"
+                         "    Filename out.bdo\n"
+                         "    Geo G\n"
+                         "    Quantity DAVGE\n"
+                         "    Quantity TAVGE\n"
+                         "    Quantity DBETA\n"
+                         "    Quantity TBETA\n";
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle part;
+    struct step st;
+    struct osh_scoring_page_runtime *davge_page;
+    struct osh_scoring_page_runtime *tavge_page;
+    struct osh_scoring_page_runtime *dbeta_page;
+    struct osh_scoring_page_runtime *tbeta_page;
+    double proton_mass_mev = 938.272046;
+    double mean_energy;
+    double gamma_inv;
+    double expected_beta;
+    enum osh_status rc;
+
+    write_temp_file(path, sizeof(path), detect);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+    /* mat_tables stays NULL: DAVGE/TAVGE/DBETA/TBETA need only part.mass, no SP tables. */
+
+    memset(&part, 0, sizeof(part));
+    part.z = 1u;
+    part.a = 1u;
+    part.mass = proton_mass_mev;
+
+    memset(&st, 0, sizeof(st));
+    st.p[0] = 0.0;
+    st.p[1] = 0.0;
+    st.p[2] = 0.5;
+    st.p[3] = 150.0;
+    st.q[0] = 0.0;
+    st.q[1] = 0.0;
+    st.q[2] = 2.5;
+    st.q[3] = 148.0;
+    st.v[0] = 0.0;
+    st.v[1] = 0.0;
+    st.v[2] = 1.0;
+    st.ds = 2.0;
+    st.de = 2.0;
+    st.rho = 1.0;
+    st.wt = 1.0;
+    st.medium = 0;
+
+    rc = osh_scoring_score_step(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    rc = osh_scoring_postprocess(&rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    mean_energy = 0.5 * (150.0 + 148.0);
+    gamma_inv = proton_mass_mev / (mean_energy + proton_mass_mev);
+    expected_beta = sqrt(1.0 - (gamma_inv * gamma_inv));
+
+    davge_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DAVGE);
+    ASSERT_TRUE(davge_page != NULL);
+    assert_close(davge_page->acc.data[0], mean_energy);
+    assert_close(davge_page->acc.data[1], mean_energy);
+    assert_close(davge_page->acc.data[2], mean_energy);
+
+    tavge_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_TAVGE);
+    ASSERT_TRUE(tavge_page != NULL);
+    assert_close(tavge_page->acc.data[0], mean_energy);
+    assert_close(tavge_page->acc.data[1], mean_energy);
+    assert_close(tavge_page->acc.data[2], mean_energy);
+
+    dbeta_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DBETA);
+    ASSERT_TRUE(dbeta_page != NULL);
+    assert_close(dbeta_page->acc.data[0], expected_beta);
+    assert_close(dbeta_page->acc.data[1], expected_beta);
+    assert_close(dbeta_page->acc.data[2], expected_beta);
+
+    tbeta_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_TBETA);
+    ASSERT_TRUE(tbeta_page != NULL);
+    assert_close(tbeta_page->acc.data[0], expected_beta);
+    assert_close(tbeta_page->acc.data[1], expected_beta);
+    assert_close(tbeta_page->acc.data[2], expected_beta);
+
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+    remove(path);
+}
+
+/* Unlike DLET/TLET/DQEFF/TQEFF, average-kinetic-energy scoring is defined for
+ * neutrals too: kinetic energy needs no charge, so DAVGE/TAVGE apply no
+ * part->z/part->a gate. */
+static void test_score_mesh_davge_neutral(void) {
+    char path[512];
+    char const *detect = "Geometry Mesh\n"
+                         "    Name G\n"
+                         "    X -0.5 0.5 1\n"
+                         "    Y -0.5 0.5 1\n"
+                         "    Z  0.0 1.0 1\n"
+                         "\n"
+                         "Output\n"
+                         "    Filename out.bdo\n"
+                         "    Geo G\n"
+                         "    Quantity DAVGE\n"
+                         "    Quantity TAVGE\n";
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle part;
+    struct step st;
+    struct osh_scoring_page_runtime *davge_page;
+    struct osh_scoring_page_runtime *tavge_page;
+    double mean_energy;
+    enum osh_status rc;
+
+    write_temp_file(path, sizeof(path), detect);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&part, 0, sizeof(part));
+    part.z = 0u; /* neutral, e.g. neutron; mass left unset (0.0) */
+    part.a = 0u;
+
+    memset(&st, 0, sizeof(st));
+    st.p[2] = 0.0;
+    st.p[3] = 10.0;
+    st.q[2] = 1.0;
+    st.q[3] = 9.0;
+    st.v[2] = 1.0;
+    st.ds = 1.0;
+    st.de = 1.0;
+    st.rho = 1.0;
+    st.wt = 1.0;
+    st.medium = 0;
+
+    rc = osh_scoring_score_step(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    rc = osh_scoring_postprocess(&rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    mean_energy = 0.5 * (10.0 + 9.0);
+
+    davge_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DAVGE);
+    ASSERT_TRUE(davge_page != NULL);
+    assert_close(davge_page->acc.data[0], mean_energy);
+
+    tavge_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_TAVGE);
+    ASSERT_TRUE(tavge_page != NULL);
+    assert_close(tavge_page->acc.data[0], mean_energy);
+
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+    remove(path);
+}
+
 /* LET and QEFF can be differential-axis values for ordinary extensive scores
  * such as FLUENCE.  They are not the same thing as the averaged quantities DLET,
  * TLET, DQEFF, and TQEFF.  This test verifies that a FLUENCE page can bin track
@@ -909,6 +1088,8 @@ int main(void) {
     test_score_mesh_neutron_id_filter();
     test_score_mesh_dose_and_let_geometric();
     test_score_mesh_dqeff_tqeff();
+    test_score_mesh_davge_tavge_dbeta_tbeta();
+    test_score_mesh_davge_neutral();
     test_score_mesh_fluence_diff_let_qeff();
     test_score_zone_energy_fluence_dose();
     test_score_private_then_merge_equals_direct();

--- a/tests/unit/test_osh_scoring_step.c
+++ b/tests/unit/test_osh_scoring_step.c
@@ -742,6 +742,144 @@ static void test_score_mesh_davge_neutral(void) {
     remove(path);
 }
 
+/* A page whose filter never matches must be skipped entirely (no deposit into
+ * either accumulator array), for all four new score kinds. */
+static void test_score_mesh_davge_dbeta_filtered_out(void) {
+    char path[512];
+    char const *detect = "Filter\n"
+                         "    Name NeverMatches\n"
+                         "    Z = 99\n"
+                         "\n"
+                         "Geometry Mesh\n"
+                         "    Name G\n"
+                         "    X -0.5 0.5 1\n"
+                         "    Y -0.5 0.5 1\n"
+                         "    Z  0.0 1.0 1\n"
+                         "\n"
+                         "Output\n"
+                         "    Filename out.bdo\n"
+                         "    Geo G\n"
+                         "    Quantity DAVGE NeverMatches\n"
+                         "    Quantity TAVGE NeverMatches\n"
+                         "    Quantity DBETA NeverMatches\n"
+                         "    Quantity TBETA NeverMatches\n";
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle part;
+    struct step st;
+    size_t i;
+    enum osh_status rc;
+
+    write_temp_file(path, sizeof(path), detect);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&part, 0, sizeof(part));
+    part.z = 1u;
+    part.a = 1u;
+    part.mass = 938.272046;
+
+    memset(&st, 0, sizeof(st));
+    st.p[2] = 0.0;
+    st.p[3] = 150.0;
+    st.q[2] = 1.0;
+    st.q[3] = 148.0;
+    st.v[2] = 1.0;
+    st.ds = 1.0;
+    st.de = 2.0;
+    st.rho = 1.0;
+    st.wt = 1.0;
+    st.medium = 0;
+
+    rc = osh_scoring_score_step(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    rc = osh_scoring_postprocess(&rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    ASSERT_TRUE(rt.npages == 4u);
+    for (i = 0; i < rt.npages; ++i) {
+        assert_close(rt.pages[i].acc.data[0], 0.0);
+    }
+
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+    remove(path);
+}
+
+/* A fully-absorbed photon (zero kinetic energy at both step endpoints, zero
+ * rest mass) makes beta a literal 0/0 -> NaN.  DBETA/TBETA must recognise this
+ * and skip the step rather than book a NaN into the accumulator. */
+static void test_score_mesh_dbeta_massless_zero_energy(void) {
+    char path[512];
+    char const *detect = "Geometry Mesh\n"
+                         "    Name G\n"
+                         "    X -0.5 0.5 1\n"
+                         "    Y -0.5 0.5 1\n"
+                         "    Z  0.0 1.0 1\n"
+                         "\n"
+                         "Output\n"
+                         "    Filename out.bdo\n"
+                         "    Geo G\n"
+                         "    Quantity DBETA\n"
+                         "    Quantity TBETA\n";
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle part;
+    struct step st;
+    struct osh_scoring_page_runtime *dbeta_page;
+    struct osh_scoring_page_runtime *tbeta_page;
+    enum osh_status rc;
+
+    write_temp_file(path, sizeof(path), detect);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&part, 0, sizeof(part));
+    part.z = 0u; /* photon: zero rest mass */
+    part.a = 0u;
+
+    memset(&st, 0, sizeof(st));
+    st.p[2] = 0.0;
+    st.p[3] = 0.0; /* fully absorbed: zero kinetic energy at both step endpoints */
+    st.q[2] = 1.0;
+    st.q[3] = 0.0;
+    st.v[2] = 1.0;
+    st.ds = 1.0;
+    st.de = 1.0;
+    st.rho = 1.0;
+    st.wt = 1.0;
+    st.medium = 0;
+
+    rc = osh_scoring_score_step(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    rc = osh_scoring_postprocess(&rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    dbeta_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DBETA);
+    ASSERT_TRUE(dbeta_page != NULL);
+    assert_close(dbeta_page->acc.data[0], 0.0);
+
+    tbeta_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_TBETA);
+    ASSERT_TRUE(tbeta_page != NULL);
+    assert_close(tbeta_page->acc.data[0], 0.0);
+
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+    remove(path);
+}
+
 /* LET and QEFF can be differential-axis values for ordinary extensive scores
  * such as FLUENCE.  They are not the same thing as the averaged quantities DLET,
  * TLET, DQEFF, and TQEFF.  This test verifies that a FLUENCE page can bin track
@@ -1090,6 +1228,8 @@ int main(void) {
     test_score_mesh_dqeff_tqeff();
     test_score_mesh_davge_tavge_dbeta_tbeta();
     test_score_mesh_davge_neutral();
+    test_score_mesh_davge_dbeta_filtered_out();
+    test_score_mesh_dbeta_massless_zero_energy();
     test_score_mesh_fluence_diff_let_qeff();
     test_score_zone_energy_fluence_dose();
     test_score_private_then_merge_equals_direct();

--- a/tests/unit/test_osh_scoring_step.c
+++ b/tests/unit/test_osh_scoring_step.c
@@ -705,7 +705,7 @@ static void test_score_mesh_davge_neutral(void) {
     ASSERT_TRUE(rc == OSH_OK);
 
     memset(&part, 0, sizeof(part));
-    part.z = 0u; /* neutral, e.g. neutron; mass left unset (0.0) */
+    part.z = 0u; /* neutral, e.g. photon; mass left unset (0.0) */
     part.a = 0u;
 
     memset(&st, 0, sizeof(st));


### PR DESCRIPTION
## Summary
- Adds `DAVGE`/`TAVGE` (dose-/track-averaged kinetic energy, MeV) and `DBETA`/`TBETA` (dose-/track-averaged v/c, dimensionless), following the exact two-pass `AVER` pattern already used by `DLET`/`TLET` and `DQEFF`/`TQEFF`.
- Unlike LET/QEFF, kinetic energy and beta are well-defined for any particle (including neutrals and photons), so the new `score_step` handlers apply no charge/mass gate and need no stopping-power table — `osh_scoring_estimator_particle_beta()` is exact for massless particles (photon rest mass is 0 in the particle DB).
- Reuses `postprocess_ratio` verbatim (no new postprocess code).
- Also backfills a couple of doc gaps found while touching these files: `docs/dev/scoring.md`'s estimator table and `osh_scoring_step.h`'s doc comment were missing `DIRTYDOSE`/`DIRTYDOSEGY` rows from an earlier PR (#290).

## Test plan
- [x] `cmake --build --preset debug --parallel`
- [x] `ctest --test-dir build_debug --output-on-failure` — 141/141 runnable tests pass (13 `reference::` tests skipped, pre-existing — they require an external SH12A reference binary)
- [x] New unit tests in `tests/unit/test_osh_scoring_step.c`: a monoenergetic-proton case (mirrors the existing `DQEFF`/`TQEFF` test) and a neutral-particle case proving `DAVGE`/`TAVGE` score particles with no charge, unlike `DLET`/`TLET`/`DQEFF`/`TQEFF`
- [x] Extended `tests/unit/test_osh_scoring_postprocess_into.c` (AVER-kind classification) and `tests/unit/test_osh_scoring_save.c` (BDO2019 save path exercises the new units/legacy codes)
- [x] `clang-format` applied to all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)