### PR TITLE
scoring: feed point-deposited recoils into DLET/TLET (issue #227)

### DIFF
--- a/docs/dev/scoring.md
+++ b/docs/dev/scoring.md
@@ -299,8 +299,10 @@ Each estimator owns a trio of handlers, registered in
   form once per bin (÷volume, unit conversion, or two-pass ratio).
 
 A `—` below means the handler is `NULL`: the estimator is not scored on that path
-(`score_point_` needs a track length for FLUENCE/LET), or the accumulator is
-already final (`postprocess_` for ENERGY/COUNT unless the page is differential).
+(`score_point_` needs a track length for FLUENCE and the Qeff averages; DLET/TLET
+instead take the recoil's birth-energy stopping power as a representative dE/dx —
+issue #227), or the accumulator is already final (`postprocess_` for ENERGY/COUNT
+unless the page is differential).
 The scorer deposits the extensive quantity; geometry-specific normalisation
 (÷volume via `geo->bin_vol_inv`) and differential-axis normalisation (÷bin width,
 or ÷width1÷width2 for double-differential pages) live in `postprocess_` — never
@@ -312,8 +314,8 @@ at score time and never at save.
 | `FLUENCE` | `osh_scoring_estimator_step_fluence` | — | `postprocess_volume` | track length → ÷volume [1/cm²] |
 | `DOSE`    | `osh_scoring_estimator_step_dose`    | `osh_scoring_estimator_point_dose`  | `postprocess_volume` | `de·(path/score_len)/ρ` [+SP-ratio] → ÷volume [MeV/g] |
 | `DOSEGY`  | `osh_scoring_estimator_step_dose`    | `osh_scoring_estimator_point_dose`  | `postprocess_dosegy` | as `DOSE` → ÷volume, ×`OSH_MEVG2GY` [Gy] |
-| `DLET`    | `osh_scoring_estimator_step_dlet`    | — | `postprocess_ratio` | dose-weighted `(LET·w, w)` → `data/data2` [MeV/cm] |
-| `TLET`    | `osh_scoring_estimator_step_tlet`    | — | `postprocess_ratio` | track-weighted `(LET·w, w)` → `data/data2` [MeV/cm] |
+| `DLET`    | `osh_scoring_estimator_step_dlet`    | `osh_scoring_estimator_point_dlet` | `postprocess_ratio` | dose-weighted `(LET·w, w)` → `data/data2` [MeV/cm] |
+| `TLET`    | `osh_scoring_estimator_step_tlet`    | `osh_scoring_estimator_point_tlet` | `postprocess_ratio` | track-weighted `(LET·w, w)` → `data/data2` [MeV/cm] |
 | `DQEFF`   | `osh_scoring_estimator_step_dqeff`   | — | `postprocess_ratio` | dose-weighted `((z_eff/β)²·w, w)` → `data/data2` |
 | `TQEFF`   | `osh_scoring_estimator_step_tqeff`   | — | `postprocess_ratio` | track-weighted `((z_eff/β)²·w, w)` → `data/data2` |
 | `NKERMA`  | —                    | — | `postprocess_volume` | (neutron kerma) → ÷volume [MeV/g] |
@@ -322,6 +324,17 @@ at score time and never at save.
 in `osh_scoring_estimator.c` and one row to this table. `osh_scoring_estimator_point_dose` guards
 neutral particles (they book energy but no local dose); `osh_scoring_estimator_point_energy` books
 the whole point energy deposit (equivalent to a unit-length crossing).
+
+`osh_scoring_estimator_point_dlet`/`_tlet` (issue #227) let a sub-threshold
+recoil/fragment contribute to the LET averages even though it has no track: they
+take the recoil's stopping power at its **birth energy** — `S(medium, E_birth)·ρ`
+from the SP table, resolved at `st->p[3] == st->q[3]` — as its representative LET.
+The dose-weighted numerator uses the whole local energy release `de` (so DLET books
+`(LET·de, de)`); the track-weighted one uses the effective range `de/LET` (so TLET
+books `(de, de/LET)`) — "like a track step" with `LET = de/ds`. Both collapse to
+`LET` for an isolated deposit; the weighting differs only when a bin mixes several
+contributions, exactly as on the step path. A recoil species with no SP-table
+column has no representable dE/dx and is skipped (its energy/dose still score).
 
 !!! note "NKERMA is a registry placeholder (deposit not yet wired)"
     The `NKERMA` row is `{NULL, NULL, postprocess_volume}`: it has neither a

--- a/src/scoring/runtime/osh_scoring_estimator.c
+++ b/src/scoring/runtime/osh_scoring_estimator.c
@@ -22,8 +22,10 @@ static struct osh_scoring_estimator const k_dirtydose = {
     osh_scoring_estimator_step_dirtydose, osh_scoring_estimator_point_dirtydose, postprocess_volume};
 static struct osh_scoring_estimator const k_dirtydosegy = {
     osh_scoring_estimator_step_dirtydose, osh_scoring_estimator_point_dirtydose, postprocess_dosegy};
-static struct osh_scoring_estimator const k_dlet = {osh_scoring_estimator_step_dlet, NULL, postprocess_ratio};
-static struct osh_scoring_estimator const k_tlet = {osh_scoring_estimator_step_tlet, NULL, postprocess_ratio};
+static struct osh_scoring_estimator const k_dlet = {
+    osh_scoring_estimator_step_dlet, osh_scoring_estimator_point_dlet, postprocess_ratio};
+static struct osh_scoring_estimator const k_tlet = {
+    osh_scoring_estimator_step_tlet, osh_scoring_estimator_point_tlet, postprocess_ratio};
 static struct osh_scoring_estimator const k_dqeff = {osh_scoring_estimator_step_dqeff, NULL, postprocess_ratio};
 static struct osh_scoring_estimator const k_tqeff = {osh_scoring_estimator_step_tqeff, NULL, postprocess_ratio};
 static struct osh_scoring_estimator const k_nkerma = {NULL, NULL, postprocess_volume};

--- a/src/scoring/runtime/osh_scoring_estimator_internal.h
+++ b/src/scoring/runtime/osh_scoring_estimator_internal.h
@@ -109,4 +109,18 @@ enum osh_status osh_scoring_estimator_point_dirtydose(struct osh_scoring_runtime
                                                       struct particle const *part,
                                                       struct step const *st);
 
+enum osh_status osh_scoring_estimator_point_dlet(struct osh_scoring_runtime const *rt,
+                                                 struct osh_scoring_accumulator *acc_set,
+                                                 struct osh_scoring_geometry_score_group const *group,
+                                                 size_t spatial_idx,
+                                                 struct particle const *part,
+                                                 struct step const *st);
+
+enum osh_status osh_scoring_estimator_point_tlet(struct osh_scoring_runtime const *rt,
+                                                 struct osh_scoring_accumulator *acc_set,
+                                                 struct osh_scoring_geometry_score_group const *group,
+                                                 size_t spatial_idx,
+                                                 struct particle const *part,
+                                                 struct step const *st);
+
 #endif /* OSH_SCORING_ESTIMATOR_INTERNAL_H */

--- a/src/scoring/runtime/osh_scoring_estimator_point.c
+++ b/src/scoring/runtime/osh_scoring_estimator_point.c
@@ -165,3 +165,132 @@ enum osh_status osh_scoring_estimator_point_dirtydose(struct osh_scoring_runtime
     }
     return OSH_OK;
 }
+
+/**
+ * @brief Point-deposit counterpart of osh_scoring_estimator_step_dlet.
+ *
+ * A sub-threshold recoil or fragment deposits its whole birth energy locally with
+ * no track length (issue #227).  Its representative LET is the stopping power at
+ * the birth energy S(medium, E_birth) * rho, read from the same SP table the step
+ * scorer uses; because @c st->p[3] == st->q[3] on the point path, the shared LET
+ * gather resolves that value at the birth energy (clamped to the table's
+ * low-energy end for very slow recoils).  The dose weight is the whole local
+ * energy release @c st->de, exactly like a track step's per-bin dose weight, so
+ * DLET books (LET * de, de) into (data, data2) and the ratio postprocess yields
+ * LET for an isolated deposit.
+ *
+ * A recoil species with no SP-table column has no representable dE/dx and is
+ * skipped here; ENERGY and DOSE still score it on their own point paths.
+ */
+enum osh_status osh_scoring_estimator_point_dlet(struct osh_scoring_runtime const *rt,
+                                                 struct osh_scoring_accumulator *acc_set,
+                                                 struct osh_scoring_geometry_score_group const *group,
+                                                 size_t spatial_idx,
+                                                 struct particle const *part,
+                                                 struct step const *st) {
+    size_t i;
+    double let_point;        /* LET this page scores for the deposit [MeV/cm] */
+    double dose_weight;      /* whole local energy release [MeV] */
+    double dlet_numerator;   /* LET * dose_weight, booked into acc->data */
+    double dlet_denominator; /* dose_weight, booked into acc->data2 */
+    struct osh_scoring_step_let_ctx let_ctx;
+    struct osh_scoring_page_runtime const *page;
+    struct osh_scoring_accumulator *acc;
+
+    if (part->z == 0 || part->a == 0 || !(st->rho > 0.0)) {
+        return OSH_OK;
+    }
+    /* Mean step energy equals the birth energy here (p[3] == q[3]).  The de/score_len
+     * fallback baked into the gather is unused: we require an SP-table column
+     * (have_proj) below, since a point deposit has no track to derive LET from. */
+    let_ctx = osh_scoring_estimator_step_let_gather(rt, part, st, 1.0);
+    if (!let_ctx.have_proj) {
+        return OSH_OK;
+    }
+
+    for (i = 0; i < group->npages; ++i) {
+        page = &rt->pages[group->first_page + i];
+        acc = &acc_set[group->first_page + i];
+        if (!osh_scoring_page_passes_filters(page, part, st)) {
+            continue;
+        }
+        /* A per-page Settings override changes the LET value, honoured by _apply. */
+        let_point = osh_scoring_estimator_step_let_apply(&let_ctx, rt, page);
+        if (!(let_point > 0.0)) {
+            continue;
+        }
+        if (spatial_idx >= page->diff_stride) {
+            return OSH_ESTATE;
+        }
+        /* Dose-weighted LET sample.  Differential axes are not valid for DLET pages,
+         * so spatial_idx is the complete bin index. */
+        dose_weight = st->de;
+        dlet_numerator = let_point * dose_weight;
+        dlet_denominator = dose_weight;
+        osh_score_deposit(acc->data, spatial_idx, dlet_numerator);
+        osh_score_deposit(acc->data2, spatial_idx, dlet_denominator);
+    }
+    return OSH_OK;
+}
+
+/**
+ * @brief Point-deposit counterpart of osh_scoring_estimator_step_tlet.
+ *
+ * Same representative birth-energy LET as osh_scoring_estimator_point_dlet, but
+ * track-averaged.  A stopping recoil traverses an effective track length equal to
+ * its residual range, approximated by de/LET (constant-LET slowing down).  This is
+ * exactly "like a track step" with LET = de/ds, so TLET books
+ * (LET * (de/LET), de/LET) == (de, de/LET) into (data, data2): the ratio
+ * postprocess collapses to LET for an isolated deposit, while the de/LET
+ * denominator gives the correct track-length weight against real track steps and
+ * other recoils sharing the bin (a high-LET, short-range recoil counts less than a
+ * low-LET, long-range one).
+ */
+enum osh_status osh_scoring_estimator_point_tlet(struct osh_scoring_runtime const *rt,
+                                                 struct osh_scoring_accumulator *acc_set,
+                                                 struct osh_scoring_geometry_score_group const *group,
+                                                 size_t spatial_idx,
+                                                 struct particle const *part,
+                                                 struct step const *st) {
+    size_t i;
+    double let_point;        /* LET this page scores for the deposit [MeV/cm] */
+    double track_weight;     /* effective track length de/LET [cm] */
+    double tlet_numerator;   /* LET * track_weight, booked into acc->data */
+    double tlet_denominator; /* track_weight, booked into acc->data2 */
+    struct osh_scoring_step_let_ctx let_ctx;
+    struct osh_scoring_page_runtime const *page;
+    struct osh_scoring_accumulator *acc;
+
+    if (part->z == 0 || part->a == 0 || !(st->rho > 0.0)) {
+        return OSH_OK;
+    }
+    /* See osh_scoring_estimator_point_dlet: birth-energy LET, have_proj required. */
+    let_ctx = osh_scoring_estimator_step_let_gather(rt, part, st, 1.0);
+    if (!let_ctx.have_proj) {
+        return OSH_OK;
+    }
+
+    for (i = 0; i < group->npages; ++i) {
+        page = &rt->pages[group->first_page + i];
+        acc = &acc_set[group->first_page + i];
+        if (!osh_scoring_page_passes_filters(page, part, st)) {
+            continue;
+        }
+        let_point = osh_scoring_estimator_step_let_apply(&let_ctx, rt, page);
+        if (!(let_point > 0.0)) {
+            continue; /* no representable LET -> also avoids the de/LET divide */
+        }
+        if (spatial_idx >= page->diff_stride) {
+            return OSH_ESTATE;
+        }
+        /* Effective track length of a stopping recoil: de/LET (constant-LET range).
+         * Differential axes are not valid for TLET pages, so spatial_idx is the
+         * complete bin index. */
+        track_weight = st->de / let_point;
+        tlet_numerator = let_point * track_weight;
+        tlet_denominator = track_weight;
+        osh_score_deposit(acc->data, spatial_idx, tlet_numerator);
+        osh_score_deposit(acc->data2, spatial_idx, tlet_denominator);
+    }
+    return OSH_OK;
+}

--- a/src/scoring/runtime/osh_scoring_point.c
+++ b/src/scoring/runtime/osh_scoring_point.c
@@ -102,7 +102,8 @@ enum osh_status osh_scoring_score_point(struct osh_scoring_runtime const *rt,
             struct osh_scoring_estimator const *est;
 
             /* A NULL score_point means the estimator has no point meaning (FLUENCE
-             * and LET/Qeff need a track length): skip it. */
+             * and Qeff need a track length): skip it.  DLET/TLET do define a point
+             * meaning via the recoil's birth-energy stopping power (issue #227). */
             est = osh_scoring_estimator_for(geo->groups[g].score_kind);
             if (est && est->score_point) {
                 rc = est->score_point(rt, acc_set, &geo->groups[g], idx, part, st);

--- a/src/scoring/runtime/osh_scoring_point.h
+++ b/src/scoring/runtime/osh_scoring_point.h
@@ -27,10 +27,11 @@ extern "C" {
  * by page filters and differential axes.  @c st->q and @c st->ds are ignored
  * (a point has no exit point or track length); callers may set @c st->q == st->p.
  *
- * Only ENERGY and DOSE/DOSEGY pages receive a point contribution for now.
- * FLUENCE and LET/QEFF have no meaning without a track length and are wired in
- * later via precomputed LETd/LETt-versus-Ekin tables; those page kinds are
- * silently skipped. Mesh (X,Y,Z), Cyl (R,Z), and Zone geometries are supported.
+ * ENERGY, DOSE/DOSEGY, DIRTYDOSE/DIRTYDOSEGY and DLET/TLET pages receive a point
+ * contribution: the LET scorers use the recoil's stopping power at its birth
+ * energy as a representative dE/dx (issue #227).  FLUENCE and DQEFF/TQEFF have no
+ * meaning without a track length and are silently skipped.  Mesh (X,Y,Z),
+ * Cyl (R,Z), and Zone geometries are supported.
  *
  * @param rt       Read-only compiled scoring descriptor.
  * @param acc_set  Mutable accumulator storage (indexed in lockstep with rt->pages).

--- a/tests/reference/idd_water_200mev_nucre0/detect.dat
+++ b/tests/reference/idd_water_200mev_nucre0/detect.dat
@@ -107,9 +107,10 @@ Output
     Diff1Type EKIN
 
 # Depth-resolved LET by species on the narrow column (issue #212 LET criterion).
-# NB: sub-threshold recoils are point-deposited (issue #179) and feed dose/energy
-# but not yet LET, so HeavyRec LET here reflects only above-threshold transported
-# recoils until the score_point LET tables land.
+# NB: sub-threshold recoils are point-deposited (issue #179).  They now feed the
+# DLET/TLET averages too (issue #227), using the recoil's birth-energy stopping
+# power as a representative dE/dx, so HeavyRec LET is no longer above-threshold
+# transported recoils only.
 Output
     Filename let.dat
     Fileformat TEXT

--- a/tests/reference/idd_water_200mev_nucre1/detect.dat
+++ b/tests/reference/idd_water_200mev_nucre1/detect.dat
@@ -107,9 +107,10 @@ Output
     Diff1Type EKIN
 
 # Depth-resolved LET by species on the narrow column (issue #212 LET criterion).
-# NB: sub-threshold recoils are point-deposited (issue #179) and feed dose/energy
-# but not yet LET, so HeavyRec LET here reflects only above-threshold transported
-# recoils until the score_point LET tables land.
+# NB: sub-threshold recoils are point-deposited (issue #179).  They now feed the
+# DLET/TLET averages too (issue #227), using the recoil's birth-energy stopping
+# power as a representative dE/dx, so HeavyRec LET is no longer above-threshold
+# transported recoils only.
 Output
     Filename let.dat
     Fileformat TEXT

--- a/tests/reference/idd_water_200mev_nucre2/detect.dat
+++ b/tests/reference/idd_water_200mev_nucre2/detect.dat
@@ -107,9 +107,10 @@ Output
     Diff1Type EKIN
 
 # Depth-resolved LET by species on the narrow column (issue #212 LET criterion).
-# NB: sub-threshold recoils are point-deposited (issue #179) and feed dose/energy
-# but not yet LET, so HeavyRec LET here reflects only above-threshold transported
-# recoils until the score_point LET tables land.
+# NB: sub-threshold recoils are point-deposited (issue #179).  They now feed the
+# DLET/TLET averages too (issue #227), using the recoil's birth-energy stopping
+# power as a representative dE/dx, so HeavyRec LET is no longer above-threshold
+# transported recoils only.
 Output
     Filename let.dat
     Fileformat TEXT

--- a/tests/reference/idd_water_200mev_nucre3/detect.dat
+++ b/tests/reference/idd_water_200mev_nucre3/detect.dat
@@ -107,9 +107,10 @@ Output
     Diff1Type EKIN
 
 # Depth-resolved LET by species on the narrow column (issue #212 LET criterion).
-# NB: sub-threshold recoils are point-deposited (issue #179) and feed dose/energy
-# but not yet LET, so HeavyRec LET here reflects only above-threshold transported
-# recoils until the score_point LET tables land.
+# NB: sub-threshold recoils are point-deposited (issue #179).  They now feed the
+# DLET/TLET averages too (issue #227), using the recoil's birth-energy stopping
+# power as a representative dE/dx, so HeavyRec LET is no longer above-threshold
+# transported recoils only.
 Output
     Filename let.dat
     Fileformat TEXT

--- a/tests/reference/shieldhit/idd_water_200mev_nucre0/detect.dat
+++ b/tests/reference/shieldhit/idd_water_200mev_nucre0/detect.dat
@@ -107,9 +107,10 @@ Output
     Diff1Type EKIN
 
 # Depth-resolved LET by species on the narrow column (issue #212 LET criterion).
-# NB: sub-threshold recoils are point-deposited (issue #179) and feed dose/energy
-# but not yet LET, so HeavyRec LET here reflects only above-threshold transported
-# recoils until the score_point LET tables land.
+# NB: sub-threshold recoils are point-deposited (issue #179).  They now feed the
+# DLET/TLET averages too (issue #227), using the recoil's birth-energy stopping
+# power as a representative dE/dx, so HeavyRec LET is no longer above-threshold
+# transported recoils only.
 Output
     Filename let.dat
     Fileformat TEXT

--- a/tests/reference/shieldhit/idd_water_200mev_nucre1/detect.dat
+++ b/tests/reference/shieldhit/idd_water_200mev_nucre1/detect.dat
@@ -107,9 +107,10 @@ Output
     Diff1Type EKIN
 
 # Depth-resolved LET by species on the narrow column (issue #212 LET criterion).
-# NB: sub-threshold recoils are point-deposited (issue #179) and feed dose/energy
-# but not yet LET, so HeavyRec LET here reflects only above-threshold transported
-# recoils until the score_point LET tables land.
+# NB: sub-threshold recoils are point-deposited (issue #179).  They now feed the
+# DLET/TLET averages too (issue #227), using the recoil's birth-energy stopping
+# power as a representative dE/dx, so HeavyRec LET is no longer above-threshold
+# transported recoils only.
 Output
     Filename let.dat
     Fileformat TEXT

--- a/tests/unit/test_osh_scoring_point_let.c
+++ b/tests/unit/test_osh_scoring_point_let.c
@@ -22,6 +22,8 @@
 #include "particle/osh_particle_const.h"
 #include "scoring/runtime/osh_scoring_compile.h"
 #include "scoring/runtime/osh_scoring_defs.h"
+#include "scoring/runtime/osh_scoring_estimator_internal.h"
+#include "scoring/runtime/osh_scoring_geometry_runtime.h"
 #include "scoring/runtime/osh_scoring_point.h"
 #include "scoring/runtime/osh_scoring_postprocess.h"
 #include "scoring/runtime/osh_scoring_runtime.h"
@@ -79,6 +81,26 @@ static char const *const DETECT_TEXT = "Geometry Mesh\n"
                                        "    Quantity DLET\n"
                                        "    Quantity TLET\n";
 
+/* Same geometry, but the DLET/TLET pages carry a Protons (Z=1, A=1) filter, so a
+ * heavier recoil is rejected inside the handler's page loop before it books a
+ * LET sample. */
+static char const *const DETECT_FILTERED = "Geometry Mesh\n"
+                                           "    Name G\n"
+                                           "    X -0.5 0.5 1\n"
+                                           "    Y -0.5 0.5 1\n"
+                                           "    Z  0.0 3.0 3\n"
+                                           "\n"
+                                           "Filter\n"
+                                           "    Name Protons\n"
+                                           "    Z = 1\n"
+                                           "    A = 1\n"
+                                           "\n"
+                                           "Output\n"
+                                           "    Filename out.bdo\n"
+                                           "    Geo G\n"
+                                           "    Quantity DLET Protons\n"
+                                           "    Quantity TLET Protons\n";
+
 /* Build a flat SP table: two projectiles (Z=2 alpha, Z=6 carbon), one material,
  * two energy grid points holding the same mass stopping power per projectile so the
  * midpoint lookup returns it exactly regardless of the birth energy.  rho is 1
@@ -120,7 +142,8 @@ static void init_two_proj_tables(struct osh_material_runtime *mat_rt,
     mat_rt->mass_stopping_power = sp_values;
 }
 
-/* Fill a point-deposit step at Z-bin 1 (Z in [1,2)) for species with mass number a. */
+/* Fill a point deposit at Z-bin 1 (Z in [1,2)): birth energy `energy` [MeV] and the
+ * whole energy released locally `de` [MeV], with zero track length. */
 static void point_step(struct step *st, double energy, double de) {
     memset(st, 0, sizeof(*st));
     st->p[2] = 1.5;
@@ -353,10 +376,221 @@ static void test_point_species_not_in_table(void) {
     remove(path);
 }
 
+/* A neutral point deposit (a de-excitation gamma) reaches the DLET/TLET point path
+ * but the z == 0 guard rejects it: LET has no meaning for an uncharged deposit. */
+static void test_point_let_neutral_skipped(void) {
+    char path[512];
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle gamma;
+    struct step st;
+    struct osh_scoring_page_runtime *dlet_page;
+    struct osh_scoring_page_runtime *tlet_page;
+    unsigned int proj_z[2];
+    unsigned int proj_a[2];
+    double proj_mass[2];
+    float rho_arr[1];
+    float sp_values[4];
+    struct osh_material_runtime mat_rt;
+    enum osh_status rc;
+
+    write_temp_file(path, sizeof(path), DETECT_TEXT);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+    init_two_proj_tables(&mat_rt, proj_z, proj_a, proj_mass, rho_arr, sp_values, 50.0f, 400.0f);
+    rt.mat_tables = &mat_rt;
+
+    memset(&gamma, 0, sizeof(gamma));
+    gamma.charge = 0;
+    gamma.z = 0u;
+    gamma.a = 0u;
+
+    point_step(&st, 40.0, 4.0);
+    rc = osh_scoring_score_point(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &gamma, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    dlet_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DLET);
+    tlet_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_TLET);
+    ASSERT_TRUE(dlet_page != NULL && tlet_page != NULL);
+    assert_near(dlet_page->acc.data2[1], 0.0);
+    assert_near(tlet_page->acc.data2[1], 0.0);
+
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+    remove(path);
+}
+
+/* A recoil rejected by a page's particle filter books no LET sample even though it
+ * has a valid SP-table column: the skip happens inside the handler page loop. */
+static void test_point_let_filtered_out(void) {
+    char path[512];
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle alpha;
+    struct step st;
+    struct osh_scoring_page_runtime *dlet_page;
+    struct osh_scoring_page_runtime *tlet_page;
+    unsigned int proj_z[2];
+    unsigned int proj_a[2];
+    double proj_mass[2];
+    float rho_arr[1];
+    float sp_values[4];
+    struct osh_material_runtime mat_rt;
+    enum osh_status rc;
+
+    write_temp_file(path, sizeof(path), DETECT_FILTERED);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+    init_two_proj_tables(&mat_rt, proj_z, proj_a, proj_mass, rho_arr, sp_values, 50.0f, 400.0f);
+    rt.mat_tables = &mat_rt;
+
+    /* An alpha (Z=2) is in the SP table but fails the Protons (Z=1) filter. */
+    memset(&alpha, 0, sizeof(alpha));
+    alpha.charge = 2;
+    alpha.z = 2u;
+    alpha.a = 4u;
+    alpha.mass = proj_mass[0];
+
+    point_step(&st, 40.0, 4.0);
+    rc = osh_scoring_score_point(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &alpha, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    dlet_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DLET);
+    tlet_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_TLET);
+    ASSERT_TRUE(dlet_page != NULL && tlet_page != NULL);
+    assert_near(dlet_page->acc.data2[1], 0.0);
+    assert_near(tlet_page->acc.data2[1], 0.0);
+
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+    remove(path);
+}
+
+/* A recoil present in the SP table but with zero stopping power there has no
+ * representable LET (let_point == 0), so it is skipped — the TLET path in
+ * particular never reaches the de/LET divide. */
+static void test_point_let_zero_sp_skipped(void) {
+    char path[512];
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle alpha;
+    struct step st;
+    struct osh_scoring_page_runtime *dlet_page;
+    struct osh_scoring_page_runtime *tlet_page;
+    unsigned int proj_z[2];
+    unsigned int proj_a[2];
+    double proj_mass[2];
+    float rho_arr[1];
+    float sp_values[4];
+    struct osh_material_runtime mat_rt;
+    enum osh_status rc;
+
+    write_temp_file(path, sizeof(path), DETECT_TEXT);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+    /* Alpha column present (have_proj true) but its stopping power is zero. */
+    init_two_proj_tables(&mat_rt, proj_z, proj_a, proj_mass, rho_arr, sp_values, 0.0f, 400.0f);
+    rt.mat_tables = &mat_rt;
+
+    memset(&alpha, 0, sizeof(alpha));
+    alpha.charge = 2;
+    alpha.z = 2u;
+    alpha.a = 4u;
+    alpha.mass = proj_mass[0];
+
+    point_step(&st, 40.0, 4.0);
+    rc = osh_scoring_score_point(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &alpha, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    dlet_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DLET);
+    tlet_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_TLET);
+    ASSERT_TRUE(dlet_page != NULL && tlet_page != NULL);
+    assert_near(dlet_page->acc.data2[1], 0.0);
+    assert_near(tlet_page->acc.data2[1], 0.0);
+
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+    remove(path);
+}
+
+/* An out-of-range spatial bin trips the defensive bound check.  The public locator
+ * in osh_scoring_score_point() never produces such an index, so the handlers are
+ * called directly with spatial_idx == diff_stride (one past the last bin). */
+static void test_point_let_out_of_range_bin(void) {
+    char path[512];
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle alpha;
+    struct step st;
+    struct osh_scoring_page_runtime *dlet_page;
+    struct osh_scoring_page_runtime *tlet_page;
+    struct osh_scoring_geometry_score_group gd;
+    struct osh_scoring_geometry_score_group gt;
+    struct osh_scoring_accumulator *acc;
+    unsigned int proj_z[2];
+    unsigned int proj_a[2];
+    double proj_mass[2];
+    float rho_arr[1];
+    float sp_values[4];
+    struct osh_material_runtime mat_rt;
+    enum osh_status rc;
+
+    write_temp_file(path, sizeof(path), DETECT_TEXT);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+    init_two_proj_tables(&mat_rt, proj_z, proj_a, proj_mass, rho_arr, sp_values, 50.0f, 400.0f);
+    rt.mat_tables = &mat_rt;
+
+    memset(&alpha, 0, sizeof(alpha));
+    alpha.charge = 2;
+    alpha.z = 2u;
+    alpha.a = 4u;
+    alpha.mass = proj_mass[0];
+    point_step(&st, 40.0, 4.0);
+
+    dlet_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DLET);
+    tlet_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_TLET);
+    ASSERT_TRUE(dlet_page != NULL && tlet_page != NULL);
+
+    acc = osh_scoring_runtime_master_accumulators(&rt);
+    gd.first_page = (size_t) (dlet_page - rt.pages);
+    gd.npages = 1u;
+    gd.score_kind = OSH_SCORING_SCORE_DLET;
+    gt.first_page = (size_t) (tlet_page - rt.pages);
+    gt.npages = 1u;
+    gt.score_kind = OSH_SCORING_SCORE_TLET;
+
+    ASSERT_TRUE(osh_scoring_estimator_point_dlet(&rt, acc, &gd, dlet_page->diff_stride, &alpha, &st) == OSH_ESTATE);
+    ASSERT_TRUE(osh_scoring_estimator_point_tlet(&rt, acc, &gt, tlet_page->diff_stride, &alpha, &st) == OSH_ESTATE);
+
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+    remove(path);
+}
+
 int main(void) {
     test_point_single_recoil_let();
     test_point_mixed_recoils_dlet_vs_tlet();
     test_point_species_not_in_table();
+    test_point_let_neutral_skipped();
+    test_point_let_filtered_out();
+    test_point_let_zero_sp_skipped();
+    test_point_let_out_of_range_bin();
     printf("All osh_scoring_point_let tests passed.\n");
     return 0;
 }

--- a/tests/unit/test_osh_scoring_point_let.c
+++ b/tests/unit/test_osh_scoring_point_let.c
@@ -1,0 +1,362 @@
+/*
+ * Unit tests for the point-deposit LET scorers (osh_scoring_estimator_point_dlet /
+ * _tlet, issue #227).  A heavy recoil or fragment born below the transport
+ * threshold deposits its whole birth energy at one bin with no track length.  The
+ * point LET scorers give it a representative dE/dx — the stopping power at its
+ * birth energy S(medium, E_birth) * rho — so that the single highest-LET component
+ * of the field becomes visible in the DLET/TLET scorers instead of contributing
+ * energy/dose only.
+ */
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "apps/osh/osh_app_osh.h"
+#include "common/osh_step.h"
+#include "material/runtime/osh_material_runtime.h"
+#include "openshieldhit/scoring.h"
+#include "openshieldhit/status.h"
+#include "particle/osh_particle.h"
+#include "particle/osh_particle_const.h"
+#include "scoring/runtime/osh_scoring_compile.h"
+#include "scoring/runtime/osh_scoring_defs.h"
+#include "scoring/runtime/osh_scoring_point.h"
+#include "scoring/runtime/osh_scoring_postprocess.h"
+#include "scoring/runtime/osh_scoring_runtime.h"
+
+#define ASSERT_TRUE(cond)                                                                                              \
+    do {                                                                                                               \
+        if (!(cond)) {                                                                                                 \
+            fprintf(stderr, "ASSERT FAILED: %s (%s:%d)\n", #cond, __FILE__, __LINE__);                                 \
+            exit(1);                                                                                                   \
+        }                                                                                                              \
+    } while (0)
+
+static int tmp_counter = 0;
+
+/* LET ratios come from a few divides; compare with a relative tolerance that is
+ * immune to floating-point noise but far tighter than the physics differences the
+ * tests assert (DLET vs TLET differ by tens of MeV/cm). */
+static void assert_near(double a, double b) {
+    ASSERT_TRUE(fabs(a - b) < 1.0e-9 * (1.0 + fabs(b)));
+}
+
+static void write_temp_file(char *path, size_t path_cap, char const *content) {
+    FILE *fp;
+
+    snprintf(path, path_cap, "osh_scoring_point_let_test_%d.tmp", tmp_counter++);
+    fp = fopen(path, "w");
+    ASSERT_TRUE(fp != NULL);
+    ASSERT_TRUE(fputs(content, fp) >= 0);
+    ASSERT_TRUE(fclose(fp) == 0);
+}
+
+static struct osh_scoring_page_runtime *find_page_by_kind(struct osh_scoring_runtime *rt,
+                                                          enum osh_scoring_score_kind kind) {
+    size_t i;
+    for (i = 0; i < rt->npages; ++i) {
+        if (rt->pages[i].score_kind == kind) {
+            return &rt->pages[i];
+        }
+    }
+    return NULL;
+}
+
+/* detect.dat with a 1x1x3 mesh (1 cm bins) scoring both DLET and TLET.  The point
+ * deposits land in Z bin 1; the volume cancels in the LET ratio, so the mesh sizing
+ * is irrelevant beyond locating the bin. */
+static char const *const DETECT_TEXT = "Geometry Mesh\n"
+                                       "    Name G\n"
+                                       "    X -0.5 0.5 1\n"
+                                       "    Y -0.5 0.5 1\n"
+                                       "    Z  0.0 3.0 3\n"
+                                       "\n"
+                                       "Output\n"
+                                       "    Filename out.bdo\n"
+                                       "    Geo G\n"
+                                       "    Quantity DLET\n"
+                                       "    Quantity TLET\n";
+
+/* Build a flat SP table: two projectiles (Z=2 alpha, Z=6 carbon), one material,
+ * two energy grid points holding the same mass stopping power per projectile so the
+ * midpoint lookup returns it exactly regardless of the birth energy.  rho is 1
+ * g/cm^3, so LET [MeV/cm] equals the mass stopping power [MeV*cm^2/g].  Caller owns
+ * the backing arrays and must keep them alive for the test. */
+static void init_two_proj_tables(struct osh_material_runtime *mat_rt,
+                                 unsigned int proj_z[2],
+                                 unsigned int proj_a[2],
+                                 double proj_mass[2],
+                                 float rho_arr[1],
+                                 float sp_values[4],
+                                 float sp_alpha,
+                                 float sp_carbon) {
+    proj_z[0] = 2u;
+    proj_a[0] = 4u;
+    proj_mass[0] = 4.0 * OSH_PART_MASS_PROTON;
+    proj_z[1] = 6u;
+    proj_a[1] = 12u;
+    proj_mass[1] = 12.0 * OSH_PART_MASS_PROTON;
+    rho_arr[0] = 1.0f;
+    /* Layout [material][projectile][energy] with nenergy == 2. */
+    sp_values[0] = sp_alpha;  /* proj 0, energy 0 */
+    sp_values[1] = sp_alpha;  /* proj 0, energy 1 */
+    sp_values[2] = sp_carbon; /* proj 1, energy 0 */
+    sp_values[3] = sp_carbon; /* proj 1, energy 1 */
+
+    memset(mat_rt, 0, sizeof(*mat_rt));
+    mat_rt->nprojectiles = 2u;
+    mat_rt->nmaterials = 1u;
+    mat_rt->nenergy = 2u;
+    mat_rt->emin = 1.0;
+    mat_rt->emax = 1000.0;
+    mat_rt->log_emin = log(mat_rt->emin);
+    mat_rt->inv_dlog = 1.0 / (log(mat_rt->emax) - log(mat_rt->emin));
+    mat_rt->projectile_z = proj_z;
+    mat_rt->projectile_a = proj_a;
+    mat_rt->projectile_mass_mev = proj_mass;
+    mat_rt->rho = rho_arr;
+    mat_rt->mass_stopping_power = sp_values;
+}
+
+/* Fill a point-deposit step at Z-bin 1 (Z in [1,2)) for species with mass number a. */
+static void point_step(struct step *st, double energy, double de) {
+    memset(st, 0, sizeof(*st));
+    st->p[2] = 1.5;
+    st->p[3] = energy;
+    st->q[2] = 1.5;
+    st->q[3] = energy; /* point: q == p, so mean energy == birth energy */
+    st->ds = 0.0;      /* zero track length: the case issue #227 handles */
+    st->de = de;
+    st->rho = 1.0;
+    st->wt = 1.0;
+    st->medium = 0;
+}
+
+/* An isolated recoil deposit makes both DLET and TLET equal its birth-energy LET
+ * (S * rho), and books it at the located bin only. */
+static void test_point_single_recoil_let(void) {
+    char path[512];
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle part;
+    struct step st;
+    struct osh_scoring_page_runtime *dlet_page;
+    struct osh_scoring_page_runtime *tlet_page;
+    unsigned int proj_z[2];
+    unsigned int proj_a[2];
+    double proj_mass[2];
+    float rho_arr[1];
+    float sp_values[4];
+    struct osh_material_runtime mat_rt;
+    enum osh_status rc;
+    float const sp_alpha = 50.0f; /* LET = 50 MeV/cm at rho = 1 */
+
+    write_temp_file(path, sizeof(path), DETECT_TEXT);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    init_two_proj_tables(&mat_rt, proj_z, proj_a, proj_mass, rho_arr, sp_values, sp_alpha, 400.0f);
+    rt.mat_tables = &mat_rt;
+
+    /* An alpha recoil (Z=2, A=4) born at 40 MeV (10 MeV/u, inside the table). */
+    memset(&part, 0, sizeof(part));
+    part.charge = 2;
+    part.z = 2u;
+    part.a = 4u;
+    part.mass = proj_mass[0];
+
+    point_step(&st, 40.0, 4.0);
+    rc = osh_scoring_score_point(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    /* Check the raw two-pass accumulators before postprocess collapses the ratio. */
+    dlet_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DLET);
+    tlet_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_TLET);
+    ASSERT_TRUE(dlet_page != NULL);
+    ASSERT_TRUE(tlet_page != NULL);
+    /* DLET numerator/denominator: (LET*de, de) = (200, 4) at bin 1, zero elsewhere. */
+    assert_near(dlet_page->acc.data[1], 200.0);
+    assert_near(dlet_page->acc.data2[1], 4.0);
+    assert_near(dlet_page->acc.data[0], 0.0);
+    assert_near(dlet_page->acc.data[2], 0.0);
+    /* TLET numerator/denominator: (de, de/LET) = (4, 0.08). */
+    assert_near(tlet_page->acc.data[1], 4.0);
+    assert_near(tlet_page->acc.data2[1], 4.0 / 50.0);
+
+    rc = osh_scoring_postprocess(&rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    /* Both averages collapse to the representative birth-energy LET. */
+    assert_near(dlet_page->acc.data[1], 50.0);
+    assert_near(tlet_page->acc.data[1], 50.0);
+    assert_near(dlet_page->acc.data[0], 0.0);
+    assert_near(tlet_page->acc.data[2], 0.0);
+
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+    remove(path);
+}
+
+/* Two recoils of different LET sharing one bin: DLET is dose-weighted and TLET is
+ * track-weighted, so the two averages differ in the physically expected direction
+ * (the high-LET, short-range recoil dominates the dose average more than the track
+ * average). */
+static void test_point_mixed_recoils_dlet_vs_tlet(void) {
+    char path[512];
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle alpha;
+    struct particle carbon;
+    struct step st;
+    struct osh_scoring_page_runtime *dlet_page;
+    struct osh_scoring_page_runtime *tlet_page;
+    unsigned int proj_z[2];
+    unsigned int proj_a[2];
+    double proj_mass[2];
+    float rho_arr[1];
+    float sp_values[4];
+    struct osh_material_runtime mat_rt;
+    enum osh_status rc;
+    double const let_a = 100.0; /* alpha  recoil LET [MeV/cm] */
+    double const let_c = 300.0; /* carbon recoil LET [MeV/cm] */
+    double const de_a = 3.0;
+    double const de_c = 6.0;
+    double expected_dlet;
+    double expected_tlet;
+    double tw_a;
+    double tw_c;
+
+    write_temp_file(path, sizeof(path), DETECT_TEXT);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    init_two_proj_tables(&mat_rt, proj_z, proj_a, proj_mass, rho_arr, sp_values, (float) let_a, (float) let_c);
+    rt.mat_tables = &mat_rt;
+
+    memset(&alpha, 0, sizeof(alpha));
+    alpha.charge = 2;
+    alpha.z = 2u;
+    alpha.a = 4u;
+    alpha.mass = proj_mass[0];
+
+    memset(&carbon, 0, sizeof(carbon));
+    carbon.charge = 6;
+    carbon.z = 6u;
+    carbon.a = 12u;
+    carbon.mass = proj_mass[1];
+
+    /* Both recoils deposit into the same bin (Z bin 1). */
+    point_step(&st, 40.0, de_a);
+    rc = osh_scoring_score_point(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &alpha, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    point_step(&st, 120.0, de_c);
+    rc = osh_scoring_score_point(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &carbon, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    rc = osh_scoring_postprocess(&rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    dlet_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DLET);
+    tlet_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_TLET);
+    ASSERT_TRUE(dlet_page != NULL);
+    ASSERT_TRUE(tlet_page != NULL);
+
+    expected_dlet = (let_a * de_a + let_c * de_c) / (de_a + de_c);
+    tw_a = de_a / let_a;
+    tw_c = de_c / let_c;
+    expected_tlet = (let_a * tw_a + let_c * tw_c) / (tw_a + tw_c);
+
+    assert_near(dlet_page->acc.data[1], expected_dlet);
+    assert_near(tlet_page->acc.data[1], expected_tlet);
+    /* The dose average is pulled higher than the track average by the high-LET
+     * carbon recoil (sanity check on the weighting distinction). */
+    ASSERT_TRUE(dlet_page->acc.data[1] > tlet_page->acc.data[1]);
+
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+    remove(path);
+}
+
+/* A recoil species with no SP-table column has no representable dE/dx, so it feeds
+ * neither DLET nor TLET (the two-pass denominator stays zero -> ratio 0). */
+static void test_point_species_not_in_table(void) {
+    char path[512];
+    struct osh_scoring_workspace *ws = NULL;
+    struct osh_scoring_runtime rt;
+    struct particle part;
+    struct step st;
+    struct osh_scoring_page_runtime *dlet_page;
+    struct osh_scoring_page_runtime *tlet_page;
+    unsigned int proj_z[2];
+    unsigned int proj_a[2];
+    double proj_mass[2];
+    float rho_arr[1];
+    float sp_values[4];
+    struct osh_material_runtime mat_rt;
+    enum osh_status rc;
+
+    write_temp_file(path, sizeof(path), DETECT_TEXT);
+    rc = osh_scoring_setup_from_path(path, NULL, &ws);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    memset(&rt, 0, sizeof(rt));
+    rc = osh_scoring_compile(ws, NULL, &rt);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    /* Table has Z=2 and Z=6 only. */
+    init_two_proj_tables(&mat_rt, proj_z, proj_a, proj_mass, rho_arr, sp_values, 50.0f, 400.0f);
+    rt.mat_tables = &mat_rt;
+
+    /* An oxygen recoil (Z=8) is absent from the projectile columns. */
+    memset(&part, 0, sizeof(part));
+    part.charge = 8;
+    part.z = 8u;
+    part.a = 16u;
+    part.mass = 16.0 * OSH_PART_MASS_PROTON;
+
+    point_step(&st, 40.0, 4.0);
+    rc = osh_scoring_score_point(
+        &rt, osh_scoring_runtime_master_accumulators(&rt), osh_scoring_runtime_master_scratch(&rt), &part, &st);
+    ASSERT_TRUE(rc == OSH_OK);
+
+    dlet_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_DLET);
+    tlet_page = find_page_by_kind(&rt, OSH_SCORING_SCORE_TLET);
+    ASSERT_TRUE(dlet_page != NULL);
+    ASSERT_TRUE(tlet_page != NULL);
+    /* Nothing booked: both numerator and denominator stay zero. */
+    assert_near(dlet_page->acc.data[1], 0.0);
+    assert_near(dlet_page->acc.data2[1], 0.0);
+    assert_near(tlet_page->acc.data[1], 0.0);
+    assert_near(tlet_page->acc.data2[1], 0.0);
+
+    rc = osh_scoring_postprocess(&rt);
+    ASSERT_TRUE(rc == OSH_OK);
+    assert_near(dlet_page->acc.data[1], 0.0);
+    assert_near(tlet_page->acc.data[1], 0.0);
+
+    osh_scoring_runtime_free(&rt);
+    osh_scoring_workspace_free(ws);
+    remove(path);
+}
+
+int main(void) {
+    test_point_single_recoil_let();
+    test_point_mixed_recoils_dlet_vs_tlet();
+    test_point_species_not_in_table();
+    printf("All osh_scoring_point_let tests passed.\n");
+    return 0;
+}

--- a/tools/plot_nucre.py
+++ b/tools/plot_nucre.py
@@ -481,9 +481,10 @@ def main() -> int:
         ("flu_alpha", "alphas", "C6"),
         ("flu_heavy", "heavy rec (Z>=3)", "C7"),
     ]
-    # Only the track-based species read cleanly; alphas/heavy DLET are dominated
-    # by rare high-LET transported recoils in low-statistics bins, and heavy-recoil
-    # LET is ~0 until point deposits feed LET (score_point energy/dose only today).
+    # Track-based species read cleanly; alphas/heavy DLET are noisier, dominated
+    # by rare high-LET recoils in low-statistics bins.  Heavy-recoil DLET is now
+    # non-zero: point deposits feed the LET averages using the recoil's
+    # birth-energy stopping power as a representative dE/dx (issue #227).
     DLET_SPECIES = [
         ("dlet", "all", "C0"),
         ("dlet_prim", "primary p", "C1"),
@@ -583,9 +584,11 @@ def main() -> int:
                     color="gray",
                 )
             a.tick_params(labelbottom=False)
-            # DLET-all omitted from the residual: OSH's heavy-recoil LET is not yet
-            # scored (point deposits feed dose, not LET), so DLET-all is not
-            # comparable; primary/all-proton DLET are.
+            # DLET-all omitted from the residual: heavy-recoil LET now feeds the
+            # DLET averages via point deposits (issue #227), but its representative
+            # birth-energy dE/dx is not expected to track SH12A's full recoil
+            # transport bin-for-bin; the residual keeps the cleaner
+            # primary/all-proton DLET, where the two codes are directly comparable.
             draw_residual_strip(fig.add_subplot(gs[1, 1], sharex=a), osh_let, sh_let, DLET_SPECIES[1:], zend)
 
             # --- Plateau secondary spectrum (spans lower-right) ---


### PR DESCRIPTION
## Why

Heavy recoils and p+A-elastic recoils are frequently born **below** the ion
transport threshold (0.025 MeV/nucleon). These are deposited locally via
`score_point` (#179), which until now booked **energy + dose only — not LET**. So
the single highest-LET component of the field was invisible in the DLET/TLET
scorers, and the recoil-LET payoff of #212 (fragment transport, p+A elastic) could
not be seen.

Closes #227.

## What

Add `score_point` handlers for **DLET** and **TLET** so a point-deposited
sub-threshold recoil/fragment contributes to the LET accumulators with a
representative dE/dx:

- **Representative LET** = the recoil's stopping power at its **birth energy**,
  `S(medium, E_birth)·ρ`, read from the SP table through the same
  `..._step_let_gather` / `..._step_let_apply` helpers the step scorers use. On the
  point path the mean step energy equals the birth energy (`st->p[3] == st->q[3]`),
  and the table lookup clamps to its low-energy end for very slow recoils, so the
  value is physical even below threshold.
- **Zero-track-length handling (DLET vs TLET).** DLET is dose-weighted, so it books
  `(LET·de, de)` using the whole local energy release `de`. TLET is track-weighted;
  a stopping recoil's effective track length is its residual range, approximated by
  `de/LET` (constant-LET slowing down) — i.e. "like a track step" with `LET = de/ds`
  — so it books `(de, de/LET)`. Both collapse to `LET` for an isolated deposit; the
  weighting only diverges when a bin mixes several contributions, matching the step
  path.
- A recoil species with **no SP-table column** has no representable dE/dx and is
  skipped for LET; its energy and dose still score on their own point paths.

## Changes

- `osh_scoring_estimator_point.c` — new `osh_scoring_estimator_point_dlet` /
  `_tlet` handlers (declared in `osh_scoring_estimator_internal.h`).
- `osh_scoring_estimator.c` — register the two handlers on the `DLET`/`TLET` rows.
- `osh_scoring_point.{c,h}` — refresh the doc comments that listed which page kinds
  receive a point contribution.
- `docs/dev/scoring.md` — update the estimator-contract table and add a note on the
  point-LET representation.
- `tools/plot_nucre.py` — refresh the comments that flagged heavy-recoil LET as ~0.
- `tests/unit/test_osh_scoring_point_let.c` — new unit tests: single-recoil
  (`DLET == TLET == LET`), the dose- vs track-weighting distinction for two recoils
  sharing a bin, and the skip for a species absent from the SP table.

## Testing

- `ctest --test-dir build_debug` — 141/141 pass (reference cases needing external
  fixtures are skipped as usual).
- New and neighbouring scoring tests pass under the **asan** preset (ASan + UBSan).
- `clang-format` and `clang-tidy` clean on the changed C files.

## Acceptance (issue #227)

- Heavy-recoil **DLET** now becomes nonzero and physical — the `plot_nucre.py`
  LET-by-species panel is no longer ~0 for the heavy-recoil family.
- The #212 recoil-LET contribution of the fragment-transport and p+A-elastic stages
  becomes visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtiH6w7uGebcAjA5XyzPjB

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtiH6w7uGebcAjA5XyzPjB)_