### PR TITLE
scoring: realign DoseGy BDO id to SH12A SH_SDET_DOSEGY (39)

### DIFF
--- a/src/scoring/save/osh_scoring_save_bdo2019.c
+++ b/src/scoring/save/osh_scoring_save_bdo2019.c
@@ -585,7 +585,7 @@ static int legacy_score_kind(struct osh_scoring_page_runtime const *page) {
     case OSH_SCORING_SCORE_DOSE:
         return 5;
     case OSH_SCORING_SCORE_DOSEGY:
-        return 56;
+        return 39;
     case OSH_SCORING_SCORE_DIRTYDOSE:
         return 64;
     case OSH_SCORING_SCORE_DIRTYDOSEGY:


### PR DESCRIPTION
## Summary

`legacy_score_kind()` in `src/scoring/save/osh_scoring_save_bdo2019.c` mapped `OSH_SCORING_SCORE_DOSEGY` to on-disk BDO detector id **56**, which:

- drifts from SH12A's `SH_SDET_DOSEGY = 39`
- collides with a *different* SH12A detector, `SH_SDET_NORMCOUNTPOINT = 56` (score_point counter, normalized per primary)

External BDO readers (pymchelper, `bdo2txt`, etc.) key off this id, so a DoseGy page written by OpenShieldHIT would be misread as a normalized point counter — wrong name, wrong units.

Fix: realign the id to **39**, matching `SH_SDET_DOSEGY`.

While here, cross-checked the rest of `legacy_score_kind()`'s map against the full SH12A `sh_scoredef.h` table posted in the issue thread — every other shared id already matches SH12A (DoseGy was the only drift/collision). `DIRTYDOSE`/`DIRTYDOSEGY`/`DAVGE`/`DBETA` are OSH-only extensions using ids beyond SH12A's range (64–67), so they don't collide with anything.

Note: this changes the on-disk id for existing DoseGy `.bdo` outputs — deliberate, per the issue.

Fixes #304

## Test plan

- [x] `cmake --preset debug && cmake --build --preset debug --parallel`
- [x] `ctest --test-dir build_debug --output-on-failure` — 141/141 passed (13 reference fixtures skipped, unrelated)
- [x] `./tools/clang-format-all.sh` — no formatting changes needed for the touched file


---
_Generated by [Claude Code](https://claude.ai/code/session_016XgRNouhTjw781UAusaad9)_