### PR TITLE
tests: clean up osh_run() output directories left by test_osh_run_dump

### DIFF
--- a/src/common/osh_file.c
+++ b/src/common/osh_file.c
@@ -381,13 +381,15 @@ enum osh_status osh_path_ensure_dir(char const *path) {
 }
 
 /**
- * @brief Remove @p path and the non-directory entries directly inside it.
+ * @brief Remove @p path and the regular files directly inside it.
  *
  * @details
  * Counterpart to osh_path_ensure_dir(): walks the directory once via
- * osh_dir_foreach_file(), removing each file, then removes the now-empty
- * directory itself. A missing @p path is treated as success so callers can
- * use it unconditionally in test teardown.
+ * osh_dir_foreach_file() (which only visits regular files, not
+ * subdirectories), removing each one, then removes the now-empty directory
+ * itself. A missing @p path is treated as success so callers can use it
+ * unconditionally in test teardown; any other stat() failure (e.g. a
+ * permission error) is reported as OSH_EIO rather than silently ignored.
  *
  * @param[in] path  Directory to remove.
  *
@@ -402,7 +404,7 @@ enum osh_status osh_path_remove_dir(char const *path) {
     }
 
     if (stat(path, &st) != 0) {
-        return OSH_OK; /* already gone */
+        return (errno == ENOENT) ? OSH_OK : OSH_EIO;
     }
     if (!_mode_is_dir(st.st_mode)) {
         return OSH_EIO;

--- a/src/common/osh_file.c
+++ b/src/common/osh_file.c
@@ -26,6 +26,8 @@ static int _is_drive_letter(char c);
 #endif
 static int _path_is_absolute(char const *path);
 static size_t _path_root_len(char const *path);
+static int _remove_dir_entry(char const *path, void *user);
+static int _remove_directory(char const *path);
 
 struct oshfile *osh_fopen(char const *filename) {
     FILE *fp;
@@ -376,6 +378,63 @@ enum osh_status osh_path_ensure_dir(char const *path) {
 
     free(tmp);
     return OSH_OK;
+}
+
+/**
+ * @brief Remove @p path and the non-directory entries directly inside it.
+ *
+ * @details
+ * Counterpart to osh_path_ensure_dir(): walks the directory once via
+ * osh_dir_foreach_file(), removing each file, then removes the now-empty
+ * directory itself. A missing @p path is treated as success so callers can
+ * use it unconditionally in test teardown.
+ *
+ * @param[in] path  Directory to remove.
+ *
+ * @returns OSH_OK on success, OSH_EINVAL for invalid input, or OSH_EIO when a
+ *          filesystem operation fails.
+ */
+enum osh_status osh_path_remove_dir(char const *path) {
+    struct stat st;
+
+    if (!path || !path[0]) {
+        return OSH_EINVAL;
+    }
+
+    if (stat(path, &st) != 0) {
+        return OSH_OK; /* already gone */
+    }
+    if (!_mode_is_dir(st.st_mode)) {
+        return OSH_EIO;
+    }
+
+    if (osh_dir_foreach_file(path, _remove_dir_entry, NULL) != OSH_OK) {
+        return OSH_EIO;
+    }
+
+    return (_remove_directory(path) == 0) ? OSH_OK : OSH_EIO;
+}
+
+static int _remove_dir_entry(char const *path, void *user) {
+    (void) user;
+    remove(path);
+    return 1;
+}
+
+/**
+ * @brief Remove an empty directory.
+ *
+ * @details
+ * MSVC's `remove()` maps to `_unlink` and cannot remove directories, so
+ * Windows builds use `_rmdir` from `<direct.h>` (already pulled in above for
+ * `_mkdir`). Elsewhere, plain `remove()` removes an empty directory.
+ */
+static int _remove_directory(char const *path) {
+#if defined(_WIN32)
+    return _rmdir(path);
+#else
+    return remove(path);
+#endif
 }
 
 enum osh_status osh_dir_foreach_file(char const *dir, osh_dir_iter_fn fn, void *user) {

--- a/src/common/osh_file.h
+++ b/src/common/osh_file.h
@@ -79,12 +79,13 @@ char *osh_path_dirname(char const *path);
 enum osh_status osh_path_ensure_dir(char const *path);
 
 /**
- * @brief Remove a directory and the (non-directory) entries directly inside it.
+ * @brief Remove a directory and the regular files directly inside it.
  *
  * @details
  * Counterpart to osh_path_ensure_dir(), used by tests to tear down scratch
- * output directories they created. A missing @p path is treated as success.
- * Does not recurse into subdirectories.
+ * output directories they created. A missing @p path is treated as success;
+ * any other stat() failure is reported as OSH_EIO. Does not recurse into
+ * subdirectories.
  *
  * @return OSH_OK on success, OSH_EINVAL for invalid arguments, or OSH_EIO on
  *         filesystem errors.

--- a/src/common/osh_file.h
+++ b/src/common/osh_file.h
@@ -79,6 +79,19 @@ char *osh_path_dirname(char const *path);
 enum osh_status osh_path_ensure_dir(char const *path);
 
 /**
+ * @brief Remove a directory and the (non-directory) entries directly inside it.
+ *
+ * @details
+ * Counterpart to osh_path_ensure_dir(), used by tests to tear down scratch
+ * output directories they created. A missing @p path is treated as success.
+ * Does not recurse into subdirectories.
+ *
+ * @return OSH_OK on success, OSH_EINVAL for invalid arguments, or OSH_EIO on
+ *         filesystem errors.
+ */
+enum osh_status osh_path_remove_dir(char const *path);
+
+/**
  * @brief Callback used by osh_dir_foreach_file().
  *
  * @param[in] path  Full path to one non-directory entry.

--- a/tests/unit/test_osh_file.c
+++ b/tests/unit/test_osh_file.c
@@ -15,11 +15,15 @@
 static void test_relative_path_join(void);
 static void test_dirname_accepts_backslashes(void);
 static void test_windows_absolute_path_detection(void);
+static void test_remove_dir_removes_files_and_directory(void);
+
+static int _count_entry(char const *path, void *user);
 
 int main(void) {
     test_relative_path_join();
     test_dirname_accepts_backslashes();
     test_windows_absolute_path_detection();
+    test_remove_dir_removes_files_and_directory();
     return 0;
 }
 
@@ -62,4 +66,39 @@ static void test_windows_absolute_path_detection(void) {
     ASSERT_TRUE(strcmp(resolved, "/tmp/base/C:/tmp/out.dat") == 0);
     free(resolved);
 #endif
+}
+
+static int _count_entry(char const *path, void *user) {
+    int *count = (int *) user;
+
+    (void) path;
+    (*count)++;
+    return 1;
+}
+
+/* osh_path_remove_dir() is the teardown counterpart to osh_path_ensure_dir(),
+ * used by tests (e.g. test_osh_run_dump.c) to avoid leaving scratch output
+ * directories behind. Cover both the create-populate-remove path and the
+ * missing-path no-op. */
+static void test_remove_dir_removes_files_and_directory(void) {
+    char const *dir = "test_osh_file_remove_dir_scratch";
+    char file_path[256];
+    FILE *fp;
+    int count;
+
+    ASSERT_TRUE(osh_path_ensure_dir(dir) == OSH_OK);
+    snprintf(file_path, sizeof(file_path), "%s/scratch.tmp", dir);
+    fp = fopen(file_path, "w");
+    ASSERT_TRUE(fp != NULL);
+    ASSERT_TRUE(fputs("x", fp) >= 0);
+    ASSERT_TRUE(fclose(fp) == 0);
+
+    ASSERT_TRUE(osh_path_remove_dir(dir) == OSH_OK);
+
+    count = 0;
+    ASSERT_TRUE(osh_dir_foreach_file(dir, _count_entry, &count) != OSH_OK);
+    ASSERT_TRUE(count == 0);
+
+    /* Already gone: a repeat call is a no-op, not an error. */
+    ASSERT_TRUE(osh_path_remove_dir(dir) == OSH_OK);
 }

--- a/tests/unit/test_osh_file.c
+++ b/tests/unit/test_osh_file.c
@@ -16,6 +16,7 @@ static void test_relative_path_join(void);
 static void test_dirname_accepts_backslashes(void);
 static void test_windows_absolute_path_detection(void);
 static void test_remove_dir_removes_files_and_directory(void);
+static void test_remove_dir_rejects_invalid_input(void);
 
 static int _count_entry(char const *path, void *user);
 
@@ -24,6 +25,7 @@ int main(void) {
     test_dirname_accepts_backslashes();
     test_windows_absolute_path_detection();
     test_remove_dir_removes_files_and_directory();
+    test_remove_dir_rejects_invalid_input();
     return 0;
 }
 
@@ -101,4 +103,23 @@ static void test_remove_dir_removes_files_and_directory(void) {
 
     /* Already gone: a repeat call is a no-op, not an error. */
     ASSERT_TRUE(osh_path_remove_dir(dir) == OSH_OK);
+}
+
+/* Invalid arguments and a non-directory path are rejected rather than
+ * silently treated as "nothing to do". */
+static void test_remove_dir_rejects_invalid_input(void) {
+    char const *file_path = "test_osh_file_remove_dir_not_a_dir.tmp";
+    FILE *fp;
+
+    ASSERT_TRUE(osh_path_remove_dir(NULL) == OSH_EINVAL);
+    ASSERT_TRUE(osh_path_remove_dir("") == OSH_EINVAL);
+
+    fp = fopen(file_path, "w");
+    ASSERT_TRUE(fp != NULL);
+    ASSERT_TRUE(fputs("x", fp) >= 0);
+    ASSERT_TRUE(fclose(fp) == 0);
+
+    ASSERT_TRUE(osh_path_remove_dir(file_path) == OSH_EIO);
+
+    remove(file_path);
 }

--- a/tests/unit/test_osh_run_dump.c
+++ b/tests/unit/test_osh_run_dump.c
@@ -83,7 +83,7 @@ static void test_time_cadence_run_reports_and_reserves(void) {
     fclose(out);
     fclose(err);
     remove(detect_path);
-    osh_path_remove_dir(out_dir);
+    ASSERT_TRUE(osh_path_remove_dir(out_dir) == OSH_OK);
 }
 
 /* A valid beam.dat whose cadence comes from the cards themselves — a positive
@@ -133,7 +133,7 @@ static void test_beam_dat_cadence_reports(void) {
     fclose(err);
     remove(beam_path);
     remove(detect_path);
-    osh_path_remove_dir(out_dir);
+    ASSERT_TRUE(osh_path_remove_dir(out_dir) == OSH_OK);
 }
 
 /*
@@ -161,7 +161,7 @@ static void test_scheduled_dump_over_budget_is_refused(void) {
     ASSERT_TRUE(osh_run(&opt, NULL, err) == OSH_ENOMEM);
     fclose(err);
     remove(detect_path);
-    osh_path_remove_dir(out_dir);
+    ASSERT_TRUE(osh_path_remove_dir(out_dir) == OSH_OK);
 }
 
 int main(void) {

--- a/tests/unit/test_osh_run_dump.c
+++ b/tests/unit/test_osh_run_dump.c
@@ -12,6 +12,7 @@
 #include <string.h>
 
 #include "apps/osh/osh_run.h"
+#include "common/osh_file.h"
 #include "openshieldhit/status.h"
 
 #define ASSERT_TRUE(cond)                                                                                              \
@@ -82,6 +83,7 @@ static void test_time_cadence_run_reports_and_reserves(void) {
     fclose(out);
     fclose(err);
     remove(detect_path);
+    osh_path_remove_dir(out_dir);
 }
 
 /* A valid beam.dat whose cadence comes from the cards themselves — a positive
@@ -131,6 +133,7 @@ static void test_beam_dat_cadence_reports(void) {
     fclose(err);
     remove(beam_path);
     remove(detect_path);
+    osh_path_remove_dir(out_dir);
 }
 
 /*
@@ -158,6 +161,7 @@ static void test_scheduled_dump_over_budget_is_refused(void) {
     ASSERT_TRUE(osh_run(&opt, NULL, err) == OSH_ENOMEM);
     fclose(err);
     remove(detect_path);
+    osh_path_remove_dir(out_dir);
 }
 
 int main(void) {


### PR DESCRIPTION
## Summary

- `tests/unit/test_osh_run_dump.c` passes an `osh_rundump_out_<n>` directory to `osh_run()` as `opt.out_dir` in all three of its tests, but never removed it — `osh_run()` creates the directory (and `osh_path_ensure_dir` runs before the budget-refusal check in the third test, so it's created even there) and scoring writes output into it, and nothing ever cleaned it up. Every `ctest` run left these directories behind.
- Adds `osh_path_remove_dir()` to `src/common/osh_file.{c,h}` as the teardown counterpart to the existing `osh_path_ensure_dir()`, and calls it after each test that creates an output directory.

Fixes #297.

## Why this approach, not the audit's suggested one

The linked bug-hunt finding (T-3) suggested rooting scratch under an `OSH_TEST_TMPDIR` derived from `CMAKE_CURRENT_BINARY_DIR`. `DEVELOPER.md` §11.3 ("Test Output Files") is the style authority here and says the opposite: write to `.` (the CTest working directory) with fixed names and clean up with `remove()` — explicitly rejecting `mkdtemp`/tmp-dir schemes. Per `CLAUDE.md`, the linked doc wins, so this PR keeps the existing pattern and fixes the actual bug: the missing directory cleanup, done via a small reusable helper rather than ad hoc platform-specific code in the test.

`osh_path_remove_dir()` mirrors `osh_path_ensure_dir()`'s existing portability handling in the same file (`_mkdir`/`mkdir` macro under `_WIN32` from the already-included `<direct.h>`); no new POSIX-only headers are introduced.

## Scope note

T-3 also cited `tests/unit/test_osh_transport_parallel.c` on branch `feat/parallel-threads`. That branch/file doesn't exist in this repo's history (not yet merged), so it isn't touched here — worth revisiting when that branch lands.

## Test plan

- [x] `cmake --preset debug && cmake --build --preset debug --parallel`
- [x] `ctest --test-dir build_debug --output-on-failure` — 139/139 pass
- [x] Ran `test_osh_file` and `test_osh_run_dump` directly from the repo root; `git status` clean afterward, no stray `osh_rundump_out_*` directories
- [x] `./tools/clang-format-all.sh` — no changes to touched files
- [x] `clang-tidy` on all four changed files — no warnings in user code
- [x] Added `test_remove_dir_removes_files_and_directory` covering the new `osh_path_remove_dir()` (create+populate+remove, and the missing-path no-op)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RRp3XEkZ1qtJhz82t8nKMj)_