### PR TITLE
scoring: reconcile variance↔postprocess docs with #247 + enforce finalise order

### DIFF
--- a/docs/dev/scoring.md
+++ b/docs/dev/scoring.md
@@ -206,7 +206,9 @@ required.
 
 `osh_scoring_finalize_errors()` (issue #209) applies this once, **before**
 `osh_scoring_postprocess()` rescales `data` or collapses the two-pass ratios,
-because it reads the raw sums. Rather than the absolute `SE` it stores the per-bin
+because it reads the raw sums — an ordering the function enforces by returning
+`OSH_ESTATE` if the runtime has already been postprocessed. Rather than the
+absolute `SE` it stores the per-bin
 **relative** error `SE / |mean| = sqrt(M2 · weight / (nbatch−1)) / |data|` back
 into `data_var`; the save layer then emits the absolute error column as
 `|value| · data_var`, so whatever per-primary / physical-mean / unit scaling the
@@ -356,16 +358,24 @@ one of these states:
 because `data2` is discarded at post-process; merging requires re-weighting by
 each file's `nstat`.
 
-!!! warning "These handlers are on the variance-finalisation critical path"
+!!! note "Variance finalisation is ordered *before* these handlers, not folded into them"
     Because ÷volume moved *into* `postprocess_` (never at score time, never at
-    save), the handlers here own the geometry normalisation — and therefore, once
-    the variance feature (#169) makes `data_var` (M2) live, its finalisation too.
-    `postprocess_volume`/`postprocess_dosegy` scale `data` by `vinv` (×`extra`), so
-    they must scale M2 by `vinv²` (×`extra²`); `postprocess_ratio` forms
-    `data/data2`, so it must propagate error through that quotient. Today M2 is
-    `NULL` and the handlers touch `data` only — correct as-is — but wiring
-    variance (#247) is **not** a deposit-only change: it must extend these
-    handlers. See the coupling note in §4.
+    save), the handlers here own the geometry normalisation. When #251 was written
+    the open question was whether making `data_var` (M2) live would force these
+    handlers to carry the error too — `postprocess_volume`/`postprocess_dosegy`
+    scaling M2 by `vinv²` (×`extra²`), `postprocess_ratio` propagating error through
+    the `data/data2` quotient.
+
+    The batch-means variance (#247, issue #209) resolved it the other way and the
+    handlers were deliberately **left untouched**. `osh_scoring_finalize_errors()`
+    runs **before** postprocess and stores a *relative* standard error in `data_var`
+    (§4). A relative error is invariant under the linear rescales these handlers
+    apply (`data → data · vinv · extra`), so ÷volume and MeV/g→Gy need no M2
+    bookkeeping at all; the ratio's numerator/denominator errors are combined in
+    quadrature at finalise time, before `postprocess_ratio` collapses `data/data2`.
+    The coupling is therefore one of **ordering** — finalise-then-postprocess,
+    enforced by an `OSH_ESTATE` guard in `osh_scoring_finalize_errors()` — not of
+    extending the handlers. See §4.
 
 ## 7. Lifecycle and module boundaries
 

--- a/docs/dev/scoring.md
+++ b/docs/dev/scoring.md
@@ -207,8 +207,10 @@ required.
 `osh_scoring_finalize_errors()` (issue #209) applies this once, **before**
 `osh_scoring_postprocess()` rescales `data` or collapses the two-pass ratios,
 because it reads the raw sums — an ordering the function enforces by returning
-`OSH_ESTATE` if the runtime has already been postprocessed. Rather than the
-absolute `SE` it stores the per-bin
+`OSH_ESTATE` if the runtime's `postprocessed` flag is set (an *in-place*
+postprocess already ran; an out-of-place `..._into` a distinct `dst` leaves the
+sums intact and is not rejected). Rather than the absolute `SE` it stores the
+per-bin
 **relative** error `SE / |mean| = sqrt(M2 · weight / (nbatch−1)) / |data|` back
 into `data_var`; the save layer then emits the absolute error column as
 `|value| · data_var`, so whatever per-primary / physical-mean / unit scaling the
@@ -373,9 +375,10 @@ each file's `nstat`.
     apply (`data → data · vinv · extra`), so ÷volume and MeV/g→Gy need no M2
     bookkeeping at all; the ratio's numerator/denominator errors are combined in
     quadrature at finalise time, before `postprocess_ratio` collapses `data/data2`.
-    The coupling is therefore one of **ordering** — finalise-then-postprocess,
-    enforced by an `OSH_ESTATE` guard in `osh_scoring_finalize_errors()` — not of
-    extending the handlers. See §4.
+    The coupling is therefore one of **ordering** — finalise-then-(in-place-)postprocess,
+    enforced by an `OSH_ESTATE` guard in `osh_scoring_finalize_errors()` that fires
+    when the `postprocessed` flag is set (i.e. an in-place postprocess already ran) —
+    not of extending the handlers. See §4.
 
 ## 7. Lifecycle and module boundaries
 

--- a/src/scoring/runtime/osh_scoring_postprocess.c
+++ b/src/scoring/runtime/osh_scoring_postprocess.c
@@ -342,6 +342,14 @@ enum osh_status osh_scoring_finalize_errors(struct osh_scoring_runtime *rt) {
     if (!rt) {
         return OSH_EINVAL;
     }
+    /* Ordering guard: the relative error is derived from the raw sums (data, data2),
+     * so this must run before osh_scoring_postprocess() rescales data / collapses the
+     * two-pass ratio.  A runtime already postprocessed would yield error relative to
+     * the wrong (rescaled) value — reject rather than silently mis-report.  Mirrors
+     * the single-shot guard on the in-place postprocess path. */
+    if (rt->postprocessed) {
+        return OSH_ESTATE;
+    }
 
     for (p = 0; p < rt->npages; ++p) {
         struct osh_scoring_accumulator *acc = &rt->pages[p].acc;

--- a/src/scoring/runtime/osh_scoring_postprocess.c
+++ b/src/scoring/runtime/osh_scoring_postprocess.c
@@ -343,10 +343,13 @@ enum osh_status osh_scoring_finalize_errors(struct osh_scoring_runtime *rt) {
         return OSH_EINVAL;
     }
     /* Ordering guard: the relative error is derived from the raw sums (data, data2),
-     * so this must run before osh_scoring_postprocess() rescales data / collapses the
-     * two-pass ratio.  A runtime already postprocessed would yield error relative to
-     * the wrong (rescaled) value — reject rather than silently mis-report.  Mirrors
-     * the single-shot guard on the in-place postprocess path. */
+     * so this must run before an in-place postprocess rescales data / collapses the
+     * two-pass ratio.  The postprocessed flag is set only by that destructive path
+     * (dst==src); once set, the raw sums are gone and finalising would report error
+     * against the rescaled value — reject rather than silently mis-report.  An
+     * out-of-place postprocess into a distinct dst never sets the flag and leaves
+     * src's raw sums intact, so finalising src stays valid.  Mirrors the single-shot
+     * guard on the in-place postprocess path. */
     if (rt->postprocessed) {
         return OSH_ESTATE;
     }

--- a/src/scoring/runtime/osh_scoring_postprocess.h
+++ b/src/scoring/runtime/osh_scoring_postprocess.h
@@ -88,17 +88,21 @@ enum osh_status osh_scoring_postprocess_into(struct osh_scoring_runtime *dst, st
  * *conservative* (an upper bound), never an under-estimate.
  *
  * @b Ordering: this reads the raw sums (@c data, @c data2) and their M2 arrays, so
- * it must run **before** @ref osh_scoring_postprocess rescales @c data or collapses
- * the LET ratio.  That order is enforced: a runtime already postprocessed is
- * rejected with @c OSH_ESTATE rather than mis-reporting error against the rescaled
- * value.  @c B < 2 (zero degrees of freedom), a zero mean, or a zero weight yield a
- * 0 error for that bin.  Pages without M2 arrays (variance off, or the dump shadow)
- * are skipped, so this is a no-op unless a page enabled variance tracking via a
- * "Variance On" Settings block.
+ * it must run **before** an in-place @ref osh_scoring_postprocess rescales @c data
+ * or collapses the LET ratio.  That order is enforced against the destructive path:
+ * if @c rt->postprocessed is set (an in-place postprocess already ran on this
+ * runtime) it returns @c OSH_ESTATE rather than mis-reporting error against the
+ * rescaled value.  An out-of-place @ref osh_scoring_postprocess_into into a distinct
+ * @c dst leaves @c rt->postprocessed clear and @c rt's raw sums intact, so
+ * finalising @c rt afterwards is still valid and not rejected.  @c B < 2 (zero
+ * degrees of freedom), a zero mean, or a zero weight yield a 0 error for that bin.
+ * Pages without M2 arrays (variance off, or the dump shadow) are skipped, so this is
+ * a no-op unless a page enabled variance tracking via a "Variance On" Settings block.
  *
  * @param[in,out] rt  Scoring runtime whose variance pages are finalised in place.
- * @returns OSH_OK on success, OSH_EINVAL if @p rt is NULL, or OSH_ESTATE if @p rt
- *          has already been postprocessed (the raw sums are gone — finalise first).
+ * @returns OSH_OK on success, OSH_EINVAL if @p rt is NULL, or OSH_ESTATE if
+ *          @c rt->postprocessed is set (an in-place postprocess already ran and the
+ *          raw sums are gone — finalise before in-place postprocess).
  */
 enum osh_status osh_scoring_finalize_errors(struct osh_scoring_runtime *rt);
 

--- a/src/scoring/runtime/osh_scoring_postprocess.h
+++ b/src/scoring/runtime/osh_scoring_postprocess.h
@@ -89,13 +89,16 @@ enum osh_status osh_scoring_postprocess_into(struct osh_scoring_runtime *dst, st
  *
  * @b Ordering: this reads the raw sums (@c data, @c data2) and their M2 arrays, so
  * it must run **before** @ref osh_scoring_postprocess rescales @c data or collapses
- * the LET ratio.  @c B < 2 (zero degrees of freedom), a zero mean, or a zero
- * weight yield a 0 error for that bin.  Pages without M2 arrays (variance off, or
- * the dump shadow) are skipped, so this is a no-op unless a page enabled variance
- * tracking via a "Variance On" Settings block.
+ * the LET ratio.  That order is enforced: a runtime already postprocessed is
+ * rejected with @c OSH_ESTATE rather than mis-reporting error against the rescaled
+ * value.  @c B < 2 (zero degrees of freedom), a zero mean, or a zero weight yield a
+ * 0 error for that bin.  Pages without M2 arrays (variance off, or the dump shadow)
+ * are skipped, so this is a no-op unless a page enabled variance tracking via a
+ * "Variance On" Settings block.
  *
  * @param[in,out] rt  Scoring runtime whose variance pages are finalised in place.
- * @returns OSH_OK on success, OSH_EINVAL if @p rt is NULL.
+ * @returns OSH_OK on success, OSH_EINVAL if @p rt is NULL, or OSH_ESTATE if @p rt
+ *          has already been postprocessed (the raw sums are gone — finalise first).
  */
 enum osh_status osh_scoring_finalize_errors(struct osh_scoring_runtime *rt);
 

--- a/tests/unit/test_osh_scoring_variance.c
+++ b/tests/unit/test_osh_scoring_variance.c
@@ -10,6 +10,7 @@
  *   test_one_batch_zero_error     — B < 2 (zero d.o.f.) → error zeroed
  *   test_empty_bin_zero_error     — a zero-sum bin has no defined relative error → 0
  *   test_variance_off_noop        — pages without M2 arrays are left untouched
+ *   test_rejects_after_postprocess — runtime already postprocessed → OSH_ESTATE
  *   test_null_rejected            — NULL runtime → OSH_EINVAL
  */
 
@@ -161,6 +162,31 @@ static void test_variance_off_noop(void) {
     osh_scoring_accumulator_free(&page.acc);
 }
 
+/* Ordering guard: the relative error is read off the raw sums, so finalize must
+ * precede postprocess.  A runtime already marked postprocessed is rejected with
+ * OSH_ESTATE, before any bin is touched. */
+static void test_rejects_after_postprocess(void) {
+    struct osh_scoring_page_runtime page;
+    struct osh_scoring_runtime rt;
+
+    make_var_page(&page, OSH_SCORING_SCORE_DOSE, 2u, 0, 1);
+    page.acc.data[0] = 24.0;
+    page.acc.data[1] = 8.0;
+    page.acc.data_var[0] = 16.0;
+    page.acc.data_var[1] = 0.0;
+    page.acc.weight = 4.0;
+    page.acc.nbatch = 2u;
+    make_runtime(&rt, &page, 1u);
+    rt.postprocessed = 1; /* postprocess already ran: raw sums are gone */
+
+    ASSERT_TRUE(osh_scoring_finalize_errors(&rt) == OSH_ESTATE);
+    /* Guard fires up front: the M2 array is left exactly as supplied. */
+    ASSERT_TRUE(page.acc.data_var[0] == 16.0);
+    ASSERT_TRUE(page.acc.data_var[1] == 0.0);
+
+    osh_scoring_accumulator_free(&page.acc);
+}
+
 static void test_null_rejected(void) {
     ASSERT_TRUE(osh_scoring_finalize_errors(NULL) == OSH_EINVAL);
 }
@@ -171,6 +197,7 @@ int main(void) {
     test_one_batch_zero_error();
     test_empty_bin_zero_error();
     test_variance_off_noop();
+    test_rejects_after_postprocess();
     test_null_rejected();
     printf("All osh_scoring_finalize_errors tests passed.\n");
     return 0;


### PR DESCRIPTION
Closes #251

## Why

This is the last open item of #251 — **variance ↔ postprocess coupling** — now that the batch-means standard error (#247) has actually landed.

The rest of #251's checklist was already delivered by #256 (Zone e2e CTest, Zone save coverage, §6.1 namespacing, `osh_scoring_geometry_runtime.c`, NKERMA docs, postprocess idempotency guard) and #249 (ASCII multi-page diff-axis validation). I re-verified each against the current tree before concluding they were done. The one item #256 could only *anticipate* was the coupling, because #247 hadn't merged yet — so it wrote the docs against a predicted design. #247 then shipped a **different** design, leaving the docs contradicting the code.

## The discrepancy

The §6 warning in `docs/dev/scoring.md` (written pre-#247) predicted that making M2 (`data_var`) live would force the postprocess handlers to carry the error:

> `postprocess_volume`/`postprocess_dosegy` … must scale M2 by `vinv²`; `postprocess_ratio` … must propagate error through that quotient … wiring variance (#247) is **not** a deposit-only change: it must extend these handlers.

#247 resolved it the **opposite** way and left the handlers untouched: `osh_scoring_finalize_errors()` runs **before** postprocess and stores a *relative* standard error in `data_var`. A relative error is invariant under the linear rescales the handlers apply (`data → data · vinv · extra`), so ÷volume and MeV/g→Gy need no M2 bookkeeping; the ratio's numerator/denominator errors are combined in quadrature at finalise time. The coupling is therefore one of **ordering**, not handler extension.

## What's in this PR

**Docs (`docs/dev/scoring.md`)**
- Rewrote the stale §6 warning to describe the design that actually shipped (ordering, not handler extension) and folded in the resolution of the §4 forward-reference.
- Amended §4 to note the ordering is now *enforced*, not just conventional.

**Code + test**
- `osh_scoring_finalize_errors()` now returns `OSH_ESTATE` when `rt->postprocessed` is already set (an in-place postprocess already ran). It reads the raw sums, so running it after an in-place postprocess would report error against the rescaled value — this makes the finalise-then-postprocess contract the docs rely on a hard guarantee, mirroring the single-shot guard already on the postprocess path. An out-of-place `osh_scoring_postprocess_into(dst, src)` leaves `src->postprocessed` clear and is not rejected. Header `@returns` / ordering note updated to match.
- New `test_rejects_after_postprocess` in `test_osh_scoring_variance.c` covering the guard.

## Verification
- Clean debug build; full suite green (139/139).
- `clang-format` (18) clean on all changed files.
- Rebased onto latest `main`.
- Addressed review feedback scoping the guard's docs to the in-place path only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2ZtLrxRncu3LB5Aav7CWC)_