### PR TITLE
tests: guard integration-case registration against incomplete directories

### DIFF
--- a/tests/cases/CMakeLists.txt
+++ b/tests/cases/CMakeLists.txt
@@ -19,15 +19,37 @@
 
 file(GLOB CASE_DIRS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/*/")
 
+# A real case carries all four documented input files (see the header above).
+# Register a directory only when the complete set is present, so a stray
+# directory the glob may catch — a __pycache__/ left by the Python helpers, or a
+# half-checked-out case from a stashed/rebased branch — is not turned into a
+# phantom failing test (issue #296).
+set(CASE_REQUIRED_INPUTS geo.dat beam.dat mat.dat detect.dat)
+
 foreach(case_dir ${CASE_DIRS})
     if(NOT IS_DIRECTORY "${case_dir}")
         continue()
     endif()
 
-    # A real case always has a detect.dat; skip any other directory the glob may
-    # catch (e.g. a stray __pycache__/ left by running the Python test helpers),
-    # so it is not registered as a broken case.
-    if(NOT EXISTS "${case_dir}/detect.dat")
+    set(_missing_inputs "")
+    foreach(_input ${CASE_REQUIRED_INPUTS})
+        if(NOT EXISTS "${case_dir}/${_input}")
+            list(APPEND _missing_inputs "${_input}")
+        endif()
+    endforeach()
+
+    if(_missing_inputs)
+        # A directory carrying detect.dat but missing another input was almost
+        # certainly meant to be a case; warn so the omission is visible rather
+        # than silently dropped. A directory without even detect.dat is just
+        # noise the glob caught (e.g. __pycache__/), so skip it quietly.
+        if(EXISTS "${case_dir}/detect.dat")
+            get_filename_component(case_name "${case_dir}" NAME)
+            string(REPLACE ";" ", " _missing_str "${_missing_inputs}")
+            message(WARNING
+                "tests/cases: skipping incomplete case '${case_name}' "
+                "(missing input file(s): ${_missing_str})")
+        endif()
         continue()
     endif()
 

--- a/tests/reference/CMakeLists.txt
+++ b/tests/reference/CMakeLists.txt
@@ -18,12 +18,37 @@
 
 file(GLOB IDD_CASE_DIRS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/idd_*/")
 
+# A real benchmark carries all four documented input files (see the header
+# above). Register a directory only when the complete set is present, so a
+# half-checked-out idd_*/ directory from a stashed/rebased branch is not turned
+# into a phantom failing test (issue #296). A missing reference/ curve is a
+# separate, expected state: run_idd.cmake reports such a (complete) case as
+# SKIPPED at run time, letting the infrastructure precede the reference data.
+set(IDD_REQUIRED_INPUTS geo.dat beam.dat mat.dat detect.dat)
+
 foreach(case_dir ${IDD_CASE_DIRS})
     if(NOT IS_DIRECTORY "${case_dir}")
         continue()
     endif()
 
     get_filename_component(case_name "${case_dir}" NAME)
+
+    set(_missing_inputs "")
+    foreach(_input ${IDD_REQUIRED_INPUTS})
+        if(NOT EXISTS "${case_dir}/${_input}")
+            list(APPEND _missing_inputs "${_input}")
+        endif()
+    endforeach()
+
+    # Every idd_*/ directory is meant to be a benchmark, so any missing input is
+    # an incomplete case worth surfacing rather than dropping silently.
+    if(_missing_inputs)
+        string(REPLACE ";" ", " _missing_str "${_missing_inputs}")
+        message(WARNING
+            "tests/reference: skipping incomplete benchmark '${case_name}' "
+            "(missing input file(s): ${_missing_str})")
+        continue()
+    endif()
 
     add_test(
         NAME "reference::${case_name}"


### PR DESCRIPTION
## Why

Glob-based test discovery in `tests/cases/CMakeLists.txt` and `tests/reference/CMakeLists.txt` registered a CTest entry per subdirectory without fully verifying that the required input files were present. A leftover directory — a stray `__pycache__/` from the Python helpers, or a half-checked-out case from a stashed/rebased branch (some case artifacts are git-ignored and persist across checkouts) — was therefore registered as a "test case" doomed to fail: a **phantom failure** unrelated to any real regression. That erodes trust in the suite ("red is normal") and risks masking genuine failures.

Fixes #296 (originally finding T-1 in the 2026-07-05 deep-audit bug hunt).

## What was wrong

- **`tests/cases/`** had only a partial guard: it checked for `detect.dat` alone. A directory with `detect.dat` but missing one of `geo.dat` / `beam.dat` / `mat.dat` still registered and failed, even though the case-directory contract documented at the top of the file requires all four inputs.
- **`tests/reference/`** had **no guard at all**: any `idd_*/` directory was registered as a `reference::` test regardless of whether any input files existed.

## Change

Both files now require **all four documented input files** (`geo.dat`, `beam.dat`, `mat.dat`, `detect.dat`) before calling `add_test()`:

- A directory that looks like an intended case (in `cases/`: has `detect.dat`; in `reference/`: matches `idd_*/`) but is missing an input emits a `message(WARNING …)` naming the missing file(s), so the omission is **visible** rather than silently dropped.
- A directory that is just noise the glob caught (e.g. `__pycache__/`, no `detect.dat`) is skipped quietly.
- A missing `reference/` curve is unaffected: `run_idd.cmake` still reports a **complete-but-dataless** benchmark as `SKIPPED` at run time, so the benchmark infrastructure can still precede the reference data.

## Verification

- Clean tree: all 17 `cases::` and 13 `reference::` tests still register (`ctest -N`); `cases::00_minimal` passes and `reference::idd_water_70mev` correctly reports `Skipped` (no reference curve yet).
- Injected the three phantom scenarios and reconfigured:
  - `cases/__pycache__/` (no `detect.dat`) → skipped silently, not registered.
  - `cases/99_phantom/` (`detect.dat`, missing `beam.dat`) → warned + skipped, not registered.
  - `reference/idd_phantom/` (missing `mat.dat`) → warned + skipped, not registered.
- Removed the fixtures; clean reconfigure produces no warnings.

## Notes

Changes are confined to CMake test-registration logic. The issue's longer-term suggestion (manifest-driven registration instead of glob discovery) is intentionally left out of scope; this closes the immediate phantom-failure hole for both tiers with a minimal change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014GzondNT73aWTzy1fkvUEM)_